### PR TITLE
Fix cra-vsr layer3 findFreeTableID()

### DIFF
--- a/pkg/cra-vsr/layer3.go
+++ b/pkg/cra-vsr/layer3.go
@@ -65,7 +65,7 @@ func (l *Layer3) findFreeTableID() (int, error) {
 	sort.Ints(listTableID)
 
 	freeTableID := vrfTableStart
-	for t := range listTableID {
+	for _, t := range listTableID {
 		if t == freeTableID {
 			freeTableID++
 		}


### PR DESCRIPTION
The API to find table-id associated to VRF was bugged, it was comparing GO list index and not table-id and so was unable to detect if a table-id was already used. This make the function to give the same table-id (50) to every VRFs.