### PR TITLE
Fix cra-vsr unit-test and unchecked LocalVRFs

### DIFF
--- a/pkg/cra-vsr/layer3.go
+++ b/pkg/cra-vsr/layer3.go
@@ -96,7 +96,9 @@ func (l *Layer3) setupTableID() error {
 			continue
 		}
 		if _, ok := l.nodeCfg.FabricVRFs[name]; !ok {
-			delete(l.tableID, name)
+			if _, ok := l.nodeCfg.LocalVRFs[name]; !ok {
+				delete(l.tableID, name)
+			}
 		}
 	}
 


### PR DESCRIPTION
Sort VRF before assigning table-id to fix random unit-test failure.
Fix LocalVRF not checked to determine if a VRF table-id can be re-used.