### PR TITLE
Make Neighbor Suppression configurable

### DIFF
--- a/api/v1alpha1/layer2networkconfiguration_types.go
+++ b/api/v1alpha1/layer2networkconfiguration_types.go
@@ -53,6 +53,9 @@ type Layer2NetworkConfigurationSpec struct {
 	// Create MACVLAN attach interface
 	CreateMACVLANInterface bool `json:"createMacVLANInterface,omitempty"`
 
+	// Enable ARP / ND suppression
+	NeighSuppression *bool `json:"neighSuppression,omitempty"`
+
 	// VRF to attach Layer2 network to, default if not set
 	VRF string `json:"vrf,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -93,6 +93,11 @@ func (in *Layer2NetworkConfigurationSpec) DeepCopyInto(out *Layer2NetworkConfigu
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NeighSuppression != nil {
+		in, out := &in.NeighSuppression, &out.NeighSuppression
+		*out = new(bool)
+		**out = **in
+	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = new(v1.LabelSelector)

--- a/config/crd/bases/network.schiff.telekom.de_layer2networkconfigurations.yaml
+++ b/config/crd/bases/network.schiff.telekom.de_layer2networkconfigurations.yaml
@@ -51,9 +51,6 @@ spec:
                 description: If anycast is desired, specify anycast gateway MAC address
                 pattern: (?:[[:xdigit:]]{2}:){5}[[:xdigit:]]{2}
                 type: string
-              arpSuppression:
-                description: Enable ARP suppression
-                type: boolean
               createMacVLANInterface:
                 description: Create MACVLAN attach interface
                 type: boolean
@@ -65,6 +62,9 @@ spec:
                 maximum: 9000
                 minimum: 1000
                 type: integer
+              neighSuppression:
+                description: Enable ARP / ND suppression
+                type: boolean
               nodeSelector:
                 description: Select nodes to create Layer2 network on
                 properties:

--- a/config/crd/bases/network.schiff.telekom.de_layer2networkconfigurations.yaml
+++ b/config/crd/bases/network.schiff.telekom.de_layer2networkconfigurations.yaml
@@ -51,6 +51,9 @@ spec:
                 description: If anycast is desired, specify anycast gateway MAC address
                 pattern: (?:[[:xdigit:]]{2}:){5}[[:xdigit:]]{2}
                 type: string
+              arpSuppression:
+                description: Enable ARP suppression
+                type: boolean
               createMacVLANInterface:
                 description: Create MACVLAN attach interface
                 type: boolean

--- a/pkg/nl/create.go
+++ b/pkg/nl/create.go
@@ -57,7 +57,7 @@ func (n *NetlinkManager) createBridge(bridgeName string, macAddress *net.Hardwar
 	return &netlinkBridge, nil
 }
 
-func (n *NetlinkManager) createVXLAN(vxlanName string, bridgeIdx int, vni int, mtu int, hairpin bool) (*netlink.Vxlan, error) {
+func (n *NetlinkManager) createVXLAN(vxlanName string, bridgeIdx int, vni int, mtu int, hairpin bool, neighSuppression bool) (*netlink.Vxlan, error) {
 	vxlanIf, vxlanIP, err := getInterfaceAndIP(UNDERLAY_LOOPBACK)
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func (n *NetlinkManager) createVXLAN(vxlanName string, bridgeIdx int, vni int, m
 	if err := netlink.LinkSetLearning(&netlinkVXLAN, false); err != nil {
 		return nil, err
 	}
-	if err := setNeighSuppression(&netlinkVXLAN, os.Getenv("NWOP_NEIGH_SUPPRESSION") == "true"); err != nil {
+	if err := setNeighSuppression(&netlinkVXLAN, neighSuppression); err != nil {
 		return nil, err
 	}
 	if hairpin {

--- a/pkg/nl/layer2.go
+++ b/pkg/nl/layer2.go
@@ -77,6 +77,9 @@ func (n *NetlinkManager) CreateL2(info Layer2Information) error {
 	}
 
 	neighSuppression := os.Getenv("NWOP_NEIGH_SUPPRESSION") == "true"
+	if len(info.AnycastGateways) == 0 {
+		neighSuppression = false
+	}
 	if info.NeighSuppression != nil {
 		neighSuppression = *info.NeighSuppression
 	}
@@ -284,6 +287,9 @@ func (n *NetlinkManager) ReconcileL2(current Layer2Information, desired Layer2In
 		return err
 	}
 	neighSuppression := os.Getenv("NWOP_NEIGH_SUPPRESSION") == "true"
+	if len(desired.AnycastGateways) == 0 {
+		neighSuppression = false
+	}
 	if desired.NeighSuppression != nil {
 		neighSuppression = *desired.NeighSuppression
 	}

--- a/pkg/nl/layer2.go
+++ b/pkg/nl/layer2.go
@@ -19,6 +19,7 @@ type Layer2Information struct {
 	AnycastMAC         *net.HardwareAddr
 	AnycastGateways    []*netlink.Addr
 	AdvertiseNeighbors bool
+	NeighSuppression   *bool
 
 	CreateMACVLANInterface bool
 
@@ -75,12 +76,17 @@ func (n *NetlinkManager) CreateL2(info Layer2Information) error {
 		}
 	}
 
+	neighSuppression := os.Getenv("NWOP_NEIGH_SUPPRESSION") == "true"
+	if info.NeighSuppression != nil {
+		neighSuppression = *info.NeighSuppression
+	}
 	vxlan, err := n.createVXLAN(
 		fmt.Sprintf("%s%d", VXLAN_PREFIX, info.VNI),
 		bridge.Attrs().Index,
 		info.VNI,
 		info.MTU,
 		false,
+		neighSuppression,
 	)
 	if err != nil {
 		return err
@@ -277,7 +283,11 @@ func (n *NetlinkManager) ReconcileL2(current Layer2Information, desired Layer2In
 	if err := n.configureBridge(fmt.Sprintf("%s%d", LAYER2_PREFIX, current.VlanID)); err != nil {
 		return err
 	}
-	if err := setNeighSuppression(current.vxlan, os.Getenv("NWOP_NEIGH_SUPPRESSION") == "true"); err != nil {
+	neighSuppression := os.Getenv("NWOP_NEIGH_SUPPRESSION") == "true"
+	if desired.NeighSuppression != nil {
+		neighSuppression = *desired.NeighSuppression
+	}
+	if err := setNeighSuppression(current.vxlan, neighSuppression); err != nil {
 		return err
 	}
 

--- a/pkg/nl/layer3.go
+++ b/pkg/nl/layer3.go
@@ -48,7 +48,7 @@ func (n *NetlinkManager) CreateL3(info VRFInformation) error {
 		return err
 	}
 
-	vxlan, err := n.createVXLAN(VXLAN_PREFIX+info.Name, bridge.Attrs().Index, info.VNI, DEFAULT_MTU, true)
+	vxlan, err := n.createVXLAN(VXLAN_PREFIX+info.Name, bridge.Attrs().Index, info.VNI, DEFAULT_MTU, true, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/reconciler/layer2.go
+++ b/pkg/reconciler/layer2.go
@@ -76,6 +76,7 @@ func (r *reconcile) reconcileLayer2(l2vnis []networkv1alpha1.Layer2NetworkConfig
 			AnycastMAC:             anycastMAC,
 			AnycastGateways:        anycastGateways,
 			AdvertiseNeighbors:     spec.AdvertiseNeighbors,
+			NeighSuppression:       spec.NeighSuppression,
 			CreateMACVLANInterface: spec.CreateMACVLANInterface,
 		})
 	}


### PR DESCRIPTION
Closes #33 

Also disable neighbor suppression by default for non-anycast gateway layer2 networks.