### PR TITLE
Introduce Central Reconciler

### DIFF
--- a/api/v1alpha1/vrfrouteconfiguration_webhook.go
+++ b/api/v1alpha1/vrfrouteconfiguration_webhook.go
@@ -83,6 +83,12 @@ func (r *VRFRouteConfiguration) validateItems() error {
 	if err != nil {
 		return err
 	}
+	for _, item := range r.Spec.Aggregate {
+		_, _, err := net.ParseCIDR(item)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/controllers/layer2networkconfiguration_controller.go
+++ b/controllers/layer2networkconfiguration_controller.go
@@ -18,15 +18,10 @@ package controllers
 
 import (
 	"context"
-	"fmt"
-	"net"
 	"os"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,12 +33,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
-	"github.com/telekom/das-schiff-network-operator/pkg/anycast"
-	"github.com/telekom/das-schiff-network-operator/pkg/debounce"
-	"github.com/telekom/das-schiff-network-operator/pkg/nl"
+	"github.com/telekom/das-schiff-network-operator/pkg/reconciler"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Layer2NetworkConfigurationReconciler reconciles a Layer2NetworkConfiguration object
@@ -51,9 +43,7 @@ type Layer2NetworkConfigurationReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
-	AnycastTracker *anycast.AnycastTracker
-	Debouncer      *debounce.Debouncer
-	NLManager      *nl.NetlinkManager
+	Reconciler *reconciler.Reconciler
 }
 
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
@@ -63,27 +53,19 @@ type Layer2NetworkConfigurationReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the Layer2NetworkConfiguration object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/reconcile
 func (r *Layer2NetworkConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
-	// Run ReconcileDebounced through debouncer
-	r.Debouncer.Debounce(ctx)
+	r.Reconciler.Reconcile(ctx)
 
 	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *Layer2NetworkConfigurationReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.Debouncer = debounce.NewDebouncer(r.ReconcileDebounced, 5*time.Second)
-	r.NLManager = &nl.NetlinkManager{}
-
 	// Create empty request for changes to node
 	nodesMapFn := handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request { return []reconcile.Request{{}} })
 	nodePredicates := predicate.Funcs{
@@ -99,148 +81,4 @@ func (r *Layer2NetworkConfigurationReconciler) SetupWithManager(mgr ctrl.Manager
 		For(&networkv1alpha1.Layer2NetworkConfiguration{}).
 		Watches(&source.Kind{Type: &corev1.Node{}}, nodesMapFn, builder.WithPredicates(nodePredicates)).
 		Complete(r)
-}
-
-func (r *Layer2NetworkConfigurationReconciler) ReconcileDebounced(ctx context.Context) error {
-	logger := log.FromContext(ctx)
-
-	layer2s := &networkv1alpha1.Layer2NetworkConfigurationList{}
-	err := r.Client.List(ctx, layer2s)
-	if err != nil {
-		logger.Error(err, "error getting list of Layer2s from Kubernetes")
-		return err
-	}
-
-	nodeName := os.Getenv("HOSTNAME")
-	node := &corev1.Node{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: nodeName}, node)
-	if err != nil {
-		logger.Error(err, "error getting local node name")
-		return err
-	}
-
-	layer2Info := []nl.Layer2Information{}
-
-	for _, layer2 := range layer2s.Items {
-		spec := layer2.Spec
-
-		if spec.NodeSelector != nil {
-			selector, err := metav1.LabelSelectorAsSelector(spec.NodeSelector)
-			if err != nil {
-				logger.Error(err, "error converting nodeSelector of layer2 to selector", "layer2", layer2.ObjectMeta.Name)
-				return err
-			}
-			if !selector.Matches(labels.Set(node.ObjectMeta.Labels)) {
-				logger.Info("local node does not match nodeSelector of layer2", "layer2", layer2.ObjectMeta.Name, "node", nodeName)
-				return err
-			}
-		}
-
-		var anycastMAC *net.HardwareAddr
-		if mac, err := net.ParseMAC(spec.AnycastMac); err == nil {
-			anycastMAC = &mac
-		}
-
-		anycastGateways, err := r.NLManager.ParseIPAddresses(spec.AnycastGateways)
-		if err != nil {
-			logger.Error(err, "error parsing anycast gateways", "layer", layer2.ObjectMeta.Name, "gw", spec.AnycastGateways)
-			return err
-		}
-
-		layer2Info = append(layer2Info, nl.Layer2Information{
-			VlanID:                 spec.ID,
-			MTU:                    spec.MTU,
-			VNI:                    spec.VNI,
-			VRF:                    spec.VRF,
-			AnycastMAC:             anycastMAC,
-			AnycastGateways:        anycastGateways,
-			AdvertiseNeighbors:     spec.AdvertiseNeighbors,
-			CreateMACVLANInterface: spec.CreateMACVLANInterface,
-		})
-	}
-
-	if err := r.reconcileLayer2(ctx, layer2Info); err != nil {
-		logger.Error(err, "error reconciling Layer2s")
-		return err
-	}
-
-	return nil
-}
-
-func (r *Layer2NetworkConfigurationReconciler) reconcileLayer2(ctx context.Context, layer2Info []nl.Layer2Information) error {
-	logger := log.FromContext(ctx)
-
-	existing, err := r.NLManager.ListL2()
-	if err != nil {
-		return err
-	}
-
-	delete := []nl.Layer2Information{}
-	for _, cfg := range existing {
-		stillExists := false
-		for _, info := range layer2Info {
-			if info.VlanID == cfg.VlanID {
-				// Maybe reconcile to match MTU, gateways?
-				stillExists = true
-			}
-		}
-		if !stillExists {
-			delete = append(delete, cfg)
-		}
-	}
-
-	create := []nl.Layer2Information{}
-	anycastTrackerInterfaces := []int{}
-	for _, info := range layer2Info {
-		alreadyExists := false
-		var currentConfig nl.Layer2Information
-		for _, cfg := range existing {
-			if info.VlanID == cfg.VlanID {
-				alreadyExists = true
-				currentConfig = cfg
-			}
-		}
-		if !alreadyExists {
-			create = append(create, info)
-		} else {
-			err := r.NLManager.ReconcileL2(currentConfig, info)
-			if err != nil {
-				return fmt.Errorf("error reconciling layer2 vlan %d vni %d: %v", info.VlanID, info.VNI, err)
-			}
-			if info.AdvertiseNeighbors {
-				bridgeId, err := r.NLManager.GetBridgeId(info)
-				if err != nil {
-					return fmt.Errorf("error getting bridge id for vlanId %d: %v", info.VlanID, err)
-				}
-				anycastTrackerInterfaces = append(anycastTrackerInterfaces, bridgeId)
-			}
-		}
-	}
-
-	for _, info := range delete {
-		logger.Info("Deleting Layer2 because it is no longer configured", "vlan", info.VlanID, "vni", info.VNI)
-		errs := r.NLManager.CleanupL2(info)
-		for _, err := range errs {
-			logger.Error(err, "Error deleting Layer2", "vlan", info.VlanID, "vni", info.VNI)
-		}
-	}
-
-	for _, info := range create {
-		logger.Info("Creating Layer2", "vlan", info.VlanID, "vni", info.VNI)
-		err := r.NLManager.CreateL2(info)
-		if err != nil {
-			return fmt.Errorf("error creating layer2 vlan %d vni %d: %v", info.VlanID, info.VNI, err)
-		}
-		if info.AdvertiseNeighbors {
-			bridgeId, err := r.NLManager.GetBridgeId(info)
-			if err != nil {
-				return fmt.Errorf("error getting bridge id for vlanId %d: %v", info.VlanID, err)
-			}
-			anycastTrackerInterfaces = append(anycastTrackerInterfaces, bridgeId)
-		}
-	}
-
-	r.AnycastTracker.TrackedBridges = anycastTrackerInterfaces
-
-	return nil
 }

--- a/controllers/vrfrouteconfiguration_controller.go
+++ b/controllers/vrfrouteconfiguration_controller.go
@@ -18,36 +18,22 @@ package controllers
 
 import (
 	"context"
-	"fmt"
-	"net"
-	"os"
-	"sort"
-	"strconv"
-	"time"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
-	"github.com/telekom/das-schiff-network-operator/pkg/config"
-	"github.com/telekom/das-schiff-network-operator/pkg/debounce"
-	"github.com/telekom/das-schiff-network-operator/pkg/frr"
-	"github.com/telekom/das-schiff-network-operator/pkg/nl"
+	"github.com/telekom/das-schiff-network-operator/pkg/reconciler"
 )
 
 // VRFRouteConfigurationReconciler reconciles a VRFRouteConfiguration object
 type VRFRouteConfigurationReconciler struct {
 	client.Client
-	Scheme      *runtime.Scheme
-	Config      *config.Config
-	Debouncer   *debounce.Debouncer
-	Logger      logr.Logger
-	FRRManager  *frr.FRRManager
-	NLManager   *nl.NetlinkManager
-	dirtyConfig bool
+	Scheme *runtime.Scheme
+
+	Reconciler *reconciler.Reconciler
 }
 
 //+kubebuilder:rbac:groups=network.schiff.telekom.de,resources=vrfrouteconfigurations,verbs=get;list;watch;create;update;patch;delete
@@ -63,222 +49,14 @@ func (r *VRFRouteConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 	_ = log.FromContext(ctx)
 
 	// Run ReconcileDebounced through debouncer
-	r.Debouncer.Debounce(ctx)
+	r.Reconciler.Reconcile(ctx)
 
 	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *VRFRouteConfigurationReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.Debouncer = debounce.NewDebouncer(r.ReconcileDebounced, 30*time.Second)
-	r.Logger = mgr.GetLogger().WithName("vrf-controller")
-	r.FRRManager = frr.NewFRRManager()
-	r.NLManager = &nl.NetlinkManager{}
-
-	if val := os.Getenv("FRR_CONFIG_FILE"); val != "" {
-		r.FRRManager.ConfigPath = val
-	}
-
-	if err := r.FRRManager.Init(); err != nil {
-		return err
-	}
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&networkv1alpha1.VRFRouteConfiguration{}).
 		Complete(r)
-}
-
-func (r *VRFRouteConfigurationReconciler) ReconcileDebounced(ctx context.Context) error {
-	vrfs := &networkv1alpha1.VRFRouteConfigurationList{}
-	err := r.Client.List(ctx, vrfs)
-	if err != nil {
-		r.Logger.Error(err, "error getting list of VRFs from Kubernetes")
-		return err
-	}
-
-	vrfConfigMap := map[string]frr.VRFConfiguration{}
-
-	for _, vrf := range vrfs.Items {
-		spec := vrf.Spec
-
-		var vni int
-		var rt string
-
-		if val, ok := r.Config.VRFToVNI[spec.VRF]; ok {
-			vni = val
-			r.Logger.Info("Configuring VRF from old VRFToVNI", "vrf", spec.VRF, "vni", val)
-		} else if val, ok := r.Config.VRFConfig[spec.VRF]; ok {
-			vni = val.VNI
-			rt = val.RT
-			r.Logger.Info("Configuring VRF from new VRFConfig", "vrf", spec.VRF, "vni", val.VNI, "rt", rt)
-		} else if r.Config.ShouldSkipVRFConfig(spec.VRF) {
-			vni = config.SKIP_VRF_TEMPLATE_VNI
-		} else {
-			r.Logger.Error(err, "VRF does not exist in VRF VNI config", "vrf", spec.VRF, "name", vrf.ObjectMeta.Name, "namespace", vrf.ObjectMeta.Namespace)
-			return err
-		}
-
-		// If VRF is not yet in dict, initialize it
-		if _, ok := vrfConfigMap[spec.VRF]; !ok {
-			vrfConfigMap[spec.VRF] = frr.VRFConfiguration{
-				Name: spec.VRF,
-				VNI:  vni,
-				RT:   rt,
-			}
-		}
-
-		config := vrfConfigMap[spec.VRF]
-
-		if len(spec.Export) > 0 {
-			config.Export = append(config.Export, handlePrefixItemList(spec.Export, spec.Seq))
-		}
-		if len(spec.Import) > 0 {
-			config.Import = append(config.Import, handlePrefixItemList(spec.Import, spec.Seq))
-		}
-		for _, aggregate := range spec.Aggregate {
-			_, network, _ := net.ParseCIDR(aggregate)
-			if network.IP.To4() == nil {
-				config.AggregateIPv6 = append(config.AggregateIPv6, aggregate)
-			} else {
-				config.AggregateIPv4 = append(config.AggregateIPv4, aggregate)
-			}
-		}
-		vrfConfigMap[spec.VRF] = config
-	}
-
-	vrfConfigs := []frr.VRFConfiguration{}
-	for _, vrf := range vrfConfigMap {
-		vrfConfigs = append(vrfConfigs, vrf)
-	}
-
-	sort.SliceStable(vrfConfigs, func(i, j int) bool {
-		return vrfConfigs[i].VNI < vrfConfigs[j].VNI
-	})
-
-	created, err := r.reconcileNetlink(vrfConfigs)
-	if err != nil {
-		r.Logger.Error(err, "error reconciling Netlink")
-		return err
-	}
-
-	// We wait here for two seconds to let FRR settle after updating netlink devices
-	time.Sleep(2 * time.Second)
-
-	changed, err := r.FRRManager.Configure(frr.FRRConfiguration{
-		VRFs: vrfConfigs,
-		ASN:  r.Config.ServerASN,
-	})
-	if err != nil {
-		r.Logger.Error(err, "error updating FRR configuration")
-		return err
-	}
-
-	if changed || r.dirtyConfig {
-		r.Logger.Info("trying to reload FRR config because it changed")
-		err = r.FRRManager.ReloadFRR()
-		if err != nil {
-			r.dirtyConfig = true
-			r.Logger.Error(err, "error reloading FRR systemd unit")
-			return err
-		}
-		r.dirtyConfig = false
-	}
-
-	// Make sure that all created netlink VRFs are up after FRR reload
-	time.Sleep(2 * time.Second)
-	for _, info := range created {
-		if err := r.NLManager.UpL3(info); err != nil {
-			r.Logger.Error(err, "error setting L3 to state UP")
-			return err
-		}
-	}
-	return nil
-}
-
-func (r *VRFRouteConfigurationReconciler) reconcileNetlink(vrfConfigs []frr.VRFConfiguration) ([]nl.VRFInformation, error) {
-	existing, err := r.NLManager.ListL3()
-	if err != nil {
-		return nil, err
-	}
-
-	// Check for VRFs that are configured on the host but no longer in Kubernetes
-	delete := []nl.VRFInformation{}
-	for _, cfg := range existing {
-		stillExists := false
-		for _, vrf := range vrfConfigs {
-			if vrf.Name == cfg.Name && vrf.VNI == cfg.VNI {
-				stillExists = true
-			}
-		}
-		if !stillExists {
-			delete = append(delete, cfg)
-		}
-	}
-
-	// Check for VRFs that are in Kubernetes but not yet configured on the host
-	create := []nl.VRFInformation{}
-	for _, vrf := range vrfConfigs {
-		// Skip VRF with VNI SKIP_VRF_TEMPLATE_VNI
-		if vrf.VNI == config.SKIP_VRF_TEMPLATE_VNI {
-			continue
-		}
-		alreadyExists := false
-		for _, cfg := range existing {
-			if vrf.Name == cfg.Name && vrf.VNI == cfg.VNI {
-				alreadyExists = true
-			}
-		}
-		if !alreadyExists {
-			create = append(create, nl.VRFInformation{
-				Name: vrf.Name,
-				VNI:  vrf.VNI,
-			})
-		}
-	}
-
-	// Delete / Cleanup VRFs
-	for _, info := range delete {
-		r.Logger.Info("Deleting VRF because it is no longer configured in Kubernetes", "vrf", info.Name, "vni", info.VNI)
-		errs := r.NLManager.CleanupL3(info.Name)
-		for _, err := range errs {
-			r.Logger.Error(err, "Error deleting VRF", "vrf", info.Name, "vni", strconv.Itoa(info.VNI))
-		}
-	}
-	// Create VRFs
-	for _, info := range create {
-		r.Logger.Info("Creating VRF to match Kubernetes", "vrf", info.Name, "vni", info.VNI)
-		err := r.NLManager.CreateL3(info)
-		if err != nil {
-			return nil, fmt.Errorf("error creating VRF %s, VNI %d: %w", info.Name, info.VNI, err)
-		}
-	}
-
-	return create, nil
-}
-
-func handlePrefixItemList(input []networkv1alpha1.VrfRouteConfigurationPrefixItem, seq int) frr.PrefixList {
-	prefixList := frr.PrefixList{
-		Seq: seq + 1,
-	}
-	for i, item := range input {
-		prefixList.Items = append(prefixList.Items, copyPrefixItemToFRRItem(i, item))
-	}
-	return prefixList
-}
-
-func copyPrefixItemToFRRItem(i int, item networkv1alpha1.VrfRouteConfigurationPrefixItem) frr.PrefixedRouteItem {
-	_, network, _ := net.ParseCIDR(item.CIDR)
-
-	seq := item.Seq
-	if seq <= 0 {
-		seq = i + 1
-	}
-	return frr.PrefixedRouteItem{
-		CIDR:   *network,
-		IPv6:   network.IP.To4() == nil,
-		Seq:    seq,
-		Action: item.Action,
-		GE:     item.GE,
-		LE:     item.LE,
-	}
 }

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/telekom/das-schiff-network-operator/pkg/config"
 	"github.com/telekom/das-schiff-network-operator/pkg/macvlan"
 	"github.com/telekom/das-schiff-network-operator/pkg/notrack"
+	"github.com/telekom/das-schiff-network-operator/pkg/reconciler"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -97,25 +98,30 @@ func main() {
 	anycastTracker := &anycast.AnycastTracker{}
 
 	// Start VRFRouteConfigurationReconciler when we are not running in only BPF mode.
-	if !onlyBPFMode {
-		if err = (&controllers.VRFRouteConfigurationReconciler{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
-			Config: config,
-		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "VRFRouteConfiguration")
-			os.Exit(1)
-		}
-	}
 	if err = (&networkv1alpha1.VRFRouteConfiguration{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "VRFRouteConfiguration")
 		os.Exit(1)
 	}
 	if !onlyBPFMode {
+		reconciler, err := reconciler.NewReconciler(mgr.GetClient(), anycastTracker)
+		if err != nil {
+			setupLog.Error(err, "unable to create debounced reconciler")
+			os.Exit(1)
+		}
+
+		if err = (&controllers.VRFRouteConfigurationReconciler{
+			Client:     mgr.GetClient(),
+			Scheme:     mgr.GetScheme(),
+			Reconciler: reconciler,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "VRFRouteConfiguration")
+			os.Exit(1)
+		}
+
 		if err = (&controllers.Layer2NetworkConfigurationReconciler{
-			Client:         mgr.GetClient(),
-			Scheme:         mgr.GetScheme(),
-			AnycastTracker: anycastTracker,
+			Client:     mgr.GetClient(),
+			Scheme:     mgr.GetScheme(),
+			Reconciler: reconciler,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Layer2NetworkConfiguration")
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -97,11 +97,11 @@ func main() {
 
 	anycastTracker := &anycast.AnycastTracker{}
 
-	// Start VRFRouteConfigurationReconciler when we are not running in only BPF mode.
 	if err = (&networkv1alpha1.VRFRouteConfiguration{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "VRFRouteConfiguration")
 		os.Exit(1)
 	}
+	// Start VRFRouteConfigurationReconciler when we are not running in only BPF mode.
 	if !onlyBPFMode {
 		reconciler, err := reconciler.NewReconciler(mgr.GetClient(), anycastTracker)
 		if err != nil {

--- a/pkg/debounce/debounce.go
+++ b/pkg/debounce/debounce.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync/atomic"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // Debouncer struct
@@ -35,6 +37,8 @@ func (d *Debouncer) debounceRoutine(ctx context.Context) {
 			// Reset scheduled to 0
 			atomic.StoreInt32(&d.scheduled, 0)
 			break
+		} else {
+			log.FromContext(ctx).Error(err, "error debouncing")
 		}
 	}
 }

--- a/pkg/frr/configure.go
+++ b/pkg/frr/configure.go
@@ -41,7 +41,7 @@ func (m *FRRManager) Configure(in FRRConfiguration) (bool, error) {
 		return false, err
 	}
 
-	if bytes.Equal(currentConfig, targetConfig) {
+	if !bytes.Equal(currentConfig, targetConfig) {
 		err = os.WriteFile(m.ConfigPath, targetConfig, FRR_PERMISSIONS)
 		if err != nil {
 			return false, err

--- a/pkg/reconciler/layer2.go
+++ b/pkg/reconciler/layer2.go
@@ -113,6 +113,7 @@ func (r *reconcile) reconcileLayer2(l2vnis []networkv1alpha1.Layer2NetworkConfig
 		if !alreadyExists {
 			create = append(create, info)
 		} else {
+			r.Logger.Info("Reconciling existing Layer2", "vlan", info.VlanID, "vni", info.VNI)
 			err := r.netlinkManager.ReconcileL2(currentConfig, info)
 			if err != nil {
 				return fmt.Errorf("error reconciling layer2 vlan %d vni %d: %v", info.VlanID, info.VNI, err)

--- a/pkg/reconciler/layer2.go
+++ b/pkg/reconciler/layer2.go
@@ -1,0 +1,156 @@
+package reconciler
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
+	"github.com/telekom/das-schiff-network-operator/pkg/nl"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *reconcile) fetchLayer2() ([]networkv1alpha1.Layer2NetworkConfiguration, error) {
+	layer2List := &networkv1alpha1.Layer2NetworkConfigurationList{}
+	err := r.client.List(r.Context, layer2List)
+	if err != nil {
+		r.Logger.Error(err, "error getting list of Layer2s from Kubernetes")
+		return nil, err
+	}
+
+	nodeName := os.Getenv("HOSTNAME")
+	node := &corev1.Node{}
+	err = r.client.Get(r.Context, types.NamespacedName{Name: nodeName}, node)
+	if err != nil {
+		r.Logger.Error(err, "error getting local node name")
+		return nil, err
+	}
+
+	l2vnis := []networkv1alpha1.Layer2NetworkConfiguration{}
+
+	for _, item := range layer2List.Items {
+		if item.Spec.NodeSelector != nil {
+			selector, err := metav1.LabelSelectorAsSelector(item.Spec.NodeSelector)
+			if err != nil {
+				r.Logger.Error(err, "error converting nodeSelector of layer2 to selector", "layer2", item.ObjectMeta.Name)
+				return nil, err
+			}
+			if !selector.Matches(labels.Set(node.ObjectMeta.Labels)) {
+				r.Logger.Info("local node does not match nodeSelector of layer2", "layer2", item.ObjectMeta.Name, "node", nodeName)
+				return nil, err
+			}
+		}
+
+		l2vnis = append(l2vnis, item)
+	}
+
+	return l2vnis, nil
+}
+
+func (r *reconcile) reconcileLayer2(l2vnis []networkv1alpha1.Layer2NetworkConfiguration) error {
+	layer2Info := []nl.Layer2Information{}
+
+	for _, layer2 := range l2vnis {
+		spec := layer2.Spec
+
+		var anycastMAC *net.HardwareAddr
+		if mac, err := net.ParseMAC(spec.AnycastMac); err == nil {
+			anycastMAC = &mac
+		}
+
+		anycastGateways, err := r.netlinkManager.ParseIPAddresses(spec.AnycastGateways)
+		if err != nil {
+			r.Logger.Error(err, "error parsing anycast gateways", "layer", layer2.ObjectMeta.Name, "gw", spec.AnycastGateways)
+			return err
+		}
+
+		layer2Info = append(layer2Info, nl.Layer2Information{
+			VlanID:                 spec.ID,
+			MTU:                    spec.MTU,
+			VNI:                    spec.VNI,
+			VRF:                    spec.VRF,
+			AnycastMAC:             anycastMAC,
+			AnycastGateways:        anycastGateways,
+			AdvertiseNeighbors:     spec.AdvertiseNeighbors,
+			CreateMACVLANInterface: spec.CreateMACVLANInterface,
+		})
+	}
+
+	existing, err := r.netlinkManager.ListL2()
+	if err != nil {
+		return err
+	}
+
+	delete := []nl.Layer2Information{}
+	for _, cfg := range existing {
+		stillExists := false
+		for _, info := range layer2Info {
+			if info.VlanID == cfg.VlanID {
+				// Maybe reconcile to match MTU, gateways?
+				stillExists = true
+			}
+		}
+		if !stillExists {
+			delete = append(delete, cfg)
+		}
+	}
+
+	create := []nl.Layer2Information{}
+	anycastTrackerInterfaces := []int{}
+	for _, info := range layer2Info {
+		alreadyExists := false
+		var currentConfig nl.Layer2Information
+		for _, cfg := range existing {
+			if info.VlanID == cfg.VlanID {
+				alreadyExists = true
+				currentConfig = cfg
+			}
+		}
+		if !alreadyExists {
+			create = append(create, info)
+		} else {
+			err := r.netlinkManager.ReconcileL2(currentConfig, info)
+			if err != nil {
+				return fmt.Errorf("error reconciling layer2 vlan %d vni %d: %v", info.VlanID, info.VNI, err)
+			}
+			if info.AdvertiseNeighbors {
+				bridgeId, err := r.netlinkManager.GetBridgeId(info)
+				if err != nil {
+					return fmt.Errorf("error getting bridge id for vlanId %d: %v", info.VlanID, err)
+				}
+				anycastTrackerInterfaces = append(anycastTrackerInterfaces, bridgeId)
+			}
+		}
+	}
+
+	for _, info := range delete {
+		r.Logger.Info("Deleting Layer2 because it is no longer configured", "vlan", info.VlanID, "vni", info.VNI)
+		errs := r.netlinkManager.CleanupL2(info)
+		for _, err := range errs {
+			r.Logger.Error(err, "Error deleting Layer2", "vlan", info.VlanID, "vni", info.VNI)
+		}
+	}
+
+	for _, info := range create {
+		r.Logger.Info("Creating Layer2", "vlan", info.VlanID, "vni", info.VNI)
+		err := r.netlinkManager.CreateL2(info)
+		if err != nil {
+			return fmt.Errorf("error creating layer2 vlan %d vni %d: %v", info.VlanID, info.VNI, err)
+		}
+		if info.AdvertiseNeighbors {
+			bridgeId, err := r.netlinkManager.GetBridgeId(info)
+			if err != nil {
+				return fmt.Errorf("error getting bridge id for vlanId %d: %v", info.VlanID, err)
+			}
+			anycastTrackerInterfaces = append(anycastTrackerInterfaces, bridgeId)
+		}
+	}
+
+	r.anycastTracker.TrackedBridges = anycastTrackerInterfaces
+
+	return nil
+}

--- a/pkg/reconciler/layer3.go
+++ b/pkg/reconciler/layer3.go
@@ -1,0 +1,214 @@
+package reconciler
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strconv"
+	"time"
+
+	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
+	"github.com/telekom/das-schiff-network-operator/pkg/config"
+	"github.com/telekom/das-schiff-network-operator/pkg/frr"
+	"github.com/telekom/das-schiff-network-operator/pkg/nl"
+)
+
+func (r *reconcile) fetchLayer3() ([]networkv1alpha1.VRFRouteConfiguration, error) {
+	vrfs := &networkv1alpha1.VRFRouteConfigurationList{}
+	err := r.client.List(r.Context, vrfs)
+	if err != nil {
+		r.Logger.Error(err, "error getting list of VRFs from Kubernetes")
+		return nil, err
+	}
+
+	return vrfs.Items, nil
+}
+
+func (r *reconcile) reconcileLayer3(l3vnis []networkv1alpha1.VRFRouteConfiguration) error {
+	vrfConfigMap := map[string]frr.VRFConfiguration{}
+
+	for _, vrf := range l3vnis {
+		spec := vrf.Spec
+
+		var vni int
+		var rt string
+
+		if val, ok := r.config.VRFToVNI[spec.VRF]; ok {
+			vni = val
+			r.Logger.Info("Configuring VRF from old VRFToVNI", "vrf", spec.VRF, "vni", val)
+		} else if val, ok := r.config.VRFConfig[spec.VRF]; ok {
+			vni = val.VNI
+			rt = val.RT
+			r.Logger.Info("Configuring VRF from new VRFConfig", "vrf", spec.VRF, "vni", val.VNI, "rt", rt)
+		} else if r.config.ShouldSkipVRFConfig(spec.VRF) {
+			vni = config.SKIP_VRF_TEMPLATE_VNI
+		} else {
+			err := fmt.Errorf("vrf not in vrf vni map")
+			r.Logger.Error(err, "VRF does not exist in VRF VNI config", "vrf", spec.VRF, "name", vrf.ObjectMeta.Name, "namespace", vrf.ObjectMeta.Namespace)
+			return err
+		}
+
+		// If VRF is not yet in dict, initialize it
+		if _, ok := vrfConfigMap[spec.VRF]; !ok {
+			vrfConfigMap[spec.VRF] = frr.VRFConfiguration{
+				Name: spec.VRF,
+				VNI:  vni,
+				RT:   rt,
+			}
+		}
+
+		config := vrfConfigMap[spec.VRF]
+
+		if len(spec.Export) > 0 {
+			config.Export = append(config.Export, handlePrefixItemList(spec.Export, spec.Seq))
+		}
+		if len(spec.Import) > 0 {
+			config.Import = append(config.Import, handlePrefixItemList(spec.Import, spec.Seq))
+		}
+		for _, aggregate := range spec.Aggregate {
+			_, network, _ := net.ParseCIDR(aggregate)
+			if network.IP.To4() == nil {
+				config.AggregateIPv6 = append(config.AggregateIPv6, aggregate)
+			} else {
+				config.AggregateIPv4 = append(config.AggregateIPv4, aggregate)
+			}
+		}
+		vrfConfigMap[spec.VRF] = config
+	}
+
+	vrfConfigs := []frr.VRFConfiguration{}
+	for _, vrf := range vrfConfigMap {
+		vrfConfigs = append(vrfConfigs, vrf)
+	}
+
+	sort.SliceStable(vrfConfigs, func(i, j int) bool {
+		return vrfConfigs[i].VNI < vrfConfigs[j].VNI
+	})
+
+	created, err := r.reconcileL3Netlink(vrfConfigs)
+	if err != nil {
+		r.Logger.Error(err, "error reconciling Netlink")
+		return err
+	}
+
+	// We wait here for two seconds to let FRR settle after updating netlink devices
+	time.Sleep(2 * time.Second)
+
+	changed, err := r.frrManager.Configure(frr.FRRConfiguration{
+		VRFs: vrfConfigs,
+		ASN:  r.config.ServerASN,
+	})
+	if err != nil {
+		r.Logger.Error(err, "error updating FRR configuration")
+		return err
+	}
+
+	if changed || r.dirtyFRRConfig {
+		r.Logger.Info("trying to reload FRR config because it changed")
+		err = r.frrManager.ReloadFRR()
+		if err != nil {
+			r.dirtyFRRConfig = true
+			r.Logger.Error(err, "error reloading FRR systemd unit")
+			return err
+		}
+		r.dirtyFRRConfig = false
+	}
+
+	// Make sure that all created netlink VRFs are up after FRR reload
+	time.Sleep(2 * time.Second)
+	for _, info := range created {
+		if err := r.netlinkManager.UpL3(info); err != nil {
+			r.Logger.Error(err, "error setting L3 to state UP")
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *reconcile) reconcileL3Netlink(vrfConfigs []frr.VRFConfiguration) ([]nl.VRFInformation, error) {
+	existing, err := r.netlinkManager.ListL3()
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for VRFs that are configured on the host but no longer in Kubernetes
+	delete := []nl.VRFInformation{}
+	for _, cfg := range existing {
+		stillExists := false
+		for _, vrf := range vrfConfigs {
+			if vrf.Name == cfg.Name && vrf.VNI == cfg.VNI {
+				stillExists = true
+			}
+		}
+		if !stillExists {
+			delete = append(delete, cfg)
+		}
+	}
+
+	// Check for VRFs that are in Kubernetes but not yet configured on the host
+	create := []nl.VRFInformation{}
+	for _, vrf := range vrfConfigs {
+		// Skip VRF with VNI SKIP_VRF_TEMPLATE_VNI
+		if vrf.VNI == config.SKIP_VRF_TEMPLATE_VNI {
+			continue
+		}
+		alreadyExists := false
+		for _, cfg := range existing {
+			if vrf.Name == cfg.Name && vrf.VNI == cfg.VNI {
+				alreadyExists = true
+			}
+		}
+		if !alreadyExists {
+			create = append(create, nl.VRFInformation{
+				Name: vrf.Name,
+				VNI:  vrf.VNI,
+			})
+		}
+	}
+
+	// Delete / Cleanup VRFs
+	for _, info := range delete {
+		r.Logger.Info("Deleting VRF because it is no longer configured in Kubernetes", "vrf", info.Name, "vni", info.VNI)
+		errs := r.netlinkManager.CleanupL3(info.Name)
+		for _, err := range errs {
+			r.Logger.Error(err, "Error deleting VRF", "vrf", info.Name, "vni", strconv.Itoa(info.VNI))
+		}
+	}
+	// Create VRFs
+	for _, info := range create {
+		r.Logger.Info("Creating VRF to match Kubernetes", "vrf", info.Name, "vni", info.VNI)
+		err := r.netlinkManager.CreateL3(info)
+		if err != nil {
+			return nil, fmt.Errorf("error creating VRF %s, VNI %d: %w", info.Name, info.VNI, err)
+		}
+	}
+
+	return create, nil
+}
+
+func handlePrefixItemList(input []networkv1alpha1.VrfRouteConfigurationPrefixItem, seq int) frr.PrefixList {
+	prefixList := frr.PrefixList{
+		Seq: seq + 1,
+	}
+	for i, item := range input {
+		prefixList.Items = append(prefixList.Items, copyPrefixItemToFRRItem(i, item))
+	}
+	return prefixList
+}
+
+func copyPrefixItemToFRRItem(i int, item networkv1alpha1.VrfRouteConfigurationPrefixItem) frr.PrefixedRouteItem {
+	_, network, _ := net.ParseCIDR(item.CIDR)
+
+	seq := item.Seq
+	if seq <= 0 {
+		seq = i + 1
+	}
+	return frr.PrefixedRouteItem{
+		CIDR:   *network,
+		IPv6:   network.IP.To4() == nil,
+		Seq:    seq,
+		Action: item.Action,
+		GE:     item.GE,
+		LE:     item.LE,
+	}
+}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -38,7 +38,7 @@ func NewReconciler(client client.Client, anycastTracker *anycast.AnycastTracker)
 	reconciler := &Reconciler{
 		client:         client,
 		netlinkManager: &nl.NetlinkManager{},
-		frrManager:     &frr.FRRManager{},
+		frrManager:     frr.NewFRRManager(),
 		anycastTracker: anycastTracker,
 	}
 
@@ -49,6 +49,12 @@ func NewReconciler(client client.Client, anycastTracker *anycast.AnycastTracker)
 	}
 	if err := reconciler.frrManager.Init(); err != nil {
 		return nil, err
+	}
+
+	if config, err := config.LoadConfig(); err != nil {
+		return nil, err
+	} else {
+		reconciler.config = config
 	}
 
 	return reconciler, nil

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -1,0 +1,84 @@
+package reconciler
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/telekom/das-schiff-network-operator/pkg/anycast"
+	"github.com/telekom/das-schiff-network-operator/pkg/config"
+	"github.com/telekom/das-schiff-network-operator/pkg/debounce"
+	"github.com/telekom/das-schiff-network-operator/pkg/frr"
+	"github.com/telekom/das-schiff-network-operator/pkg/nl"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type Reconciler struct {
+	client         client.Client
+	netlinkManager *nl.NetlinkManager
+	frrManager     *frr.FRRManager
+	anycastTracker *anycast.AnycastTracker
+	config         *config.Config
+
+	debouncer *debounce.Debouncer
+
+	dirtyFRRConfig bool
+}
+
+type reconcile struct {
+	*Reconciler
+	context.Context
+	logr.Logger
+}
+
+func NewReconciler(client client.Client, anycastTracker *anycast.AnycastTracker) (*Reconciler, error) {
+	reconciler := &Reconciler{
+		client:         client,
+		netlinkManager: &nl.NetlinkManager{},
+		frrManager:     &frr.FRRManager{},
+		anycastTracker: anycastTracker,
+	}
+
+	reconciler.debouncer = debounce.NewDebouncer(reconciler.reconcileDebounced, 20*time.Second)
+
+	if val := os.Getenv("FRR_CONFIG_FILE"); val != "" {
+		reconciler.frrManager.ConfigPath = val
+	}
+	if err := reconciler.frrManager.Init(); err != nil {
+		return nil, err
+	}
+
+	return reconciler, nil
+}
+
+func (reconciler *Reconciler) Reconcile(ctx context.Context) {
+	reconciler.debouncer.Debounce(ctx)
+}
+
+func (reconciler *Reconciler) reconcileDebounced(ctx context.Context) error {
+	r := &reconcile{
+		Reconciler: reconciler,
+		Context:    ctx,
+		Logger:     log.FromContext(ctx),
+	}
+
+	l3vnis, err := r.fetchLayer3()
+	if err != nil {
+		return err
+	}
+	l2vnis, err := r.fetchLayer2()
+	if err != nil {
+		return err
+	}
+
+	if err := r.reconcileLayer3(l3vnis); err != nil {
+		return err
+	}
+	if err := r.reconcileLayer2(l2vnis); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Previously reconciliation happened in each controller. However we have an interdependency between L2VNIs and L3VNIs. Thus we summarize reconciliation in a central place. This also allows us to reference L2VNIs in FRR config (e.g. for RT settings). Also we now reconcile them after L3VNI reconciliation, attaching VRFs if needed.