### PR TITLE
Remove ipv6 pbr inbound interface matching

### DIFF
--- a/pkg/cra-vsr/cra_vsr_test.xml
+++ b/pkg/cra-vsr/cra_vsr_test.xml
@@ -17,7 +17,6 @@
         <ipv6-rule>
           <priority>2</priority>
           <match>
-            <inbound-interface>hbn</inbound-interface>
             <source>fd00:34::2</source>
           </match>
           <action>

--- a/pkg/cra-vsr/layerbgp.go
+++ b/pkg/cra-vsr/layerbgp.go
@@ -126,6 +126,9 @@ func (LayerBGP) mkRule(routing *Routing, rules ...Rule) {
 		if isIPv4(ip) {
 			routing.PBR.IPv4 = append(routing.PBR.IPv4, rule)
 		} else {
+			if rule.Match != nil {
+				rule.Match.Interface = nil
+			}
 			routing.PBR.IPv6 = append(routing.PBR.IPv6, rule)
 		}
 	}


### PR DESCRIPTION
Due to Linux internal limitation the inbound interface on ipv6 pbr is not working correctly, stop setting it.