### PR TITLE
Use auto route-distinguisher with cra-vsr agent

### DIFF
--- a/pkg/cra-vsr/cra_vsr_test.go
+++ b/pkg/cra-vsr/cra_vsr_test.go
@@ -672,7 +672,6 @@ var expectedXML = `
               </advertisement>
               <export>
                 <route-target>64497:30</route-target>
-                <route-distinguisher>10.50.0.10:30</route-distinguisher>
               </export>
               <import>
                 <route-target>64497:30</route-target>
@@ -827,7 +826,6 @@ var expectedXML = `
               </advertisement>
               <export>
                 <route-target>65188:2026</route-target>
-                <route-distinguisher>10.50.0.10:2026</route-distinguisher>
               </export>
               <import>
                 <route-target>65188:2026</route-target>
@@ -1025,7 +1023,6 @@ var expectedXML = `
               </advertisement>
               <export>
                 <route-target>64497:20</route-target>
-                <route-distinguisher>10.50.0.10:20</route-distinguisher>
               </export>
               <import>
                 <route-target>64497:20</route-target>


### PR DESCRIPTION
Currently we set a route-distinguisher for each VRF that exports evpn routes using `<IP>:<VNI>`.
This only works when VNI is a uint16 number, if it is higher, the generated route-distinguisher is invalid and will be refused by the VSR. Instead let's use FRR auto route-distinguisher feature by not configuring any route-distinguisher.

To fully use auto route-distinguisher, take care to also remove any route-distinguisher in the init-config.