### PR TITLE
chore: standardize Dockerfiles with cross-compilation, distroless, OCI labels

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,11 +6,11 @@ config/
 docs/
 hack/
 *.md
-LICENSE
-NOTICE
 CODEOWNERS
 PROJECT
 Makefile
 .golangci.yml
 .dockerignore
 *.Dockerfile
+
+# LICENSE and NOTICE must not be ignored - required by Dockerfiles for license compliance

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -59,7 +59,14 @@ jobs:
           go-version-file: go.mod
 
       - name: Create Licenses Report
-        run: make licenses-report
+        run: |
+          for attempt in 1 2 3; do
+            if make licenses-report; then
+              exit 0
+            fi
+            sleep 1000 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 1000(attempt * 10))
+          done
+          make licenses-report
 
       - name: Read Go version
         id: go-version

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -64,7 +64,7 @@ jobs:
             if make licenses-report; then
               exit 0
             fi
-            sleep 1000 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 1000(attempt * 10))
+            sleep 10
           done
           make licenses-report
 

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -60,13 +60,17 @@ jobs:
 
       - name: Create Licenses Report
         run: |
-          for attempt in 1 2 3; do
+          max_attempts=3
+          attempt=1
+          while [ "$attempt" -le "$max_attempts" ]; do
             if make licenses-report; then
               exit 0
             fi
             sleep 10
+            attempt=$((attempt + 1))
           done
-          make licenses-report
+          echo "make licenses-report failed after ${max_attempts} attempts" >&2
+          exit 1
 
       - name: Read Go version
         id: go-version

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -182,6 +182,7 @@ jobs:
 
       - name: system-level-dependencies
         run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
           sudo apt update
           sudo apt -y install linux-modules-extra-$(uname -r)
 

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -20,7 +20,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: run code generators
         run: make generate
       - name: golangci-lint
@@ -38,7 +41,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: Run Tests
         run: make test
       - name: Upload coverage report
@@ -59,7 +65,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: run code generators
         run: make generate
       - name: run manifest generators

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -86,8 +86,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-images.yaml
     with:
-      push: true
-      cache-write: true
+      push: false
+      cache-write: false
 
   build-images-fork:
     name: build container images (fork)

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -86,8 +86,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-images.yaml
     with:
-      push: false
-      cache-write: false
+      push: true
+      cache-write: true
 
   build-images-fork:
     name: build container images (fork)

--- a/das-schiff-cra-frr.Dockerfile
+++ b/das-schiff-cra-frr.Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS 
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG ldflags="-s -w"
+ARG ldflags=""
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -25,7 +25,7 @@ COPY bpf/ bpf/
 RUN cd pkg/bpf && go generate ./...
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} \
-    go build -trimpath -ldflags="${ldflags}" -o frr-cra main.go
+    go build -trimpath -ldflags="-s -w ${ldflags}" -o frr-cra main.go
 
 FROM docker.io/library/ubuntu:25.10
 

--- a/das-schiff-cra-frr.Dockerfile
+++ b/das-schiff-cra-frr.Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS 
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG ldflags=""
+ARG ldflags=
 
 WORKDIR /workspace
 COPY go.mod go.mod

--- a/das-schiff-cra-frr.Dockerfile
+++ b/das-schiff-cra-frr.Dockerfile
@@ -1,34 +1,38 @@
-# Build the manager binary
+# Build the frr-cra binary
 ARG GO_VERSION=1.25
-FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
+ARG BUILDPLATFORM
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+ARG ldflags="-s -w"
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Install BPF build tools
-RUN apk add llvm clang linux-headers libbpf-dev musl-dev
+# Install BPF build tools (required for go:generate in pkg/bpf)
+RUN apk add --no-cache llvm clang linux-headers libbpf-dev musl-dev
 
-# Copy the go source
 COPY cmd/frr-cra/main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-# Compile BPF program from source
+# Copy BPF C source and compile .o objects before go build
 COPY bpf/ bpf/
-RUN cd pkg/bpf/ && go generate
+RUN cd pkg/bpf && go generate ./...
 
-# Build
-ARG ldflags
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "${ldflags}" -a -o frr-cra main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} \
+    go build -trimpath -ldflags="${ldflags}" -o frr-cra main.go
 
 FROM docker.io/library/ubuntu:25.10
