### PR TITLE
chore: add versions.env and modernize Makefile

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -59,7 +59,14 @@ jobs:
           go-version-file: go.mod
 
       - name: Create Licenses Report
-        run: make licenses-report
+        run: |
+          for attempt in 1 2 3; do
+            if make licenses-report; then
+              exit 0
+            fi
+            sleep 1000 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 1000(attempt * 10))
+          done
+          make licenses-report
 
       - name: Read Go version
         id: go-version

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -64,7 +64,7 @@ jobs:
             if make licenses-report; then
               exit 0
             fi
-            sleep 1000 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 1000(attempt * 10))
+            sleep 10
           done
           make licenses-report
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -182,6 +182,7 @@ jobs:
 
       - name: system-level-dependencies
         run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
           sudo apt update
           sudo apt -y install linux-modules-extra-$(uname -r)
 

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -20,7 +20,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: run code generators
         run: make generate
       - name: golangci-lint
@@ -38,7 +41,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: Run Tests
         run: make test
       - name: Upload coverage report
@@ -59,7 +65,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: run code generators
         run: make generate
       - name: run manifest generators

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -86,8 +86,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-images.yaml
     with:
-      push: true
-      cache-write: true
+      push: false
+      cache-write: false
 
   build-images-fork:
     name: build container images (fork)

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -86,8 +86,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-images.yaml
     with:
-      push: false
-      cache-write: false
+      push: true
+      cache-write: true
 
   build-images-fork:
     name: build container images (fork)

--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,6 @@ generate: controller-gen bpf-generate ## Generate code containing DeepCopy, Deep
 fmt: ## Run go fmt against code.
 	go fmt ./...
 
-GOLANGCI_LINT ?= golangci-lint
-
-.PHONY: lint
-lint: ## Run golangci-lint.
-	$(GOLANGCI_LINT) run ./...
-
 .PHONY: vet
 vet: ## Run go vet against code.
 	go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,7 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes.
 	$(GOLANGCI_LINT) run --fix --timeout 10m
 
 .PHONY: lint-strict
-lint-strict: golangci-lint ## Run golangci-lint with strict settings (as in CI).
-	$(GOLANGCI_LINT) run --timeout 10m --issues-exit-code 1
+lint-strict: lint ## Alias for CI linting; golangci-lint already exits non-zero on issues.
 
 .PHONY: vulncheck
 vulncheck: govulncheck ## Run govulncheck to check for known vulnerabilities.

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(shell go list ./... 2>/dev/null | grep -v -e '/e2etests$$' -e /e2etests/tests -e /e2etests/config -e /e2e/ || true) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$$( $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path )" go test $$(go list ./... 2>/dev/null | grep -v -e '/e2etests$$' -e /e2etests/tests -e /e2etests/config -e /e2e/ || true) -coverprofile cover.out
 
 ##@ Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+include versions.env
 
 # Image URL to use all building/pushing image targets
 IMG_BASE ?= ghcr.io/telekom
@@ -40,7 +41,7 @@ all: build
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-##@ DevelopmentLDFLAGS := $(shell hack/version.sh)
+##@ Development
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
@@ -99,6 +100,28 @@ docs-serve: ## Serve the documentation site locally with live reload (requires m
 .PHONY: docs-build
 docs-build: docs-api ## Build the documentation site (strict; fails on warnings/broken links).
 	mkdocs build --strict
+
+##@ Linting
+
+.PHONY: lint
+lint: golangci-lint ## Run golangci-lint linter.
+	$(GOLANGCI_LINT) run --timeout 10m
+
+.PHONY: lint-fix
+lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes.
+	$(GOLANGCI_LINT) run --fix --timeout 10m
+
+.PHONY: lint-strict
+lint-strict: golangci-lint ## Run golangci-lint with strict settings (as in CI).
+	$(GOLANGCI_LINT) run --timeout 10m --issues-exit-code 1
+
+.PHONY: vulncheck
+vulncheck: govulncheck ## Run govulncheck to check for known vulnerabilities.
+	$(GOVULNCHECK) ./...
+
+.PHONY: verify
+verify: lint-strict test vulncheck ## Run all verification checks (lint, vet, test, vulncheck).
+	@echo "All verification checks passed!"
 
 ##@ Build
 
