### PR TITLE
Fix partly created L3VNIs & Reload before Reconcile

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,14 @@ type VRFConfig struct {
 func LoadConfig() (*Config, error) {
 	config := &Config{}
 
+	if err := config.ReloadConfig(); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+func (c *Config) ReloadConfig() error {
 	vniFile := vniMapFile
 	if val := os.Getenv("OPERATOR_CONFIG"); val != "" {
 		vniFile = val
@@ -35,14 +43,13 @@ func LoadConfig() (*Config, error) {
 
 	read, err := os.ReadFile(vniFile)
 	if err != nil {
-		return nil, fmt.Errorf("error reading config file: %w", err)
+		return fmt.Errorf("error reading config file: %w", err)
 	}
-	err = yaml.Unmarshal(read, &config)
+	err = yaml.Unmarshal(read, c)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling config file: %w", err)
+		return fmt.Errorf("error unmarshalling config file: %w", err)
 	}
-
-	return config, nil
+	return nil
 }
 
 func (c *Config) ShouldSkipVRFConfig(vrf string) bool {

--- a/pkg/frr/configure.go
+++ b/pkg/frr/configure.go
@@ -24,7 +24,6 @@ type templateConfig struct {
 
 	Hostname         string
 	UnderlayRouterID string
-	HostRouterID     string
 }
 
 func (m *Manager) Configure(in Configuration) (bool, error) {
@@ -59,10 +58,7 @@ func renderSubtemplates(in Configuration) (*templateConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting underlay IP: %w", err)
 	}
-	hostRouterID, err := (&nl.NetlinkManager{}).GetHostRouterID()
-	if err != nil {
-		return nil, fmt.Errorf("error getting host router ID: %w", err)
-	}
+
 	hostname := os.Getenv(healthcheck.NodenameEnv)
 	if hostname == "" {
 		return nil, fmt.Errorf("error getting node's name")
@@ -115,7 +111,6 @@ func renderSubtemplates(in Configuration) (*templateConfig, error) {
 		PrefixLists:      string(prefixlists),
 		RouteMaps:        string(routemaps),
 		UnderlayRouterID: vrfRouterID.String(),
-		HostRouterID:     hostRouterID.String(),
 		Hostname:         hostname,
 	}, nil
 }

--- a/pkg/nl/layer2.go
+++ b/pkg/nl/layer2.go
@@ -84,7 +84,7 @@ func (n *NetlinkManager) CreateL2(info *Layer2Information) error {
 		if err != nil {
 			return err
 		}
-		masterIdx = l3Info.vrfId
+		masterIdx = l3Info.vrfID
 	}
 
 	if len(info.AnycastGateways) > 0 && info.AnycastMAC == nil {
@@ -352,7 +352,7 @@ func (n *NetlinkManager) isL2VNIreattachRequired(current, desired *Layer2Informa
 			if err != nil {
 				return shouldReattachL2VNI, fmt.Errorf("error while getting L3 by name: %w", err)
 			}
-			if err := netlink.LinkSetMasterByIndex(current.bridge, l3Info.vrfId); err != nil {
+			if err := netlink.LinkSetMasterByIndex(current.bridge, l3Info.vrfID); err != nil {
 				return shouldReattachL2VNI, fmt.Errorf("error while setting master by index: %w", err)
 			}
 		} else {

--- a/pkg/nl/layer2.go
+++ b/pkg/nl/layer2.go
@@ -84,7 +84,7 @@ func (n *NetlinkManager) CreateL2(info *Layer2Information) error {
 		if err != nil {
 			return err
 		}
-		masterIdx = l3Info.vrfID
+		masterIdx = l3Info.vrfId
 	}
 
 	if len(info.AnycastGateways) > 0 && info.AnycastMAC == nil {
@@ -352,7 +352,7 @@ func (n *NetlinkManager) isL2VNIreattachRequired(current, desired *Layer2Informa
 			if err != nil {
 				return shouldReattachL2VNI, fmt.Errorf("error while getting L3 by name: %w", err)
 			}
-			if err := netlink.LinkSetMasterByIndex(current.bridge, l3Info.vrfID); err != nil {
+			if err := netlink.LinkSetMasterByIndex(current.bridge, l3Info.vrfId); err != nil {
 				return shouldReattachL2VNI, fmt.Errorf("error while setting master by index: %w", err)
 			}
 		} else {

--- a/pkg/nl/layer3.go
+++ b/pkg/nl/layer3.go
@@ -16,8 +16,8 @@ type VRFInformation struct {
 	VNI  int
 
 	table    int
-	bridgeId int
-	vrfId    int
+	bridgeID int
+	vrfID    int
 
 	MarkForDelete bool
 }

--- a/pkg/nl/layer3.go
+++ b/pkg/nl/layer3.go
@@ -16,8 +16,10 @@ type VRFInformation struct {
 	VNI  int
 
 	table    int
-	bridgeID int
-	vrfID    int
+	bridgeId int
+	vrfId    int
+
+	MarkForDelete bool
 }
 
 // Create will create a VRF and all interfaces necessary to operate the EVPN and leaking.

--- a/pkg/nl/list.go
+++ b/pkg/nl/list.go
@@ -44,7 +44,7 @@ func (*NetlinkManager) ListVRFInterfaces() ([]VRFInformation, error) {
 		info := VRFInformation{}
 		info.table = int(vrf.Table)
 		info.Name = link.Attrs().Name
-		info.vrfID = vrf.Attrs().Index
+		info.vrfId = vrf.Attrs().Index
 		infos = append(infos, info)
 	}
 
@@ -68,7 +68,7 @@ func (n *NetlinkManager) ListL3() ([]VRFInformation, error) {
 		info := VRFInformation{}
 		info.table = int(vrf.Table)
 		info.Name = link.Attrs().Name[3:]
-		info.vrfID = vrf.Attrs().Index
+		info.vrfId = vrf.Attrs().Index
 
 		err := n.updateL3Indices(&info)
 		if err != nil {

--- a/pkg/nl/list.go
+++ b/pkg/nl/list.go
@@ -83,18 +83,17 @@ func (n *NetlinkManager) ListL3() ([]VRFInformation, error) {
 
 func (*NetlinkManager) updateL3Indices(info *VRFInformation) error {
 	bridgeLink, err := netlink.LinkByName(bridgePrefix + info.Name)
-	if err != nil {
-		return fmt.Errorf("error getting link by name: %w", err)
+	if err == nil {
+		info.bridgeId = bridgeLink.Attrs().Index
+	} else {
+		info.MarkForDelete = true
 	}
 	vxlanLink, err := netlink.LinkByName(vxlanPrefix + info.Name)
-	if err != nil {
-		return fmt.Errorf("error getting link by name: %w", err)
+	if err == nil {
+		info.VNI = vxlanLink.(*netlink.Vxlan).VxlanId
+	} else {
+		info.MarkForDelete = true
 	}
-	netlinkBridge := bridgeLink.(*netlink.Bridge)
-	netlinkVXLAN := vxlanLink.(*netlink.Vxlan)
-
-	info.bridgeID = netlinkBridge.Attrs().Index
-	info.VNI = netlinkVXLAN.VxlanId
 	return nil
 }
 

--- a/pkg/nl/list.go
+++ b/pkg/nl/list.go
@@ -44,7 +44,7 @@ func (*NetlinkManager) ListVRFInterfaces() ([]VRFInformation, error) {
 		info := VRFInformation{}
 		info.table = int(vrf.Table)
 		info.Name = link.Attrs().Name
-		info.vrfId = vrf.Attrs().Index
+		info.vrfID = vrf.Attrs().Index
 		infos = append(infos, info)
 	}
 
@@ -68,12 +68,9 @@ func (n *NetlinkManager) ListL3() ([]VRFInformation, error) {
 		info := VRFInformation{}
 		info.table = int(vrf.Table)
 		info.Name = link.Attrs().Name[3:]
-		info.vrfId = vrf.Attrs().Index
+		info.vrfID = vrf.Attrs().Index
 
-		err := n.updateL3Indices(&info)
-		if err != nil {
-			return nil, err
-		}
+		n.updateL3Indices(&info)
 
 		infos = append(infos, info)
 	}
@@ -81,10 +78,10 @@ func (n *NetlinkManager) ListL3() ([]VRFInformation, error) {
 	return infos, nil
 }
 
-func (*NetlinkManager) updateL3Indices(info *VRFInformation) error {
+func (*NetlinkManager) updateL3Indices(info *VRFInformation) {
 	bridgeLink, err := netlink.LinkByName(bridgePrefix + info.Name)
 	if err == nil {
-		info.bridgeId = bridgeLink.Attrs().Index
+		info.bridgeID = bridgeLink.Attrs().Index
 	} else {
 		info.MarkForDelete = true
 	}
@@ -94,7 +91,6 @@ func (*NetlinkManager) updateL3Indices(info *VRFInformation) error {
 	} else {
 		info.MarkForDelete = true
 	}
-	return nil
 }
 
 func (*NetlinkManager) updateL2Indices(info *Layer2Information, links []netlink.Link) error {

--- a/pkg/nl/manager.go
+++ b/pkg/nl/manager.go
@@ -18,7 +18,6 @@ const (
 	vethL2Prefix       = "l2v."
 
 	underlayLoopback = "dum.underlay"
-	nodeLoopback     = "br.cluster"
 
 	vxlanPort  = 4789
 	defaultMtu = 9000
@@ -31,10 +30,5 @@ type NetlinkManager struct {
 
 func (*NetlinkManager) GetUnderlayIP() (net.IP, error) {
 	_, ip, err := getInterfaceAndIP(underlayLoopback)
-	return ip, err
-}
-
-func (*NetlinkManager) GetHostRouterID() (net.IP, error) {
-	_, ip, err := getInterfaceAndIP(nodeLoopback)
 	return ip, err
 }

--- a/pkg/reconciler/layer3.go
+++ b/pkg/reconciler/layer3.go
@@ -173,7 +173,7 @@ func (r *reconcile) reconcileL3Netlink(vrfConfigs []frr.VRFConfiguration) ([]nl.
 				break
 			}
 		}
-		if !stillExists {
+		if !stillExists || cfg.MarkForDelete {
 			toDelete = append(toDelete, cfg)
 		}
 	}
@@ -210,7 +210,7 @@ func prepareVRFsToCreate(vrfConfigs []frr.VRFConfiguration, existing []nl.VRFInf
 		}
 		alreadyExists := false
 		for _, cfg := range existing {
-			if vrfConfigs[i].Name == cfg.Name && vrfConfigs[i].VNI == cfg.VNI {
+			if vrfConfigs[i].Name == cfg.Name && vrfConfigs[i].VNI == cfg.VNI && !cfg.MarkForDelete {
 				alreadyExists = true
 				break
 			}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -86,6 +86,9 @@ func (reconciler *Reconciler) reconcileDebounced(ctx context.Context) error {
 		Logger:     log.FromContext(ctx),
 	}
 
+	r.Logger.Info("Reloading config")
+	r.config.ReloadConfig()
+
 	l3vnis, err := r.fetchLayer3(ctx)
 	if err != nil {
 		return err

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -88,7 +88,7 @@ func (reconciler *Reconciler) reconcileDebounced(ctx context.Context) error {
 
 	r.Logger.Info("Reloading config")
 	if err := r.config.ReloadConfig(); err != nil {
-		return err
+		return fmt.Errorf("error reloading network-operator config: %w", err)
 	}
 
 	l3vnis, err := r.fetchLayer3(ctx)

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -87,7 +87,9 @@ func (reconciler *Reconciler) reconcileDebounced(ctx context.Context) error {
 	}
 
 	r.Logger.Info("Reloading config")
-	r.config.ReloadConfig()
+	if err := r.config.ReloadConfig(); err != nil {
+		return err
+	}
 
 	l3vnis, err := r.fetchLayer3(ctx)
 	if err != nil {


### PR DESCRIPTION
This MR fixes L3VNIs when they are created partly in netlink for whatever reason. This will first delete the interfaces and then try to re-create them.

Also including a config reload before Reconcile.