### PR TITLE
Use BPF_FIB_LOOKUP_DIRECT for bpf router

### DIFF
--- a/bpf/router.c
+++ b/bpf/router.c
@@ -189,7 +189,7 @@ static __always_inline int tc_redir(struct __sk_buff *skb)
 
 	fib_params.ifindex = bpf_get_interface(skb->ingress_ifindex);
 
-	ret = bpf_fib_lookup(skb, &fib_params, sizeof(fib_params), 0);
+	ret = bpf_fib_lookup(skb, &fib_params, sizeof(fib_params), BPF_FIB_LOOKUP_DIRECT);
 	ebpf_record_fib_lkup(skb, ret);
 	if (ret == BPF_FIB_LKUP_RET_NOT_FWDED || ret < 0)
 		return ebpf_record_ret_stats(skb, EBPF_NOT_FWD, TC_ACT_OK);

--- a/pkg/nl/create.go
+++ b/pkg/nl/create.go
@@ -49,7 +49,7 @@ func (n *NetlinkManager) createBridge(bridgeName string, macAddress *net.Hardwar
 	if macAddress != nil {
 		netlinkBridge.LinkAttrs.HardwareAddr = *macAddress
 	} else if underlayRMAC {
-		_, vxlanIP, err := getInterfaceAndIP(underlayLoopback)
+		_, vxlanIP, err := getUnderlayInterfaceAndIP()
 		if err != nil {
 			return nil, err
 		}
@@ -72,7 +72,7 @@ func (n *NetlinkManager) createBridge(bridgeName string, macAddress *net.Hardwar
 }
 
 func (n *NetlinkManager) createVXLAN(vxlanName string, bridgeIdx, vni, mtu int, hairpin, neighSuppression bool) (*netlink.Vxlan, error) {
-	vxlanIf, vxlanIP, err := getInterfaceAndIP(underlayLoopback)
+	vxlanIf, vxlanIP, err := getUnderlayInterfaceAndIP()
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func (*NetlinkManager) setUp(intfName string) error {
 }
 
 func generateUnderlayMAC() (net.HardwareAddr, error) {
-	_, vxlanIP, err := getInterfaceAndIP(underlayLoopback)
+	_, vxlanIP, err := getUnderlayInterfaceAndIP()
 	if err != nil {
 		return nil, err
 	}
@@ -178,8 +178,8 @@ func generateUnderlayMAC() (net.HardwareAddr, error) {
 	return generatedMac, nil
 }
 
-func getInterfaceAndIP(name string) (int, net.IP, error) {
-	dummy := netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name}}
+func getUnderlayInterfaceAndIP() (int, net.IP, error) {
+	dummy := netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: underlayLoopback}}
 
 	addresses, err := netlink.AddrList(&dummy, netlink.FAMILY_V4)
 	if err != nil {

--- a/pkg/nl/layer2.go
+++ b/pkg/nl/layer2.go
@@ -100,7 +100,7 @@ func (n *NetlinkManager) CreateL2(info *Layer2Information) error {
 }
 
 func (n *NetlinkManager) setupBridge(info *Layer2Information, masterIdx int) (*netlink.Bridge, error) {
-	bridge, err := n.createBridge(fmt.Sprintf("%s%d", layer2Prefix, info.VlanID), info.AnycastMAC, masterIdx, info.MTU)
+	bridge, err := n.createBridge(fmt.Sprintf("%s%d", layer2Prefix, info.VlanID), info.AnycastMAC, masterIdx, info.MTU, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/nl/layer3.go
+++ b/pkg/nl/layer3.go
@@ -39,7 +39,7 @@ func (n *NetlinkManager) CreateL3(info VRFInformation) error {
 		return err
 	}
 
-	bridge, err := n.createBridge(bridgePrefix+info.Name, nil, vrf.Attrs().Index, defaultMtu)
+	bridge, err := n.createBridge(bridgePrefix+info.Name, nil, vrf.Attrs().Index, defaultMtu, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/nl/manager.go
+++ b/pkg/nl/manager.go
@@ -29,6 +29,6 @@ type NetlinkManager struct {
 }
 
 func (*NetlinkManager) GetUnderlayIP() (net.IP, error) {
-	_, ip, err := getInterfaceAndIP(underlayLoopback)
+	_, ip, err := getUnderlayInterfaceAndIP()
 	return ip, err
 }


### PR DESCRIPTION
BPF_FIB_LOOKUP_DIRECT bypasses all `ip rule` statements and looks directly at the routing table of the interface (if interface is part of a VRF the VRF routing table is used). For some reason not using LOOKUP_DIRECT on 22.04 with hwe Kernel causes Linux to look into the default routing table, causing packet loops and forwarding errors. We can safely switch to LOOKUP_DIRECT because we don't care about routing rules and just want a lookup in the associated VRF.

based on https://github.com/telekom/das-schiff-network-operator/pull/75, should be merged first