### PR TITLE
Added version info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,9 @@ COPY pkg/ pkg/
 COPY bpf/ bpf/
 RUN cd pkg/bpf/ && go generate
 
+ARG ldflags
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "${ldflags}" -a -o manager main.go
 
 FROM alpine:latest
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+LDFLAGS := $(shell hack/version.sh)
+
 .PHONY: all
 all: build
 
@@ -39,7 +41,7 @@ all: build
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-##@ Development
+##@ DevelopmentLDFLAGS := $(shell hack/version.sh)
 
 .PHONY: bpf-generate
 bpf-generate: ## Run go generate for the BPF program (builds it as well)
@@ -69,23 +71,23 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/manager/main.go
+	go build -ldflags "$(LDFLAGS)" -o bin/manager cmd/manager/main.go
 
 .PHONY: sidecar-build
 sidecar-build: build
-	go build -o bin/frr-exporter cmd/frr-exporter/main.go
+	go build -ldflags "$(LDFLAGS)" -o bin/frr-exporter cmd/frr-exporter/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/manager/main.go
+	go run -ldflags "$(LDFLAGS)" ./cmd/manager/main.go
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+docker-build: #test ## Build docker image with the manager.
+	docker build --build-arg ldflags="$(LDFLAGS)" -t ${IMG} .
 
 .PHONY: docker-build-sidecar
 docker-build-sidecar: test ## Build docker image with the manager.
-	docker build -t ${SIDECAR_IMG} -f frr-exporter.Dockerfile .
+	docker build --build-arg ldflags="$(LDFLAGS)" -t ${SIDECAR_IMG} -f frr-exporter.Dockerfile .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/cmd/frr-exporter/main.go
+++ b/cmd/frr-exporter/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -12,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/telekom/das-schiff-network-operator/pkg/frr"
 	"github.com/telekom/das-schiff-network-operator/pkg/monitoring"
+	"github.com/telekom/das-schiff-network-operator/pkg/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -26,6 +28,7 @@ var (
 )
 
 func main() {
+	version.Get().Print(os.Args[0])
 	var addr string
 	flag.StringVar(&addr, "listen-address", ":7082", "The address to listen on for HTTP requests.")
 	opts := zap.Options{

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/telekom/das-schiff-network-operator/pkg/nl"
 	"github.com/telekom/das-schiff-network-operator/pkg/notrack"
 	"github.com/telekom/das-schiff-network-operator/pkg/reconciler"
+	"github.com/telekom/das-schiff-network-operator/pkg/version"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.) //nolint:gci
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -89,6 +90,8 @@ func initCollectors() error {
 }
 
 func main() {
+	version.Get().Print(os.Args[0])
+
 	var onlyBPFMode bool
 	var configFile string
 	var interfacePrefix string

--- a/frr-exporter.Dockerfile
+++ b/frr-exporter.Dockerfile
@@ -22,9 +22,10 @@ COPY pkg/ pkg/
 COPY bpf/ bpf/
 RUN cd pkg/bpf/ && go generate
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o frr-exporter main.go
+ARG ldflags
 
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "${ldflags}" -a -o frr-exporter main.go
 
 FROM ${REGISTRY}/frrouting/frr:${FRR_VERSION}
 

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# borrowed from https://github.com/kubernetes-sigs/cluster-api/hack/vershion.sh with minor changes
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
+version::get_version_vars() {
+    # shellcheck disable=SC1083
+    GIT_COMMIT="$(git rev-parse HEAD^{commit})"
+
+    if git_status=$(git status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+        GIT_TREE_STATE="clean"
+    else
+        GIT_TREE_STATE="dirty"
+    fi
+
+    # stolen from k8s.io/hack/lib/version.sh
+    # Use git describe to find the version based on annotated tags.
+    if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --tags --abbrev=14 --match "v[0-9]*" 2>/dev/null); then
+        if [[ "${GIT_TREE_STATE}" == "dirty" ]]; then
+            # git describe --dirty only considers changes to existing files, but
+            # that is problematic since new untracked .go files affect the build,
+            # so use our idea of "dirty" from git status instead.
+            GIT_VERSION+="-dirty"
+        fi
+
+
+        # Try to match the "git describe" output to a regex to try to extract
+        # the "major" and "minor" versions and whether this is the exact tagged
+        # version or whether the tree is between two tagged versions.
+        if [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?([+].*)?$ ]]; then
+            GIT_MAJOR=${BASH_REMATCH[1]}
+            GIT_MINOR=${BASH_REMATCH[2]}
+        fi
+
+        # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
+        if ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "GIT_VERSION should be a valid Semantic Version. Current value: ${GIT_VERSION}"
+            echo "Please see more details here: https://semver.org"
+            exit 1
+        fi
+    fi
+
+    GIT_RELEASE_TAG=$(git describe --abbrev=0 --tags)
+    GIT_RELEASE_COMMIT=$(git rev-list -n 1  "${GIT_RELEASE_TAG}")
+}
+
+# stolen from k8s.io/hack/lib/version.sh and modified
+# Prints the value that needs to be passed to the -ldflags parameter of go build
+version::ldflags() {
+    version::get_version_vars
+
+    local -a ldflags
+    function add_ldflag() {
+        local key=${1}
+        local val=${2}
+        ldflags+=(
+            "-X 'github.com/telekom/das-schiff-network-operator/pkg/version.${key}=${val}'"
+        )
+    }
+
+    add_ldflag "gitCommit" "${GIT_COMMIT}"
+    add_ldflag "gitVersion" "${GIT_VERSION}"
+
+    # The -ldflags parameter takes a single string, so join the output.
+    echo "${ldflags[*]-}"
+}
+
+version::ldflags

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,31 @@
+// based on https://github.com/kubernetes-sigs/cluster-api/version/version.go
+
+// Package version implements version handling code.
+package version
+
+import (
+	"fmt"
+)
+
+var (
+	gitVersion string // semantic version, derived by build scripts
+	gitCommit  string // sha1 from git, output of $(git rev-parse HEAD)
+)
+
+// Info exposes information about the version used for the current running code.
+type Info struct {
+	GitVersion string `json:"gitVersion,omitempty"`
+	GitCommit  string `json:"gitCommit,omitempty"`
+}
+
+// Get returns an Info object with all the information about the current running code.
+func Get() *Info {
+	return &Info{
+		GitVersion: gitVersion,
+		GitCommit:  gitCommit,
+	}
+}
+
+func (i *Info) Print(name string) {
+	fmt.Printf("%s info - version: %s, commit: %s\n", name, i.GitVersion, i.GitCommit)
+}


### PR DESCRIPTION
This PR introduces minimal implementation for version printing - #134.

The version info is printed as follows:

```bash
$ ./bin/manager 
./bin/manager info - version: v0.2.10-1-g6f6b1166eeff14, commit: 6f6b1166eeff1404a3932e5153c03f3f67704d10
2024-10-07T11:34:00+02:00       INFO   ...
```