### PR TITLE
Fix L2VNI nodeSelector

### DIFF
--- a/controllers/layer2networkconfiguration_controller.go
+++ b/controllers/layer2networkconfiguration_controller.go
@@ -132,7 +132,7 @@ func (r *Layer2NetworkConfigurationReconciler) ReconcileDebounced(ctx context.Co
 			}
 			if !selector.Matches(labels.Set(node.ObjectMeta.Labels)) {
 				logger.Info("local node does not match nodeSelector of layer2", "layer2", layer2.ObjectMeta.Name, "node", nodeName)
-				return err
+				continue
 			}
 		}
 


### PR DESCRIPTION
We are iterating over a list of L2VNIs here. The first non-matching L2VNI config made the controller quit the loop + function.