@@ -256,27 +279,45 @@ e2e-test-sync: ## Run E2E sync controller tests.
 	docker exec clab-nwop-tester bash -c \
 	  'cd /repo && KUBECONFIG=/repo/e2etests/.kubeconfig E2E_INTENT_MODE=true go test -v -count=1 -timeout=30m ./e2etests -ginkgo.label-filter="sync"'
 
-##@ Build Dependencies
+##@ Dependencies
 
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+## Tool Binaries
+CONTROLLER_GEN = $(LOCALBIN)/controller-gen
+KUSTOMIZE = $(LOCALBIN)/kustomize
+ENVTEST = $(LOCALBIN)/setup-envtest
+GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+GO_LICENSES = $(LOCALBIN)/go-licenses
+GOVULNCHECK = $(LOCALBIN)/govulncheck
+
 .PHONY: controller-gen
-controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.20.0)
+controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
+$(CONTROLLER_GEN): $(LOCALBIN) versions.env
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
 
-KUSTOMIZE = $(shell pwd)/bin/kustomize
 .PHONY: kustomize
-kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5@v5.0.3)
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
+$(KUSTOMIZE): $(LOCALBIN) versions.env
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
 
-ENVTEST = $(shell pwd)/bin/setup-envtest
 .PHONY: envtest
-envtest: ## Download setup-envtest locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20260305142021-f9589b9f2b9d)
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST): $(LOCALBIN) versions.env
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
 
-GO_LICENSES = $(shell pwd)/bin/go-licenses
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT): $(LOCALBIN) versions.env
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
 .PHONY: go-licenses
-go-licenses: ## Download go-licenses locally if necessary.
-	$(call go-get-tool,$(GO_LICENSES),github.com/google/go-licenses@latest)
+go-licenses: $(GO_LICENSES) ## Download go-licenses locally if necessary.
+$(GO_LICENSES): $(LOCALBIN) versions.env
+	$(call go-install-tool,$(GO_LICENSES),github.com/google/go-licenses,$(GO_LICENSES_VERSION))
 
 CRD_REF_DOCS = $(shell pwd)/bin/crd-ref-docs
 .PHONY: crd-ref-docs
@@ -295,4 +336,28 @@ echo "Downloading $(2)" ;\
 GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
