### PR TITLE
Removed deprecated bpf_map_def from bpf program

### DIFF
--- a/bpf/router.c
+++ b/bpf/router.c
@@ -42,12 +42,12 @@
 #define AF_INET6 10
 #endif
 
-struct bpf_map_def SEC("maps") lookup_port = {
-	.type = BPF_MAP_TYPE_HASH,
-	.key_size = sizeof(__u32),
-	.value_size = sizeof(__u32),
-	.max_entries = 256,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, __u32);
+	__type(value, __u32);
+	__uint(max_entries, 256);
+} lookup_port SEC(".maps");
 
 struct datarec
 {
@@ -55,18 +55,19 @@ struct datarec
 	__u64 rx_bytes;
 };
 
-struct bpf_map_def SEC("maps") ebpf_ret_stats_map = {
-	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
-	.key_size = sizeof(__u32),
-	.value_size = sizeof(struct datarec),
-	.max_entries = EBPF_RES_MAX,
-};
-struct bpf_map_def SEC("maps") ebpf_fib_lkup_stats_map = {
-	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
-	.key_size = sizeof(__u32),
-	.value_size = sizeof(struct datarec),
-	.max_entries = BPF_FIB_LKUP_RET_MAX,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(struct datarec));
+	__uint(max_entries, EBPF_RES_MAX);
+} ebpf_ret_stats_map SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(struct datarec));
+	__uint(max_entries, BPF_FIB_LKUP_RET_MAX);
+} ebpf_fib_lkup_stats_map SEC(".maps");
 
 static __always_inline int ebpf_record_ret_stats(struct __sk_buff *skb, __u32 record, int tc_action)
 {

--- a/pkg/bpf/router_bpfel_x86.go
+++ b/pkg/bpf/router_bpfel_x86.go
@@ -28,9 +28,9 @@ func loadRouter() (*ebpf.CollectionSpec, error) {
 //
 // The following types are suitable as obj argument:
 //
-//     *routerObjects
-//     *routerPrograms
-//     *routerMaps
+//	*routerObjects
+//	*routerPrograms
+//	*routerMaps
 //
 // See ebpf.CollectionSpec.LoadAndAssign documentation for details.
 func loadRouterObjects(obj interface{}, opts *ebpf.CollectionOptions) error {
@@ -121,5 +121,6 @@ func _RouterClose(closers ...io.Closer) error {
 }
 
 // Do not access this directly.
+//
 //go:embed router_bpfel_x86.o
 var _RouterBytes []byte


### PR DESCRIPTION
* As of today `bpf_map_def got removed from kernel in favor of a more sophisticated API
* https://lore.kernel.org/bpf/87lez87rbm.fsf@toke.dk/t/