### PR TITLE
Set accept-untracked-na on L2 bridges of cra-vsr

### DIFF
--- a/pkg/cra-vsr/cra_vsr_test.xml
+++ b/pkg/cra-vsr/cra_vsr_test.xml
@@ -586,6 +586,7 @@
             </ipv4>
             <ipv6>
               <accept-duplicate-address-detection>never</accept-duplicate-address-detection>
+              <accept-untracked-neighbor-advertisement>connected</accept-untracked-neighbor-advertisement>
             </ipv6>
             <neighbor>
               <ipv4-base-reachable-time>30000</ipv4-base-reachable-time>
@@ -624,6 +625,7 @@
             </ipv4>
             <ipv6>
               <accept-duplicate-address-detection>never</accept-duplicate-address-detection>
+              <accept-untracked-neighbor-advertisement>connected</accept-untracked-neighbor-advertisement>
             </ipv6>
             <neighbor>
               <ipv4-base-reachable-time>30000</ipv4-base-reachable-time>

--- a/pkg/cra-vsr/layer2.go
+++ b/pkg/cra-vsr/layer2.go
@@ -100,7 +100,8 @@ func (l *Layer2) setupBridge(info *InfoL2, intfs *Interfaces) *Bridge {
 	if br.NetworkStack.IPv6 == nil {
 		br.NetworkStack.IPv6 = &NetworkStackV6{}
 	}
-	br.NetworkStack.IPv6.AcceptDAD = types.ToPtr(NeverDAD)
+	br.NetworkStack.IPv6.AcceptDuplicateAD = types.ToPtr("never")
+	br.NetworkStack.IPv6.AcceptUntrackedNA = types.ToPtr("connected")
 
 	br.NetworkStack.IPv4 = &NetworkStackV4{
 		AcceptARP: types.ToPtr("always"),

--- a/pkg/cra-vsr/types.go
+++ b/pkg/cra-vsr/types.go
@@ -237,17 +237,10 @@ const (
 	EUI64       AddressGenMode = "eui64"
 )
 
-type DAD string
-
-const (
-	NeverDAD       DAD = "never"
-	AlwaysDAD      DAD = "always"
-	DisableIPv6DAD DAD = "disable-ipv6-on-dad-fail"
-)
-
 type NetworkStackV6 struct {
-	AddrGenMode *AddressGenMode `xml:"address-generation-mode,omitempty"`
-	AcceptDAD   *DAD            `xml:"accept-duplicate-address-detection,omitempty"`
+	AddrGenMode       *AddressGenMode `xml:"address-generation-mode,omitempty"`
+	AcceptDuplicateAD *string         `xml:"accept-duplicate-address-detection,omitempty"`
+	AcceptUntrackedNA *string         `xml:"accept-untracked-neighbor-advertisement"`
 }
 
 type NeighborNetworkStack struct {


### PR DESCRIPTION
Add accept-untracked-na in IPv6 NetworkStack and set it to "connected" on all L2 bridges.

Node: A new VSR release is needed for this patch to work.