+endef
+
+.PHONY: govulncheck
+govulncheck: $(GOVULNCHECK) ## Download govulncheck locally if necessary.
+$(GOVULNCHECK): $(LOCALBIN) versions.env
+	$(call go-install-tool,$(GOVULNCHECK),golang.org/x/vuln/cmd/govulncheck,$(GOVULNCHECK_VERSION))
+
+# go-install-tool will 'go install' any package with custom target and name of binary
+# $1 - target path with name of binary
+# $2 - package url which can be installed
+# $3 - specific version of package
+define go-install-tool
+@[ -f "$(1)-$(3)" ] || { \
+package=$(2)@$(3) ;\
+echo "Downloading $${package}" ;\
+tmpdir=$$(mktemp -d) ;\
+trap 'rm -rf "$$tmpdir"' EXIT ;\
+GOBIN=$$tmpdir go install $${package} ;\
+tmpbin="$$tmpdir/$$(basename "$(1)")" ;\
+[ -f "$$tmpbin" ] ;\
+mv "$$tmpbin" "$(1)-$(3)" ;\
+} ;\
+ link_dir="$$(dirname "$(1)")" ;\
+ ln -sf "$$(basename "$(1)-$(3)")" "$$link_dir/$$(basename "$(1)")"
 endef

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$$( $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path )"; \
+	KUBEBUILDER_ASSETS="$$( "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) -p path )"; \
 	KUBEBUILDER_ASSETS="$$KUBEBUILDER_ASSETS" go test $$(go list ./... 2>/dev/null | grep -v -e '/e2etests$$' -e /e2etests/tests -e /e2etests/config -e /e2e/ || true) -coverprofile cover.out
 
 ##@ Documentation
@@ -100,11 +100,11 @@ docs-build: docs-api ## Build the documentation site (strict; fails on warnings/
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter.
-	$(GOLANGCI_LINT) run --timeout 10m
+	$(GOLANGCI_LINT) run ./... --timeout 10m
 
 .PHONY: lint-fix
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes.
-	$(GOLANGCI_LINT) run --fix --timeout 10m
+	$(GOLANGCI_LINT) run ./... --fix --timeout 10m
 
 .PHONY: lint-strict
 lint-strict: lint ## Alias for CI linting; golangci-lint already exits non-zero on issues.
@@ -278,7 +278,7 @@ e2e-test-sync: ## Run E2E sync controller tests.
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
-	mkdir -p $(LOCALBIN)
+	mkdir -p "$(LOCALBIN)"
 
 ## Tool Binaries
 CONTROLLER_GEN = $(LOCALBIN)/controller-gen

--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,13 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	$(CONTROLLER_GEN) rbac:roleName=manager-role paths="./controllers/operator/..." paths="./controllers/intent/..." paths="./controllers/platform/..." paths="./controllers/agent-cra-frr/..." paths="./controllers/agent-cra-vsr/..." paths="./controllers/agent-hbn-l2/..." paths="./controllers/agent-netplan/..." paths="./pkg/monitoring/..."
-	$(CONTROLLER_GEN) rbac:roleName=network-sync-role paths="./controllers/sync/..." output:rbac:artifacts:config=config/network-sync
+	"$(CONTROLLER_GEN)" crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	"$(CONTROLLER_GEN)" rbac:roleName=manager-role paths="./controllers/operator/..." paths="./controllers/intent/..." paths="./controllers/platform/..." paths="./controllers/agent-cra-frr/..." paths="./controllers/agent-cra-vsr/..." paths="./controllers/agent-hbn-l2/..." paths="./controllers/agent-netplan/..." paths="./pkg/monitoring/..."
+	"$(CONTROLLER_GEN)" rbac:roleName=network-sync-role paths="./controllers/sync/..." output:rbac:artifacts:config=config/network-sync
 
 .PHONY: generate
 generate: controller-gen bpf-generate ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.
@@ -70,7 +70,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: docs-api
 docs-api: crd-ref-docs ## Generate the CRD field reference (docs/reference/crd-reference.md) from Go types.
-	$(CRD_REF_DOCS) \
+	"$(CRD_REF_DOCS)" \
 		--source-path=./api/v1alpha1/network-connector \
 		--config=.crd-ref-docs.yaml \
 		--renderer=markdown \
@@ -100,18 +100,18 @@ docs-build: docs-api ## Build the documentation site (strict; fails on warnings/
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter.
-	$(GOLANGCI_LINT) run ./... --timeout 10m
+	"$(GOLANGCI_LINT)" run ./... --timeout 10m
 
 .PHONY: lint-fix
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes.
-	$(GOLANGCI_LINT) run ./... --fix --timeout 10m
+	"$(GOLANGCI_LINT)" run ./... --fix --timeout 10m
 
 .PHONY: lint-strict
 lint-strict: lint ## Alias for CI linting; golangci-lint already exits non-zero on issues.
 
 .PHONY: vulncheck
 vulncheck: govulncheck ## Run govulncheck to check for known vulnerabilities.
-	$(GOVULNCHECK) ./...
+	"$(GOVULNCHECK)" ./...
 
 .PHONY: verify
 verify: lint-strict test vulncheck ## Run all verification checks (lint, vet, test, vulncheck).
@@ -188,8 +188,8 @@ $(RELEASE_DIR):
 
 licenses-report: go-licenses
 	rm -rf $(RELEASE_DIR)/licenses
-	$(GO_LICENSES) save --save_path $(RELEASE_DIR)/licenses ./...
-	$(GO_LICENSES) report --template hack/licenses.md.tpl ./... > $(RELEASE_DIR)/licenses/licenses.md
+	"$(GO_LICENSES)" save --save_path $(RELEASE_DIR)/licenses ./...
+	"$(GO_LICENSES)" report --template hack/licenses.md.tpl ./... > $(RELEASE_DIR)/licenses/licenses.md
 	(cd out/licenses && tar -czf ../licenses.tar.gz *)
 
 ##@ Deployment
@@ -200,28 +200,28 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	"$(KUSTOMIZE)" build config/crd | kubectl apply -f -
 
 .PHONY: install-certs
 install-certs: manifests kustomize ## Install certs
-	$(KUSTOMIZE) build config/certmanager | kubectl apply -f -
+	"$(KUSTOMIZE)" build config/certmanager | kubectl apply -f -
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	"$(KUSTOMIZE)" build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: uninstall-certs
 uninstall-certs: manifests kustomize ## Uninstall certs
-	$(KUSTOMIZE) build config/certmanager | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	"$(KUSTOMIZE)" build config/certmanager | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/operator && $(KUSTOMIZE) edit set image operator=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	cd config/operator && "$(KUSTOMIZE)" edit set image operator=${IMG}
+	"$(KUSTOMIZE)" build config/default | kubectl apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	"$(KUSTOMIZE)" build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ E2E Testing
 
@@ -277,7 +277,12 @@ e2e-test-sync: ## Run E2E sync controller tests.
 
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
-$(LOCALBIN):
+empty :=
+space := $(empty) $(empty)
+escape-space = $(subst $(space),\ ,$(1))
+
+LOCALBIN_TARGET := $(call escape-space,$(LOCALBIN))
+$(LOCALBIN_TARGET):
 	mkdir -p "$(LOCALBIN)"
 
 ## Tool Binaries
@@ -288,29 +293,36 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 GO_LICENSES = $(LOCALBIN)/go-licenses
 GOVULNCHECK = $(LOCALBIN)/govulncheck
 
+CONTROLLER_GEN_TARGET := $(call escape-space,$(CONTROLLER_GEN))
+KUSTOMIZE_TARGET := $(call escape-space,$(KUSTOMIZE))
+ENVTEST_TARGET := $(call escape-space,$(ENVTEST))
+GOLANGCI_LINT_TARGET := $(call escape-space,$(GOLANGCI_LINT))
+GO_LICENSES_TARGET := $(call escape-space,$(GO_LICENSES))
+GOVULNCHECK_TARGET := $(call escape-space,$(GOVULNCHECK))
+
 .PHONY: controller-gen
-controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
-$(CONTROLLER_GEN): $(LOCALBIN) versions.env
+controller-gen: $(CONTROLLER_GEN_TARGET) ## Download controller-gen locally if necessary.
+$(CONTROLLER_GEN_TARGET): $(LOCALBIN_TARGET) versions.env
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
 
 .PHONY: kustomize
-kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-$(KUSTOMIZE): $(LOCALBIN) versions.env
+kustomize: $(KUSTOMIZE_TARGET) ## Download kustomize locally if necessary.
+$(KUSTOMIZE_TARGET): $(LOCALBIN_TARGET) versions.env
 	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
 
 .PHONY: envtest
-envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
-$(ENVTEST): $(LOCALBIN) versions.env
+envtest: $(ENVTEST_TARGET) ## Download setup-envtest locally if necessary.
+$(ENVTEST_TARGET): $(LOCALBIN_TARGET) versions.env
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
 
 .PHONY: golangci-lint
-golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
-$(GOLANGCI_LINT): $(LOCALBIN) versions.env
+golangci-lint: $(GOLANGCI_LINT_TARGET) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT_TARGET): $(LOCALBIN_TARGET) versions.env
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 .PHONY: go-licenses
-go-licenses: $(GO_LICENSES) ## Download go-licenses locally if necessary.
-$(GO_LICENSES): $(LOCALBIN) versions.env
+go-licenses: $(GO_LICENSES_TARGET) ## Download go-licenses locally if necessary.
+$(GO_LICENSES_TARGET): $(LOCALBIN_TARGET) versions.env
 	$(call go-install-tool,$(GO_LICENSES),github.com/google/go-licenses,$(GO_LICENSES_VERSION))
 
 CRD_REF_DOCS = $(shell pwd)/bin/crd-ref-docs