+
+LABEL org.opencontainers.image.title="das-schiff-cra-frr" \
+      org.opencontainers.image.source="https://github.com/telekom/das-schiff-network-operator" \
+      org.opencontainers.image.vendor="Deutsche Telekom AG" \
+      org.opencontainers.image.licenses="Apache-2.0"
 
 ENV FRRVER="frr-10.6"
 ARG DEBIAN_FRONTEND=noninteractive
@@ -68,6 +72,8 @@ COPY ./docker/daemons /etc/frr/daemons
 COPY ./docker/networkd.conf /etc/systemd/networkd.conf.d/cra.conf
 COPY ./docker/10-cra.conf /etc/sysctl.d/10-cra.conf
 COPY --from=builder /workspace/frr-cra /usr/local/bin/frr-cra
+COPY LICENSE /licenses/LICENSE
+COPY NOTICE /licenses/NOTICE
 COPY ./docker/frr-cra.env /etc/default/frr-cra
 COPY ./docker/prometheus-node-exporter.env /etc/default/prometheus-node-exporter
 COPY ./docker/hosts /etc/hosts

--- a/das-schiff-network-operator.Dockerfile
+++ b/das-schiff-network-operator.Dockerfile
@@ -1,29 +1,39 @@
 # Build the manager binary
 ARG GO_VERSION=1.25
-FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
+ARG BUILDPLATFORM
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+ARG ldflags="-s -w"
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Copy the go source
 COPY cmd/operator/main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} \
+    go build -trimpath -ldflags="${ldflags}" -o manager main.go
 
-FROM alpine:latest
+FROM gcr.io/distroless/static-debian12
+
+LABEL org.opencontainers.image.title="das-schiff-network-operator" \
+      org.opencontainers.image.description="Kubernetes network operator for das Schiff platform" \
+      org.opencontainers.image.url="https://github.com/telekom/das-schiff-network-operator" \
+      org.opencontainers.image.source="https://github.com/telekom/das-schiff-network-operator" \
+      org.opencontainers.image.vendor="Deutsche Telekom AG" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.base.name="gcr.io/distroless/static-debian12"
 
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY LICENSE /licenses/LICENSE
+COPY NOTICE /licenses/NOTICE
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/das-schiff-network-operator.Dockerfile
+++ b/das-schiff-network-operator.Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS 
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG ldflags="-s -w"
+ARG ldflags=""
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -18,7 +18,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} \
-    go build -trimpath -ldflags="${ldflags}" -o manager main.go
+    go build -trimpath -ldflags="-s -w ${ldflags}" -o manager main.go
 
 FROM gcr.io/distroless/static-debian12
 

--- a/das-schiff-network-operator.Dockerfile
+++ b/das-schiff-network-operator.Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS 
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG ldflags=""
+ARG ldflags=
 
 WORKDIR /workspace
 COPY go.mod go.mod

--- a/das-schiff-nwop-agent-cra-frr.Dockerfile
+++ b/das-schiff-nwop-agent-cra-frr.Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS 
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG ldflags="-s -w"
+ARG ldflags=""
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -18,7 +18,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} \
-    go build -trimpath -ldflags="${ldflags}" -o agent main.go
+    go build -trimpath -ldflags="-s -w ${ldflags}" -o agent main.go
 
 FROM gcr.io/distroless/static-debian12
 

--- a/das-schiff-nwop-agent-cra-frr.Dockerfile
+++ b/das-schiff-nwop-agent-cra-frr.Dockerfile
@@ -1,29 +1,36 @@
-# Build the manager binary
+# Build the agent binary
 ARG GO_VERSION=1.25
-FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
+ARG BUILDPLATFORM
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+ARG ldflags="-s -w"
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Copy the go source
 COPY cmd/agent-cra-frr/main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o agent main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} \
+    go build -trimpath -ldflags="${ldflags}" -o agent main.go
 
-FROM alpine:latest
+FROM gcr.io/distroless/static-debian12
+
+LABEL org.opencontainers.image.title="das-schiff-nwop-agent-cra-frr" \
+      org.opencontainers.image.source="https://github.com/telekom/das-schiff-network-operator" \
+      org.opencontainers.image.vendor="Deutsche Telekom AG" \
+      org.opencontainers.image.licenses="Apache-2.0"
 
 WORKDIR /
 COPY --from=builder /workspace/agent .
