### PR TITLE
Allow NWOP to disable bridge netfilter on the fly

### DIFF
--- a/pkg/nl/layer2.go
+++ b/pkg/nl/layer2.go
@@ -570,3 +570,33 @@ func (n *Manager) GetBridgeID(info *Layer2Information) (int, error) {
 	}
 	return link.Attrs().Index, nil
 }
+
+// ReconcileL2NodeConfig sets bridge netfilter according to NWOP_BRIDGE_NF environment variable.
+// NWOP_BRIDGE_NF can be "enable" or "disable". Any other value leaves the setting unchanged.
+func (*Manager) ReconcileL2NodeConfig() error {
+	switch os.Getenv("NWOP_BRIDGE_NF") {
+	case "disable":
+		// Disable bridge netfilter
+		if err := os.WriteFile(fmt.Sprintf("%s/bridge/bridge-nf-call-iptables", procSysNetPath), []byte("0"), neighFilePermissions); err != nil {
+			return fmt.Errorf("error setting bridge bridge-nf-call-iptables = 0: %w", err)
+		}
+		if err := os.WriteFile(fmt.Sprintf("%s/bridge/bridge-nf-call-ip6tables", procSysNetPath), []byte("0"), neighFilePermissions); err != nil {
+			return fmt.Errorf("error setting bridge bridge-nf-call-ip6tables = 0: %w", err)
+		}
+		if err := os.WriteFile(fmt.Sprintf("%s/bridge/bridge-nf-call-arptables", procSysNetPath), []byte("0"), neighFilePermissions); err != nil {
+			return fmt.Errorf("error setting bridge bridge-nf-call-arptables = 0: %w", err)
+		}
+	case "enable":
+		// Enable bridge netfilter
+		if err := os.WriteFile(fmt.Sprintf("%s/bridge/bridge-nf-call-iptables", procSysNetPath), []byte("1"), neighFilePermissions); err != nil {
+			return fmt.Errorf("error setting bridge nf_call_iptables = 1: %w", err)
+		}
+		if err := os.WriteFile(fmt.Sprintf("%s/bridge/bridge-nf-call-ip6tables", procSysNetPath), []byte("1"), neighFilePermissions); err != nil {
+			return fmt.Errorf("error setting bridge nf_call_ip6tables = 1: %w", err)
+		}
+		if err := os.WriteFile(fmt.Sprintf("%s/bridge/bridge-nf-call-arptables", procSysNetPath), []byte("1"), neighFilePermissions); err != nil {
+			return fmt.Errorf("error setting bridge nf_call_arptables = 1: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/reconciler/layer2.go
+++ b/pkg/reconciler/layer2.go
@@ -126,6 +126,10 @@ func (r *reconcile) reconcileLayer2(data *reconcileData) error {
 
 	r.anycastTracker.TrackedBridges = anycastTrackerInterfaces
 
+	if err := r.netlinkManager.ReconcileL2NodeConfig(); err != nil {
+		r.Logger.Error(err, "error reconciling L2 node config")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
In our deployment (with Calico or any other recent CNI) using br_netfilter is no longer required. If it is, it should be enabled per bridge (nf_call_iptables) through netlink.