### PR TITLE
Create optional VRF redistribute route-map on cra-vsr

### DIFF
--- a/pkg/cra-vsr/cra_vsr_test.xml
+++ b/pkg/cra-vsr/cra_vsr_test.xml
@@ -293,9 +293,11 @@
             <ipv4-unicast>
               <redistribute>
                 <protocol>connected</protocol>
+                <route-map>rm_cluster_redist_connected</route-map>
               </redistribute>
               <redistribute>
                 <protocol>static</protocol>
+                <route-map>rm_cluster_redist_static</route-map>
               </redistribute>
               <l3vrf>
                 <import>
@@ -308,9 +310,11 @@
             <ipv6-unicast>
               <redistribute>
                 <protocol>connected</protocol>
+                <route-map>rm_cluster_redist_connected</route-map>
               </redistribute>
               <redistribute>
                 <protocol>static</protocol>
+                <route-map>rm_cluster_redist_static</route-map>
               </redistribute>
               <l3vrf>
                 <import>
@@ -950,6 +954,20 @@
       <seq>
         <num>12</num>
         <policy>deny</policy>
+      </seq>
+    </route-map>
+    <route-map>
+      <name>rm_cluster_redist_connected</name>
+      <seq>
+        <num>10</num>
+        <policy>permit</policy>
+      </seq>
+    </route-map>
+    <route-map>
+      <name>rm_cluster_redist_static</name>
+      <seq>
+        <num>10</num>
+        <policy>permit</policy>
       </seq>
     </route-map>
     <route-map>


### PR DESCRIPTION
When VRF redistribute is configured, create route-map for each redistribute protocol and link them to protocols.