### PR TITLE
Fix cra-vsr local-vrf panic

### DIFF
--- a/pkg/cra-vsr/cra_vsr_test.go
+++ b/pkg/cra-vsr/cra_vsr_test.go
@@ -235,6 +235,15 @@ var revision = &v1alpha1.NetworkConfigRevision{
 					},
 				},
 			}, {
+				Name: "m2m-test-vrf-2",
+				VRFRouteConfigurationSpec: v1alpha1.VRFRouteConfigurationSpec{
+					SBRPrefixes: []string{"10.250.4.0/24", "fdbb:6b17:90ba::/64"},
+					Seq:         20,
+					VRF:         "m2m",
+					VNI:         types.ToPtr(2002000),
+					RouteTarget: types.ToPtr("65188:2000"),
+				},
+			}, {
 				Name: "internet",
 				VRFRouteConfigurationSpec: v1alpha1.VRFRouteConfigurationSpec{
 					VRF:         "p_internet",

--- a/pkg/cra-vsr/cra_vsr_test.xml
+++ b/pkg/cra-vsr/cra_vsr_test.xml
@@ -771,6 +771,51 @@
         </bridge>
       </interface>
     </l3vrf>
+    <l3vrf>
+      <name>s-m2m</name>
+      <table-id>52</table-id>
+      <routing xmlns="urn:6wind:vrouter/routing" nc:operation="replace">
+        <static></static>
+        <bgp xmlns="urn:6wind:vrouter/bgp">
+          <as>64497</as>
+          <router-id>10.50.0.10</router-id>
+          <suppress-duplicates>false</suppress-duplicates>
+          <address-family>
+            <ipv4-unicast>
+              <redistribute>
+                <protocol>connected</protocol>
+              </redistribute>
+              <redistribute>
+                <protocol>static</protocol>
+              </redistribute>
+              <l3vrf>
+                <import>
+                  <l3vrf>cluster</l3vrf>
+                  <l3vrf>m2m</l3vrf>
+                  <route-map>rm_s-m2m_import</route-map>
+                </import>
+              </l3vrf>
+            </ipv4-unicast>
+            <ipv6-unicast>
+              <redistribute>
+                <protocol>connected</protocol>
+              </redistribute>
+              <redistribute>
+                <protocol>static</protocol>
+              </redistribute>
+              <l3vrf>
+                <import>
+                  <l3vrf>cluster</l3vrf>
+                  <l3vrf>m2m</l3vrf>
+                  <route-map>rm_s-m2m_import</route-map>
+                </import>
+              </l3vrf>
+            </ipv6-unicast>
+          </address-family>
+        </bgp>
+      </routing>
+      <interface xmlns="urn:6wind:vrouter/interface"></interface>
+    </l3vrf>
   </vrf>
   <routing xmlns="urn:6wind:vrouter/routing" nc:operation="replace">
     <route-map>
@@ -1241,6 +1286,39 @@
       <seq>
         <num>12</num>
         <policy>deny</policy>
+      </seq>
+    </route-map>
+    <route-map>
+      <name>rm_s-m2m_import</name>
+      <seq>
+        <num>10</num>
+        <policy>permit</policy>
+        <match>
+          <source-l3vrf>m2m</source-l3vrf>
+        </match>
+        <call>rm_s-m2m_import_m2m</call>
+      </seq>
+      <seq>
+        <num>11</num>
+        <policy>permit</policy>
+        <match>
+          <source-l3vrf>cluster</source-l3vrf>
+        </match>
+        <call>rm_s-m2m_import_cluster</call>
+      </seq>
+    </route-map>
+    <route-map>
+      <name>rm_s-m2m_import_cluster</name>
+      <seq>
+        <num>10</num>
+        <policy>permit</policy>
+      </seq>
+    </route-map>
+    <route-map>
+      <name>rm_s-m2m_import_m2m</name>
+      <seq>
+        <num>10</num>
+        <policy>permit</policy>
       </seq>
     </route-map>
     <ipv4-prefix-list>

--- a/pkg/cra-vsr/layerbgp.go
+++ b/pkg/cra-vsr/layerbgp.go
@@ -571,6 +571,11 @@ func (l *LayerBGP) setupLocalVRF(name string, conf *v1alpha1.VRF) error {
 				Protocol: BGPRedistStatic,
 			},
 		},
+		VRFImports: &BGPUcastVRF{
+			Imports: &BGPUcastImportVRF{
+				RouteMaps: []string{"rm_" + name + "_import"},
+			},
+		},
 	}
 	bgp.AF.UcastV6 = &BGPUcast{
 		Redists: []BGPRedist{
@@ -578,6 +583,11 @@ func (l *LayerBGP) setupLocalVRF(name string, conf *v1alpha1.VRF) error {
 				Protocol: BGPRedistConnect,
 			}, {
 				Protocol: BGPRedistStatic,
+			},
+		},
+		VRFImports: &BGPUcastVRF{
+			Imports: &BGPUcastImportVRF{
+				RouteMaps: []string{"rm_" + name + "_import"},
 			},
 		},
 	}


### PR DESCRIPTION
Agent cra-vsr was crashing when configuring local-vrfs.
Fix it and update unit-test to test this usecase.