### PR TITLE
Template aggregates into MGMT VRF (aka skip template VRFs)

### DIFF
--- a/pkg/frr/tpl/bgp-neighbor-v4.tpl
+++ b/pkg/frr/tpl/bgp-neighbor-v4.tpl
@@ -5,5 +5,9 @@
   neighbor dv.{{$vrf.Name}} soft-reconfiguration inbound
   neighbor dv.{{$vrf.Name}} route-map rm_{{$vrf.Name}}_import in
   neighbor dv.{{$vrf.Name}} route-map rm_{{$vrf.Name}}_export out
+{{- else }}
+{{range $item := $vrf.AggregateIPv4}}
+  aggregate-address {{$item}}
+{{- end }}
 {{end}}
 {{- end -}}

--- a/pkg/frr/tpl/bgp-neighbor-v4.tpl
+++ b/pkg/frr/tpl/bgp-neighbor-v4.tpl
@@ -9,5 +9,5 @@
 {{range $item := $vrf.AggregateIPv4}}
   aggregate-address {{$item}}
 {{- end }}
-{{end}}
+{{- end }}
 {{- end -}}

--- a/pkg/frr/tpl/bgp-neighbor-v6.tpl
+++ b/pkg/frr/tpl/bgp-neighbor-v6.tpl
@@ -5,5 +5,8 @@
   neighbor dv.{{$vrf.Name}} soft-reconfiguration inbound
   neighbor dv.{{$vrf.Name}} route-map rm6_{{$vrf.Name}}_import in
   neighbor dv.{{$vrf.Name}} route-map rm6_{{$vrf.Name}}_export out
-{{end}}
+{{- else }}
+{{range $item := $vrf.AggregateIPv6}}
+  aggregate-address {{$item}}
+{{- end }}
 {{- end -}}

--- a/pkg/frr/tpl/bgp-neighbor-v6.tpl
+++ b/pkg/frr/tpl/bgp-neighbor-v6.tpl
@@ -9,4 +9,5 @@
 {{range $item := $vrf.AggregateIPv6}}
   aggregate-address {{$item}}
 {{- end }}
+{{- end }}
 {{- end -}}


### PR DESCRIPTION
In case of the management VRF we currently do not support specifying aggregates. This MR will allow addition of Aggregate addresses from VRFs that are configured to be skipped.
