### PR TITLE
FRR Config fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Also some special config should be in place:
     exit
     ```
     Due to internal parsing of FRR one route-map entry should already be there (default deny). Also mgmt_vrf needs to be part of the list `skipVRFConfig` in the configuration file.
-2. The default VRF `router-bgp` config must be marked as `router bgp <ASN> vrf default`. Otherwise a reload will delete it and replace it completely. This will break and crash FRR in the process.
 
 ## eBPF
 

--- a/pkg/frr/configure.go
+++ b/pkg/frr/configure.go
@@ -19,7 +19,7 @@ var (
 	rtPartsRe = regexp.MustCompile(`(?m)^(\s*route-target\s*(?:import|export)\s*)(.*)`)
 	rtRe      = regexp.MustCompile(`(?m)(\S+)`)
 
-	// Regular expression for searching for router bgp <asn> vrf default
+	// Regular expression for searching for router bgp <asn> vrf default.
 	defaultVrfRe = regexp.MustCompile(`(?m)^router bgp (\d+) vrf default`)
 )
 

--- a/pkg/frr/manager.go
+++ b/pkg/frr/manager.go
@@ -107,7 +107,7 @@ func (m *Manager) Init(mgmtVrf string) error {
 	}
 	m.ipv6MgmtRouteMapIn = routeMap
 
-	communityDrop, err := hasCommunityDrop(m.ConfigPath)
+	communityDrop, err := hasCommunityDrop(m.TemplatePath)
 	if err != nil {
 		return fmt.Errorf("error checking for community drop in FRR config: %w", err)
 	}

--- a/pkg/reconciler/layer3.go
+++ b/pkg/reconciler/layer3.go
@@ -39,7 +39,7 @@ func (r *reconcile) fetchTaas(ctx context.Context) ([]networkv1alpha1.RoutingTab
 	return tables.Items, nil
 }
 
-// nolint: contextcheck,funclen // context is not relevant
+// nolint: contextcheck,funlen // context is not relevant
 func (r *reconcile) reconcileLayer3(l3vnis []networkv1alpha1.VRFRouteConfiguration, taas []networkv1alpha1.RoutingTable) error {
 	vrfConfigMap, err := r.createVrfConfigMap(l3vnis)
 	if err != nil {

--- a/pkg/reconciler/layer3.go
+++ b/pkg/reconciler/layer3.go
@@ -39,8 +39,7 @@ func (r *reconcile) fetchTaas(ctx context.Context) ([]networkv1alpha1.RoutingTab
 	return tables.Items, nil
 }
 
-// nolint: contextcheck // context is not relevant
-// nolint: funclen // it does not make sense to split this function
+// nolint: contextcheck,funclen // context is not relevant
 func (r *reconcile) reconcileLayer3(l3vnis []networkv1alpha1.VRFRouteConfiguration, taas []networkv1alpha1.RoutingTable) error {
 	vrfConfigMap, err := r.createVrfConfigMap(l3vnis)
 	if err != nil {

--- a/pkg/reconciler/layer3.go
+++ b/pkg/reconciler/layer3.go
@@ -40,6 +40,7 @@ func (r *reconcile) fetchTaas(ctx context.Context) ([]networkv1alpha1.RoutingTab
 }
 
 // nolint: contextcheck // context is not relevant
+// nolint: funclen // it does not make sense to split this function
 func (r *reconcile) reconcileLayer3(l3vnis []networkv1alpha1.VRFRouteConfiguration, taas []networkv1alpha1.RoutingTable) error {
 	vrfConfigMap, err := r.createVrfConfigMap(l3vnis)
 	if err != nil {
@@ -66,6 +67,8 @@ func (r *reconcile) reconcileLayer3(l3vnis []networkv1alpha1.VRFRouteConfigurati
 		return allConfigs[i].VNI < allConfigs[j].VNI
 	})
 
+	time.Sleep(defaultSleep)
+
 	// Create FRR configuration and reload it
 	err = r.configureFRR(allConfigs)
 	if err != nil {
@@ -85,6 +88,8 @@ func (r *reconcile) reconcileLayer3(l3vnis []networkv1alpha1.VRFRouteConfigurati
 	if err != nil {
 		return err
 	}
+
+	time.Sleep(defaultSleep)
 
 	// When a BGP VRF is deleted there is a leftover running configuration after reload
 	// A second reload fixes this.


### PR DESCRIPTION
- In some cases the reload does not apply all config (not even visible in show running-config). FRR might receive the netlink message of a new VRF at the same time as the config from frr-reload.py, leading to a race condition.
- Fix CommunityDrop was set to late to config
- Remove all `vrf default` parts from `router bgp <asn>` statements because the FRR behaviour changed