### PR TITLE
Fix duplicate update of status by two controllers

### DIFF
--- a/api/v1alpha1/nodenetworkconfig_types.go
+++ b/api/v1alpha1/nodenetworkconfig_types.go
@@ -291,6 +291,8 @@ type NodeNetworkConfigStatus struct {
 	ConfigStatus string `json:"configStatus"`
 	// LastUpdate determines when last update (change) of the ConfigStatus field took place.
 	LastUpdate metav1.Time `json:"lastUpdate"`
+	// LastAppliedRevision stores hash of the NodeConfigRevision that was last applied to the node.
+	LastAppliedRevision string `json:"lastAppliedRevision,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/network.t-caas.telekom.com_nodenetworkconfigs.yaml
+++ b/config/crd/bases/network.t-caas.telekom.com_nodenetworkconfigs.yaml
@@ -3041,6 +3041,10 @@ spec:
                 description: ConfigStatus describes provisioning state of the NodeConfig.
                   Can be either 'provisioning', 'provisioned' or 'failed'.
                 type: string
+              lastAppliedRevision:
+                description: LastAppliedRevision stores hash of the NodeConfigRevision
+                  that was last applied to the node.
+                type: string
               lastUpdate:
                 description: LastUpdate determines when last update (change) of the
                   ConfigStatus field took place.

--- a/pkg/reconciler/operator/configrevision_reconciler.go
+++ b/pkg/reconciler/operator/configrevision_reconciler.go
@@ -518,13 +518,8 @@ func (crr *ConfigRevisionReconciler) deployNodeNetworkConfig(ctx context.Context
 		cfg.Spec = newConfig.Spec
 		cfg.ObjectMeta.OwnerReferences = newConfig.ObjectMeta.OwnerReferences
 		cfg.Name = node.Name
-		cfg.Status.ConfigStatus = ""
-		cfg.Status.LastUpdate = metav1.Now()
 		if err := crr.client.Update(deploymentCtx, cfg); err != nil {
 			return fmt.Errorf("error updating NodeNetworkConfig for node %s: %w", node.Name, err)
-		}
-		if err := crr.client.Status().Update(deploymentCtx, cfg); err != nil {
-			return fmt.Errorf("error updating NodeNetworkConfig status for node %s: %w", node, err)
 		}
 	} else {
 		cfg = newConfig


### PR DESCRIPTION
Previously the central controller tried to erase the status while the node controller was already overwriting it.

Now the central controller will not update the status anymore. The node controller will keep track of the last rolled out revision by looking at a new status field called lastAppliedRevision.