### PR TITLE
Set accept_untracked_na to 2 for IPv6 NA in EVPN

### DIFF
--- a/pkg/nl/layer2.go
+++ b/pkg/nl/layer2.go
@@ -456,6 +456,15 @@ func (*Manager) configureBridge(intfName string) error {
 		return fmt.Errorf("error setting arp_accept = 1 for interface: %w", err)
 	}
 
+	// Ensure we can receive unsolicited and solicited but untracked NA
+	if _, err := os.Stat(fmt.Sprintf("%s/ipv6/conf/%s/accept_untracked_na", procSysNetPath, intfName)); err == nil {
+		if err := os.WriteFile(fmt.Sprintf("%s/ipv6/conf/%s/accept_untracked_na", procSysNetPath, intfName), []byte("2"), neighFilePermissions); err != nil {
+			return fmt.Errorf("error setting accept_untracked_na = 2 for interface: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("error checking if accept_untracked_na exists: %w", err)
+	}
+
 	baseTimer := os.Getenv("NWOP_NEIGH_BASE_REACHABLE_TIME")
 	if baseTimer == "" {
 		baseTimer = "30000"

--- a/pkg/nl/nl_test.go
+++ b/pkg/nl/nl_test.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	arpAccept           = "arp_accept"
+	acceptUntrackedNA   = "accept_untracked_na"
 	baseReachableTimeMs = "base_reachable_time"
 	addrGenMode         = "addr_gen_mode"
 )
@@ -1086,8 +1087,8 @@ var _ = Describe("ReconcileL2()", func() {
 		arpAcceptIPv4 := fmt.Sprintf("%s/ipv4/conf/%s", procSysNetPath, vlanName)
 		createInterfaceFile(arpAcceptIPv4 + "/" + arpAccept)
 
-		arpAcceptIPv6 := fmt.Sprintf("%s/ipv6/conf/%s", procSysNetPath, vlanName)
-		createInterfaceFile(arpAcceptIPv6 + "/" + arpAccept)
+		acceptUntrackedNAIPv6 := fmt.Sprintf("%s/ipv6/conf/%s", procSysNetPath, vlanName)
+		createInterfaceFile(acceptUntrackedNAIPv6 + "/" + acceptUntrackedNA)
 
 		err := nm.ReconcileL2(current, desired)
 		Expect(err).To(HaveOccurred())


### PR DESCRIPTION
This only works on newer Kernel versions e.g. with Ubuntu 24.04.

Older Kernel versions are out of luck.