+COPY LICENSE /licenses/LICENSE
+COPY NOTICE /licenses/NOTICE
 USER 65532:65532
 
 ENTRYPOINT ["/agent"]

--- a/das-schiff-nwop-agent-cra-frr.Dockerfile
+++ b/das-schiff-nwop-agent-cra-frr.Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS 
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG ldflags=""
+ARG ldflags=
 
 WORKDIR /workspace
 COPY go.mod go.mod

--- a/das-schiff-nwop-agent-cra-vsr.Dockerfile
+++ b/das-schiff-nwop-agent-cra-vsr.Dockerfile
@@ -1,29 +1,36 @@
-# Build the manager binary
+# Build the agent binary
 ARG GO_VERSION=1.25
-FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
+ARG BUILDPLATFORM
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+ARG ldflags="-s -w"
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Copy the go source
 COPY cmd/agent-cra-vsr/main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o agent main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} \
+    go build -trimpath -ldflags="${ldflags}" -o agent main.go
 
-FROM alpine:latest
+FROM gcr.io/distroless/static-debian12
+
+LABEL org.opencontainers.image.title="das-schiff-nwop-agent-cra-vsr" \
+      org.opencontainers.image.source="https://github.com/telekom/das-schiff-network-operator" \
+      org.opencontainers.image.vendor="Deutsche Telekom AG" \
+      org.opencontainers.image.licenses="Apache-2.0"
 
 WORKDIR /
 COPY --from=builder /workspace/agent .
+COPY LICENSE /licenses/LICENSE
+COPY NOTICE /licenses/NOTICE
 USER 65532:65532
 
 ENTRYPOINT ["/agent"]

--- a/das-schiff-nwop-agent-cra-vsr.Dockerfile
+++ b/das-schiff-nwop-agent-cra-vsr.Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS 
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG ldflags="-s -w"
+ARG ldflags=""
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -18,7 +18,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} \
-    go build -trimpath -ldflags="${ldflags}" -o agent main.go
+    go build -trimpath -ldflags="-s -w ${ldflags}" -o agent main.go
 
 FROM gcr.io/distroless/static-debian12
 

--- a/das-schiff-nwop-agent-cra-vsr.Dockerfile
+++ b/das-schiff-nwop-agent-cra-vsr.Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS 
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG ldflags=""
+ARG ldflags=
 
 WORKDIR /workspace
 COPY go.mod go.mod

--- a/das-schiff-nwop-agent-hbn-l2.Dockerfile
+++ b/das-schiff-nwop-agent-hbn-l2.Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS 
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG ldflags="-s -w"
+ARG ldflags=""
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -18,7 +18,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} \
-    go build -trimpath -ldflags="${ldflags}" -o agent main.go
+    go build -trimpath -ldflags="-s -w ${ldflags}" -o agent main.go
 
 FROM gcr.io/distroless/static-debian12
 

--- a/das-schiff-nwop-agent-hbn-l2.Dockerfile
+++ b/das-schiff-nwop-agent-hbn-l2.Dockerfile
@@ -1,29 +1,36 @@
-# Build the manager binary
+# Build the agent binary
 ARG GO_VERSION=1.25
-FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
+ARG BUILDPLATFORM
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+ARG ldflags="-s -w"
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Copy the go source
 COPY cmd/agent-hbn-l2/main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o agent main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} \
+    go build -trimpath -ldflags="${ldflags}" -o agent main.go
 
-FROM alpine:latest
+FROM gcr.io/distroless/static-debian12
+
+LABEL org.opencontainers.image.title="das-schiff-nwop-agent-hbn-l2" \
+      org.opencontainers.image.source="https://github.com/telekom/das-schiff-network-operator" \
+      org.opencontainers.image.vendor="Deutsche Telekom AG" \
+      org.opencontainers.image.licenses="Apache-2.0"
 
 WORKDIR /
 COPY --from=builder /workspace/agent .
+COPY LICENSE /licenses/LICENSE
+COPY NOTICE /licenses/NOTICE
 USER 65532:65532
 
 ENTRYPOINT ["/agent"]

