### PR TITLE
FRR Manager hotfix

### DIFF
--- a/pkg/frr/manager.go
+++ b/pkg/frr/manager.go
@@ -92,7 +92,7 @@ func (*Manager) ReloadFRR() error {
 
 	_, err = con.ReloadUnitContext(context.Background(), frrUnit, "fail", nil)
 	if err != nil {
-		return fmt.Errorf("error realoading %s context: %w", frrUnit, err)
+		return fmt.Errorf("error reloading %s context: %w", frrUnit, err)
 	}
 	return nil
 }

--- a/pkg/frr/manager.go
+++ b/pkg/frr/manager.go
@@ -91,7 +91,10 @@ func (*Manager) ReloadFRR() error {
 	defer con.Close()
 
 	_, err = con.ReloadUnitContext(context.Background(), frrUnit, "fail", nil)
-	return fmt.Errorf("error realoading %s context: %w", frrUnit, err)
+	if err != nil {
+		return fmt.Errorf("error realoading %s context: %w", frrUnit, err)
+	}
+	return nil
 }
 
 func (v *VRFConfiguration) ShouldTemplateVRF() bool {


### PR DESCRIPTION
PR #37 have introduced a bug in FRR Manager's `ReloadFRR()` method. With current implementation this method will always return error even if FRR daemon reloading will succeed.