### PR TITLE
FRR introduced a local host-route protocol which is installed by kernel

### DIFF
--- a/pkg/nl/route.go
+++ b/pkg/nl/route.go
@@ -97,6 +97,8 @@ func GetProtocolNumber(protocol string, frr bool) int {
 		return unix.RTPROT_ZEBRA
 	// this is a hack as there is no direct representation in Linux for
 	// directly connected routes but normally they are installed by kernel
+	case "local":
+		return unix.RTPROT_KERNEL
 	case "connected":
 		return unix.RTPROT_KERNEL
 	//


### PR DESCRIPTION
https://github.com/FRRouting/frr/blob/master/lib/route_types.txt


Linux represents them as 
```
local 172.22.172.128 dev veth4d8a11d648c table local proto kernel scope host src 172.22.172.128
```

FRR says they look like this

```
show ip route vrf default local
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

L * 172.22.172.128/32 is directly connected, dum.cluster, 00:08:39
```