### PR TITLE
Wait for FRR reload to complete, restart if failed

### DIFF
--- a/pkg/reconciler/layer3.go
+++ b/pkg/reconciler/layer3.go
@@ -70,6 +70,7 @@ func (r *reconcile) reconcileLayer3(l3vnis []networkv1alpha1.VRFRouteConfigurati
 			return fmt.Errorf("error reloading FRR systemd unit: %w", err)
 		}
 		r.dirtyFRRConfig = false
+		r.Logger.Info("reloaded FRR config")
 	}
 
 	// Make sure that all created netlink VRFs are up after FRR reload

--- a/pkg/reconciler/layer3.go
+++ b/pkg/reconciler/layer3.go
@@ -65,9 +65,14 @@ func (r *reconcile) reconcileLayer3(l3vnis []networkv1alpha1.VRFRouteConfigurati
 		r.Logger.Info("trying to reload FRR config because it changed")
 		err = r.frrManager.ReloadFRR()
 		if err != nil {
-			r.dirtyFRRConfig = true
-			r.Logger.Error(err, "error reloading FRR systemd unit")
-			return fmt.Errorf("error reloading FRR systemd unit: %w", err)
+			r.Logger.Error(err, "error reloading FRR systemd unit, trying restart")
+
+			err = r.frrManager.RestartFRR()
+			if err != nil {
+				r.dirtyFRRConfig = true
+				r.Logger.Error(err, "error restarting FRR systemd unit")
+				return fmt.Errorf("error reloading / restarting FRR systemd unit: %w", err)
+			}
 		}
 		r.dirtyFRRConfig = false
 		r.Logger.Info("reloaded FRR config")


### PR DESCRIPTION
We now wait for the FRR reload to complete (waiting for a message on the channel), if the reloadStatus (aka job status) is not `done` we trigger an FRR restart.