@@ -321,20 +333,20 @@ crd-ref-docs: ## Download crd-ref-docs locally if necessary.
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
-@[ -f $(1) ] || { \
+@[ -f "$(1)" ] || { \
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
+GOBIN="$(PROJECT_DIR)/bin" go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef
 
 .PHONY: govulncheck
-govulncheck: $(GOVULNCHECK) ## Download govulncheck locally if necessary.
-$(GOVULNCHECK): $(LOCALBIN) versions.env
+govulncheck: $(GOVULNCHECK_TARGET) ## Download govulncheck locally if necessary.
+$(GOVULNCHECK_TARGET): $(LOCALBIN_TARGET) versions.env
 	$(call go-install-tool,$(GOVULNCHECK),golang.org/x/vuln/cmd/govulncheck,$(GOVULNCHECK_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,8 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$$( $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path )" go test $$(go list ./... 2>/dev/null | grep -v -e '/e2etests$$' -e /e2etests/tests -e /e2etests/config -e /e2e/ || true) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$$( $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path )"; \
+	KUBEBUILDER_ASSETS="$$KUBEBUILDER_ASSETS" go test $$(go list ./... 2>/dev/null | grep -v -e '/e2etests$$' -e /e2etests/tests -e /e2etests/config -e /e2e/ || true) -coverprofile cover.out
 
 ##@ Documentation
 
@@ -298,7 +299,7 @@ $(KUSTOMIZE): $(LOCALBIN) versions.env
 	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
 
 .PHONY: envtest
-envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
 $(ENVTEST): $(LOCALBIN) versions.env
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
 

--- a/Makefile
+++ b/Makefile
@@ -334,12 +334,11 @@ crd-ref-docs: ## Download crd-ref-docs locally if necessary.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f "$(1)" ] || { \
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
+TMP_DIR=$$(mktemp -d) ; trap 'rm -rf "$$TMP_DIR"' EXIT ;\
+cd "$$TMP_DIR" ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
 GOBIN="$(PROJECT_DIR)/bin" go install $(2) ;\
-rm -rf $$TMP_DIR ;\
 }
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -334,7 +334,6 @@ crd-ref-docs: ## Download crd-ref-docs locally if necessary.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f "$(1)" ] || { \
-set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\

--- a/e2e/setup/phases.go
+++ b/e2e/setup/phases.go
@@ -11,6 +11,21 @@ import (
 	"time"
 )
 
+func installMultus(kubectl func(...string) error, version string) error {
+	url := fmt.Sprintf("https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/%s/deployments/multus-daemonset-thick.yml", version)
+	if err := kubectl("apply", "-f", url); err != nil {
+		return fmt.Errorf("apply Multus: %w", err)
+	}
+	if err := kubectl("-n", "kube-system", "patch", "daemonset", "kube-multus-ds", "--type=json",
+		`-p=[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"512Mi"},{"op":"replace","path":"/spec/template/spec/containers/0/resources/requests/memory","value":"512Mi"}]`); err != nil {
+		return fmt.Errorf("patch Multus: %w", err)
+	}
+	if err := kubectl("-n", "kube-system", "rollout", "status", "daemonset/kube-multus-ds", "--timeout=180s"); err != nil {
+		return fmt.Errorf("wait for Multus rollout: %w", err)
+	}
+	return nil
+}
+
 // PhaseBuildImages builds or loads all Docker images required for the E2E lab.
 //
 // When E2E_SKIP_BUILD=true, pre-built OCI tarballs are loaded from E2E_IMAGE_DIR
@@ -589,10 +604,9 @@ ports:
 	// Multus
 	multusVersion := EnvOr("MULTUS_VERSION", "v4.1.4")
 	Logf("Installing Multus %s...", multusVersion)
-	kubectl("apply", "-f", //nolint:errcheck
-		fmt.Sprintf("https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/%s/deployments/multus-daemonset-thick.yml", multusVersion))
-	kubectl("-n", "kube-system", "patch", "daemonset", "kube-multus-ds", "--type=json", //nolint:errcheck
-		`-p=[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"512Mi"},{"op":"replace","path":"/spec/template/spec/containers/0/resources/requests/memory","value":"512Mi"}]`)
+	if err := installMultus(kubectl, multusVersion); err != nil {
+		return err
+	}
 
 	// MetalLB (controller only, no speaker — kube-vip handles VIP BGP)
 	metallbVersion := EnvOr("METALLB_VERSION", "v0.14.9")
@@ -858,10 +872,9 @@ func PhaseCluster2Components(cluster *Cluster, repoRoot string) error {
 
 	// Multus
 	multusVersion := EnvOr("MULTUS_VERSION", "v4.1.4")
-	kubectl("apply", "-f", //nolint:errcheck
-		fmt.Sprintf("https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/%s/deployments/multus-daemonset-thick.yml", multusVersion))
-	kubectl("-n", "kube-system", "patch", "daemonset", "kube-multus-ds", "--type=json", //nolint:errcheck
-		`-p=[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"512Mi"},{"op":"replace","path":"/spec/template/spec/containers/0/resources/requests/memory","value":"512Mi"}]`)
+	if err := installMultus(kubectl, multusVersion); err != nil {
+		return err
+	}
 
 	// Operator + agents
 	if _, err := DockerExecShell(cp.Name, fmt.Sprintf(

--- a/e2e/setup/phases_test.go
+++ b/e2e/setup/phases_test.go
@@ -1,0 +1,43 @@
+package setup
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestInstallMultus(t *testing.T) {
+	wantURL := "https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.1.4/deployments/multus-daemonset-thick.yml"
+	for _, tt := range []struct {
+		name string
+		fail int
+	}{
+		{name: "success", fail: -1}, {name: "apply", fail: 0}, {name: "patch", fail: 1}, {name: "rollout", fail: 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var got [][]string
+			wantErr := errors.New("boom")
+			err := installMultus(func(args ...string) error {
+				got = append(got, args)
+				if len(got)-1 == tt.fail {
+					return wantErr
+				}
+				return nil
+			}, "v4.1.4")
+			if (tt.fail >= 0) != (err != nil) || tt.fail >= 0 && !errors.Is(err, wantErr) {
+				t.Fatalf("error = %v, want failure %d", err, tt.fail)
+			}
+			want := [][]string{
+				{"apply", "-f", wantURL},
+				{"-n", "kube-system", "patch", "daemonset", "kube-multus-ds", "--type=json", `-p=[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"512Mi"},{"op":"replace","path":"/spec/template/spec/containers/0/resources/requests/memory","value":"512Mi"}]`},
+				{"-n", "kube-system", "rollout", "status", "daemonset/kube-multus-ds", "--timeout=180s"},
+			}
+			if tt.fail >= 0 {
+				want = want[:tt.fail+1]
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("commands = %#v, want %#v", got, want)
+			}
+		})
+	}
+}

--- a/versions.env
+++ b/versions.env
@@ -1,0 +1,10 @@
+# Tool versions - single source of truth for local Makefile tool targets.
+# CI workflows pin tool versions directly in their own steps; see .github/workflows/.
+
+# Build tools
+KUSTOMIZE_VERSION=v5.8.0
+CONTROLLER_TOOLS_VERSION=v0.20.0
+ENVTEST_VERSION=v0.0.0-20260305142021-f9589b9f2b9d
+GOLANGCI_LINT_VERSION=v2.8.0
+GOVULNCHECK_VERSION=v1.1.4
+GO_LICENSES_VERSION=v1.6.0


### PR DESCRIPTION
## Summary
- add `versions.env` as the local Makefile tool-version source of truth
- modernize tool installation to versioned binaries with stable symlinks in `./bin`
- add `lint`, `lint-fix`, `lint-strict`, `vulncheck`, and `verify` targets
- keep the current controller-gen pin at `v0.20.0` after rebasing onto `main`
- evaluate the envtest asset path at recipe runtime so `make test` uses the `envtest` prerequisite after installation

## Validation
- `git diff --check`
- `make -n verify`

Part of cross-project alignment initiative.
