### PR TITLE
Add flag to restrict GRO/GSO to MTU size

### DIFF
--- a/api/v1alpha1/layer2networkconfiguration_types.go
+++ b/api/v1alpha1/layer2networkconfiguration_types.go
@@ -58,6 +58,9 @@ type Layer2NetworkConfigurationSpec struct {
 	// Enable ARP / ND suppression
 	NeighSuppression *bool `json:"neighSuppression,omitempty"`
 
+	// Disable segmentation offload on the interface in tx and rx path
+	DisableSegmentation bool `json:"disableSegmentation,omitempty"`
+
 	// VRF to attach Layer2 network to, default if not set
 	VRF string `json:"vrf,omitempty"`
 

--- a/config/crd/bases/network.schiff.telekom.de_layer2networkconfigurations.yaml
+++ b/config/crd/bases/network.schiff.telekom.de_layer2networkconfigurations.yaml
@@ -73,6 +73,10 @@ spec:
               createMacVLANInterface:
                 description: Create MACVLAN attach interface
                 type: boolean
+              disableSegmentation:
+                description: Disable segmentation offload on the interface in tx and
+                  rx path
+                type: boolean
               id:
                 description: VLAN Id of the layer 2 network
                 type: integer

--- a/pkg/nl/nl_test.go
+++ b/pkg/nl/nl_test.go
@@ -540,6 +540,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return(nil, errors.New("error listing addresses"))
 
 		err := nm.ReconcileL2(current, desired)
@@ -561,6 +562,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.ParseIP("2001::"))}}, nil)
 
 		err := nm.ReconcileL2(current, desired)
@@ -582,6 +584,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(errors.New("unable to set link down"))
 
@@ -604,6 +607,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(errors.New("unable to change MAC address"))
@@ -627,6 +631,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -651,6 +656,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -678,6 +684,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -706,6 +713,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -738,6 +746,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -766,6 +775,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -795,6 +805,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -825,6 +836,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -856,6 +868,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -888,6 +901,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -921,6 +935,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -953,6 +968,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -989,6 +1005,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -1058,6 +1075,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -1120,6 +1138,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)

--- a/pkg/reconciler/layer2.go
+++ b/pkg/reconciler/layer2.go
@@ -178,14 +178,15 @@ func (r *reconcile) getDesired(l2vnis []networkv1alpha1.Layer2NetworkConfigurati
 		}
 
 		desired = append(desired, nl.Layer2Information{
-			VlanID:             spec.ID,
-			MTU:                spec.MTU,
-			VNI:                spec.VNI,
-			VRF:                spec.VRF,
-			AnycastMAC:         anycastMAC,
-			AnycastGateways:    anycastGateways,
-			AdvertiseNeighbors: spec.AdvertiseNeighbors,
-			NeighSuppression:   spec.NeighSuppression,
+			VlanID:              spec.ID,
+			MTU:                 spec.MTU,
+			VNI:                 spec.VNI,
+			VRF:                 spec.VRF,
+			AnycastMAC:          anycastMAC,
+			AnycastGateways:     anycastGateways,
+			AdvertiseNeighbors:  spec.AdvertiseNeighbors,
+			NeighSuppression:    spec.NeighSuppression,
+			DisableSegmentation: spec.DisableSegmentation,
 		})
 	}
 


### PR DESCRIPTION
When customers are using AF_PACKET based apps on top of the Layer2NetworkConfiguration, GRO-ed packets might exceed the configured buffer size.