### PR TITLE
Fix Community Type to be string

### DIFF
--- a/api/v1alpha1/vrfrouteconfiguration_types.go
+++ b/api/v1alpha1/vrfrouteconfiguration_types.go
@@ -72,7 +72,7 @@ type VRFRouteConfigurationSpec struct {
 	Seq int `json:"seq"`
 
 	// Community for export, if omitted no community will be set
-	Community *int `json:"community,omitempty"`
+	Community *string `json:"community,omitempty"`
 }
 
 // VRFRouteConfigurationStatus defines the observed state of VRFRouteConfiguration.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -213,7 +213,7 @@ func (in *VRFRouteConfigurationSpec) DeepCopyInto(out *VRFRouteConfigurationSpec
 	}
 	if in.Community != nil {
 		in, out := &in.Community, &out.Community
-		*out = new(int)
+		*out = new(string)
 		**out = **in
 	}
 }

--- a/config/crd/bases/network.schiff.telekom.de_vrfrouteconfigurations.yaml
+++ b/config/crd/bases/network.schiff.telekom.de_vrfrouteconfigurations.yaml
@@ -45,7 +45,7 @@ spec:
               community:
                 description: Community for export, if omitted no community will be
                   set
-                type: integer
+                type: string
               export:
                 description: Routes exported from the cluster VRF into the specified
                   VRF

--- a/pkg/frr/manager.go
+++ b/pkg/frr/manager.go
@@ -30,7 +30,7 @@ type Manager struct {
 type PrefixList struct {
 	Items     []PrefixedRouteItem
 	Seq       int
-	Community *int
+	Community *string
 }
 
 type PrefixedRouteItem struct {


### PR DESCRIPTION
For some reason community was created as int. As this was not usable (and is not used) we can easily change the type here without bumping CRD version.