### PR TITLE
Enable neighbor-suppress by default in cra-vsr

### DIFF
--- a/pkg/cra-vsr/cra_vsr_test.xml
+++ b/pkg/cra-vsr/cra_vsr_test.xml
@@ -567,7 +567,7 @@
           <link-interface>
             <slave>vx.4000002</slave>
             <learning>false</learning>
-            <neighbor-suppress>false</neighbor-suppress>
+            <neighbor-suppress>true</neighbor-suppress>
             <hairpin>false</hairpin>
           </link-interface>
           <ipv4>
@@ -605,7 +605,7 @@
           <link-interface>
             <slave>vx.4000003</slave>
             <learning>false</learning>
-            <neighbor-suppress>false</neighbor-suppress>
+            <neighbor-suppress>true</neighbor-suppress>
             <hairpin>false</hairpin>
           </link-interface>
           <ipv4>

--- a/pkg/cra-vsr/layer2.go
+++ b/pkg/cra-vsr/layer2.go
@@ -73,7 +73,7 @@ func (l *Layer2) setupInformations() {
 }
 
 func (l *Layer2) setupVXLAN(info *InfoL2, br *Bridge, intfs *Interfaces) {
-	neighSuppress := (os.Getenv("NWOP_NEIGH_SUPPRESSION") == "true")
+	neighSuppress := os.Getenv("NWOP_NEIGH_SUPPRESSION") != "false"
 	if len(info.ips) == 0 {
 		neighSuppress = false
 	}


### PR DESCRIPTION
By default neighbor-suppress should be enabled. It will be disabled only if specificaly required, by defining an environment variable to "false".