### PR TITLE
FRR transition bugfix

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -28,8 +28,6 @@ type Reconciler struct {
 	healthChecker  *healthcheck.HealthChecker
 
 	debouncer *debounce.Debouncer
-
-	dirtyFRRConfig bool
 }
 
 type reconcile struct {


### PR DESCRIPTION
This PR should fix #143 

I've changed order of FRR configuration. Now the FRR config is created and FRR is reloaded, and then the interfaces are created. This should stop VNI L2 to L3 transition messages in FRR/Zebra.

Additionally, I've added setting already existing interfaces up. This should fix the bug where interfaces were not up after first reconciliation and they don't become up in next reconciliation as only newly created interfaces were processed previously.