### PR TITLE
Revert "Set accept-untracked-na on L2 bridges"

### DIFF
--- a/pkg/cra-vsr/cra_vsr_test.xml
+++ b/pkg/cra-vsr/cra_vsr_test.xml
@@ -586,7 +586,6 @@
             </ipv4>
             <ipv6>
               <accept-duplicate-address-detection>never</accept-duplicate-address-detection>
-              <accept-untracked-neighbor-advertisement>connected</accept-untracked-neighbor-advertisement>
             </ipv6>
             <neighbor>
               <ipv4-base-reachable-time>30000</ipv4-base-reachable-time>
@@ -625,7 +624,6 @@
             </ipv4>
             <ipv6>
               <accept-duplicate-address-detection>never</accept-duplicate-address-detection>
-              <accept-untracked-neighbor-advertisement>connected</accept-untracked-neighbor-advertisement>
             </ipv6>
             <neighbor>
               <ipv4-base-reachable-time>30000</ipv4-base-reachable-time>

--- a/pkg/cra-vsr/layer2.go
+++ b/pkg/cra-vsr/layer2.go
@@ -101,7 +101,6 @@ func (l *Layer2) setupBridge(info *InfoL2, intfs *Interfaces) *Bridge {
 		br.NetworkStack.IPv6 = &NetworkStackV6{}
 	}
 	br.NetworkStack.IPv6.AcceptDuplicateAD = types.ToPtr("never")
-	br.NetworkStack.IPv6.AcceptUntrackedNA = types.ToPtr("connected")
 
 	br.NetworkStack.IPv4 = &NetworkStackV4{
 		AcceptARP: types.ToPtr("always"),


### PR DESCRIPTION
This reverts commit 1e743308aa90fca7ee2489c3d4d7257fb90849b8.

Since the enabling of neighbor-suppress, setting accept-untracked-na is not needed aymore.