### PR TITLE
Move Neighbor Sync BPF to TCX

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -157,6 +157,7 @@ func main() {
 		setupLog.Error(err, "unable to initialize components")
 		os.Exit(1)
 	}
+	defer bpf.CleanupTCX()
 
 	if interfacePrefix != "" {
 		setupLog.Info("start macvlan sync")
@@ -166,7 +167,8 @@ func main() {
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
+		bpf.CleanupTCX()
+		os.Exit(1) //nolint:gocritic // we call cleanupTCX before..
 	}
 }
 

--- a/pkg/bpf/nwopbpf_x86_bpfel.go
+++ b/pkg/bpf/nwopbpf_x86_bpfel.go
@@ -54,8 +54,8 @@ type nwopbpfSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type nwopbpfProgramSpecs struct {
-	HandleNeighborReplyXdp *ebpf.ProgramSpec `ebpf:"handle_neighbor_reply_xdp"`
-	TcRouterFunc           *ebpf.ProgramSpec `ebpf:"tc_router_func"`
+	HandleNeighborReplyTc *ebpf.ProgramSpec `ebpf:"handle_neighbor_reply_tc"`
+	TcRouterFunc          *ebpf.ProgramSpec `ebpf:"tc_router_func"`
 }
 
 // nwopbpfMapSpecs contains maps before they are loaded into the kernel.
@@ -119,13 +119,13 @@ type nwopbpfVariables struct {
 //
 // It can be passed to loadNwopbpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type nwopbpfPrograms struct {
-	HandleNeighborReplyXdp *ebpf.Program `ebpf:"handle_neighbor_reply_xdp"`
-	TcRouterFunc           *ebpf.Program `ebpf:"tc_router_func"`
+	HandleNeighborReplyTc *ebpf.Program `ebpf:"handle_neighbor_reply_tc"`
+	TcRouterFunc          *ebpf.Program `ebpf:"tc_router_func"`
 }
 
 func (p *nwopbpfPrograms) Close() error {
 	return _NwopbpfClose(
-		p.HandleNeighborReplyXdp,
+		p.HandleNeighborReplyTc,
 		p.TcRouterFunc,
 	)
 }

--- a/pkg/reconciler/layer2.go
+++ b/pkg/reconciler/layer2.go
@@ -238,7 +238,9 @@ func (r *reconcile) applyConfiguration(desired, current *nl.Layer2Information, a
 			return fmt.Errorf("error ensuring neighbor suppression for vlanId %d: %w", desired.VlanID, err)
 		}
 	} else {
-		r.neighborSync.DisableNeighborSuppression(bridgeID, macVlanBridgeID)
+		if err := r.neighborSync.DisableNeighborSuppression(bridgeID, macVlanBridgeID); err != nil {
+			return fmt.Errorf("error disabling neighbor suppression for vlanId %d: %w", desired.VlanID, err)
+		}
 	}
 
 	if len(desired.AnycastGateways) > 0 {


### PR DESCRIPTION
Previously XDP was used. However attaching an XDP program to a veth moves this veth into NAPI poll mode (https://patchwork.ozlabs.org/project/netdev/patch/20180424143923.26519-5-toshiaki.makita1@gmail.com/). As our Kernel is always newer than 6.6 we migrate to TCX instead of XDP. We anyway rely on the Kernel stack later so moving from XDP to TC(X) is not a problem for us