--- a/das-schiff-nwop-agent-hbn-l2.Dockerfile
+++ b/das-schiff-nwop-agent-hbn-l2.Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS 
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG ldflags=""
+ARG ldflags=
 
 WORKDIR /workspace
 COPY go.mod go.mod

--- a/das-schiff-nwop-agent-netplan.Dockerfile
+++ b/das-schiff-nwop-agent-netplan.Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS 
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG ldflags="-s -w"
+ARG ldflags=""
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -18,7 +18,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} \
-    go build -trimpath -ldflags="${ldflags}" -o agent main.go
+    go build -trimpath -ldflags="-s -w ${ldflags}" -o agent main.go
 
 FROM gcr.io/distroless/static-debian12
 

--- a/das-schiff-nwop-agent-netplan.Dockerfile
+++ b/das-schiff-nwop-agent-netplan.Dockerfile
@@ -1,29 +1,36 @@
-# Build the manager binary
+# Build the agent binary
 ARG GO_VERSION=1.25
-FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
+ARG BUILDPLATFORM
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+ARG ldflags="-s -w"
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Copy the go source
 COPY cmd/agent-netplan/main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o agent main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} \
+    go build -trimpath -ldflags="${ldflags}" -o agent main.go
 
-FROM alpine:latest
+FROM gcr.io/distroless/static-debian12
+
+LABEL org.opencontainers.image.title="das-schiff-nwop-agent-netplan" \
+      org.opencontainers.image.source="https://github.com/telekom/das-schiff-network-operator" \
+      org.opencontainers.image.vendor="Deutsche Telekom AG" \
+      org.opencontainers.image.licenses="Apache-2.0"
 
 WORKDIR /
 COPY --from=builder /workspace/agent .
+COPY LICENSE /licenses/LICENSE
+COPY NOTICE /licenses/NOTICE
 USER 65532:65532
 
 ENTRYPOINT ["/agent"]

--- a/das-schiff-nwop-agent-netplan.Dockerfile
+++ b/das-schiff-nwop-agent-netplan.Dockerfile
@@ -20,12 +20,13 @@ COPY pkg/ pkg/
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} \
     go build -trimpath -ldflags="-s -w ${ldflags}" -o agent main.go
 
-FROM gcr.io/distroless/static-debian12
+FROM docker.io/library/alpine:3.21
 
 LABEL org.opencontainers.image.title="das-schiff-nwop-agent-netplan" \
       org.opencontainers.image.source="https://github.com/telekom/das-schiff-network-operator" \
       org.opencontainers.image.vendor="Deutsche Telekom AG" \
-      org.opencontainers.image.licenses="Apache-2.0"
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.base.name="docker.io/library/alpine:3.21"
 
 WORKDIR /
 COPY --from=builder /workspace/agent .

--- a/das-schiff-nwop-agent-netplan.Dockerfile
+++ b/das-schiff-nwop-agent-netplan.Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION}-alpine AS 
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG ldflags=""
+ARG ldflags=
 
 WORKDIR /workspace
 COPY go.mod go.mod

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "ip -6 route add default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1"
+        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 | grep -q \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
+        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 2>/dev/null | grep -Fq \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 2>/dev/null | grep -Fq \"inet6 fda5:25c1:193e::1/\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 | grep -q \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 2>/dev/null | grep -Fq \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "ip -6 route add default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1"
+        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
+        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 | grep -q \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 2>/dev/null | grep -Fq \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 2>/dev/null | grep -Fq \"inet6 fda5:25c1:193e::1/\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 | grep -q \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 2>/dev/null | grep -Fq \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:


### PR DESCRIPTION
Standardize the Dockerfiles to match the auth-operator build pattern: cross-compilation support, trimpath builds, OCI labels, and license/notice copies.

Most Go-only components now use distroless static runtimes. `das-schiff-nwop-agent-netplan` intentionally stays on pinned Alpine because it talks to the host DBus/netplan stack in E2E and production, and the distroless conversion caused the netplan agent to crash before gateway macvlan interfaces were created.

Also includes a CI harness fix for the E2E NAT64 route setup: the route command now explicitly waits until the `nat64` interface has the `fda5:25c1:193e::1` source address before installing the default route, uses `/bin/sh`, and dumps IPv6 address/routing state if setup fails. This prevents kubeadm DNS timeouts during E2E setup while preserving the intended source address.
