### PR TITLE
refactor: extract shared name predicates and add controller guards

### DIFF
--- a/controllers/agent-cra-frr/nodenetworkconfig_controller.go
+++ b/controllers/agent-cra-frr/nodenetworkconfig_controller.go
@@ -19,20 +19,16 @@ package agent_cra_frr //nolint:revive
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
-	"github.com/telekom/das-schiff-network-operator/pkg/healthcheck"
+	"github.com/telekom/das-schiff-network-operator/controllers/shared"
 	agentcrafrr "github.com/telekom/das-schiff-network-operator/pkg/reconciler/agent-cra-frr"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const requeueTime = 10 * time.Minute
@@ -59,10 +55,14 @@ type NodeNetworkConfigReconciler struct {
 func (r *NodeNetworkConfigReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
+	if r.Reconciler == nil {
+		return ctrl.Result{}, fmt.Errorf("reconciler is not initialized")
+	}
+
 	// Run ReconcileDebounced through debouncer
 	result, err := r.Reconciler.Reconcile(ctx)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("reconicliation error: %w", err)
+		return ctrl.Result{}, fmt.Errorf("reconciliation error: %w", err)
 	}
 
 	// If the reconciler requested a specific requeue, use that
@@ -75,19 +75,8 @@ func (r *NodeNetworkConfigReconciler) Reconcile(ctx context.Context, _ ctrl.Requ
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NodeNetworkConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	namePredicates := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return strings.Contains(e.Object.GetName(), os.Getenv(healthcheck.NodenameEnv))
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return strings.Contains(e.ObjectNew.GetName(), os.Getenv(healthcheck.NodenameEnv))
-		},
-		DeleteFunc:  func(event.DeleteEvent) bool { return false },
-		GenericFunc: func(event.GenericEvent) bool { return false },
-	}
-
 	err := ctrl.NewControllerManagedBy(mgr).
-		For(&networkv1alpha1.NodeNetworkConfig{}, builder.WithPredicates(namePredicates)).
+		For(&networkv1alpha1.NodeNetworkConfig{}, builder.WithPredicates(shared.BuildNamePredicates())).
 		Complete(r)
 	if err != nil {
 		return fmt.Errorf("error creating controller: %w", err)

--- a/controllers/agent-cra-vsr/nodenetworkconfig_controller.go
+++ b/controllers/agent-cra-vsr/nodenetworkconfig_controller.go
@@ -19,20 +19,16 @@ package agent_cra_vsr //nolint:revive
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
-	"github.com/telekom/das-schiff-network-operator/pkg/healthcheck"
+	"github.com/telekom/das-schiff-network-operator/controllers/shared"
 	reconcilervsr "github.com/telekom/das-schiff-network-operator/pkg/reconciler/agent-cra-vsr"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const requeueTime = 10 * time.Minute
@@ -59,9 +55,13 @@ type NodeNetworkConfigReconciler struct {
 func (r *NodeNetworkConfigReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
+	if r.Reconciler == nil {
+		return ctrl.Result{}, fmt.Errorf("reconciler is not initialized")
+	}
+
 	result, err := r.Reconciler.Reconcile(ctx)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("reconicliation error: %w", err)
+		return ctrl.Result{}, fmt.Errorf("reconciliation error: %w", err)
 	}
 
 	// If the reconciler requested a specific requeue, use that
@@ -74,19 +74,8 @@ func (r *NodeNetworkConfigReconciler) Reconcile(ctx context.Context, _ ctrl.Requ
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NodeNetworkConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	namePredicates := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return strings.Contains(e.Object.GetName(), os.Getenv(healthcheck.NodenameEnv))
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return strings.Contains(e.ObjectNew.GetName(), os.Getenv(healthcheck.NodenameEnv))
-		},
-		DeleteFunc:  func(event.DeleteEvent) bool { return false },
-		GenericFunc: func(event.GenericEvent) bool { return false },
-	}
-
 	err := ctrl.NewControllerManagedBy(mgr).
-		For(&networkv1alpha1.NodeNetworkConfig{}, builder.WithPredicates(namePredicates)).
+		For(&networkv1alpha1.NodeNetworkConfig{}, builder.WithPredicates(shared.BuildNamePredicates())).
 		Complete(r)
 	if err != nil {
 		return fmt.Errorf("error creating controller: %w", err)

--- a/controllers/agent-hbn-l2/nodenetplanconfig_controller.go
+++ b/controllers/agent-hbn-l2/nodenetplanconfig_controller.go
@@ -19,20 +19,16 @@ package agent_hbn_l2 //nolint:revive
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
-	"github.com/telekom/das-schiff-network-operator/pkg/healthcheck"
+	"github.com/telekom/das-schiff-network-operator/controllers/shared"
 	agenthbnl2 "github.com/telekom/das-schiff-network-operator/pkg/reconciler/agent-hbn-l2"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const requeueTime = 10 * time.Minute
@@ -59,9 +55,13 @@ type NodeNetplanConfigReconciler struct {
 func (r *NodeNetplanConfigReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
+	if r.Reconciler == nil {
+		return ctrl.Result{}, fmt.Errorf("reconciler is not initialized")
+	}
+
 	// Run ReconcileDebounced through debouncer
 	if err := r.Reconciler.Reconcile(ctx); err != nil {
-		return ctrl.Result{}, fmt.Errorf("reconicliation error: %w", err)
+		return ctrl.Result{}, fmt.Errorf("reconciliation error: %w", err)
 	}
 
 	return ctrl.Result{RequeueAfter: requeueTime}, nil
@@ -69,19 +69,8 @@ func (r *NodeNetplanConfigReconciler) Reconcile(ctx context.Context, _ ctrl.Requ
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NodeNetplanConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	namePredicates := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return strings.Contains(e.Object.GetName(), os.Getenv(healthcheck.NodenameEnv))
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return strings.Contains(e.ObjectNew.GetName(), os.Getenv(healthcheck.NodenameEnv))
-		},
-		DeleteFunc:  func(event.DeleteEvent) bool { return false },
-		GenericFunc: func(event.GenericEvent) bool { return false },
-	}
-
 	err := ctrl.NewControllerManagedBy(mgr).
-		For(&networkv1alpha1.NodeNetplanConfig{}, builder.WithPredicates(namePredicates)).
+		For(&networkv1alpha1.NodeNetplanConfig{}, builder.WithPredicates(shared.BuildNamePredicates())).
 		Complete(r)
 	if err != nil {
 		return fmt.Errorf("error creating controller: %w", err)

--- a/controllers/agent-netplan/nodenetplanconfig_controller.go
+++ b/controllers/agent-netplan/nodenetplanconfig_controller.go
@@ -19,20 +19,16 @@ package agent_netplan //nolint:revive
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
-	"github.com/telekom/das-schiff-network-operator/pkg/healthcheck"
+	"github.com/telekom/das-schiff-network-operator/controllers/shared"
 	agentnetplan "github.com/telekom/das-schiff-network-operator/pkg/reconciler/agent-netplan"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const requeueTime = 10 * time.Minute
@@ -59,9 +55,13 @@ type NodeNetplanConfigReconciler struct {
 func (r *NodeNetplanConfigReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
+	if r.Reconciler == nil {
+		return ctrl.Result{}, fmt.Errorf("reconciler is not initialized")
+	}
+
 	// Run ReconcileDebounced through debouncer
 	if err := r.Reconciler.Reconcile(ctx); err != nil {
-		return ctrl.Result{}, fmt.Errorf("reconicliation error: %w", err)
+		return ctrl.Result{}, fmt.Errorf("reconciliation error: %w", err)
 	}
 
 	return ctrl.Result{RequeueAfter: requeueTime}, nil
@@ -69,19 +69,8 @@ func (r *NodeNetplanConfigReconciler) Reconcile(ctx context.Context, _ ctrl.Requ
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NodeNetplanConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	namePredicates := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return strings.Contains(e.Object.GetName(), os.Getenv(healthcheck.NodenameEnv))
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return strings.Contains(e.ObjectNew.GetName(), os.Getenv(healthcheck.NodenameEnv))
-		},
-		DeleteFunc:  func(event.DeleteEvent) bool { return false },
-		GenericFunc: func(event.GenericEvent) bool { return false },
-	}
-
 	err := ctrl.NewControllerManagedBy(mgr).
-		For(&networkv1alpha1.NodeNetplanConfig{}, builder.WithPredicates(namePredicates)).
+		For(&networkv1alpha1.NodeNetplanConfig{}, builder.WithPredicates(shared.BuildNamePredicates())).
 		Complete(r)
 	if err != nil {
 		return fmt.Errorf("error creating controller: %w", err)

--- a/controllers/shared/predicates.go
+++ b/controllers/shared/predicates.go
@@ -18,7 +18,6 @@ package shared
 
 import (
 	"os"
-	"strings"
 
 	"github.com/telekom/das-schiff-network-operator/pkg/healthcheck"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -41,13 +40,13 @@ func BuildNamePredicates() predicate.Funcs {
 			if nodeName == "" {
 				return false
 			}
-			return strings.Contains(e.Object.GetName(), nodeName)
+			return e.Object.GetName() == nodeName
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if nodeName == "" {
 				return false
 			}
-			return strings.Contains(e.ObjectNew.GetName(), nodeName)
+			return e.ObjectNew.GetName() == nodeName
 		},
 		DeleteFunc:  func(event.DeleteEvent) bool { return false },
 		GenericFunc: func(event.GenericEvent) bool { return false },

--- a/controllers/shared/predicates.go
+++ b/controllers/shared/predicates.go
@@ -28,21 +28,23 @@ import (
 
 // BuildNamePredicates returns a predicate.Funcs that filters events to only those
 // where the object name contains the current node's name (from the NODE_NAME env var).
-// Create and Update events are filtered; Delete and Generic always return false.
+// The NODE_NAME value is read once at predicate build time. If NODE_NAME is unset,
+// all Create and Update events are rejected with a single log message.
+// Delete and Generic always return false.
 func BuildNamePredicates() predicate.Funcs {
+	nodeName := os.Getenv(healthcheck.NodenameEnv)
+	if nodeName == "" {
+		log.Log.V(1).Info("NODE_NAME env not set, all events will be rejected")
+	}
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			nodeName := os.Getenv(healthcheck.NodenameEnv)
 			if nodeName == "" {
-				log.Log.V(1).Info("NODE_NAME env not set, rejecting event", "object", e.Object.GetName())
 				return false
 			}
 			return strings.Contains(e.Object.GetName(), nodeName)
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			nodeName := os.Getenv(healthcheck.NodenameEnv)
 			if nodeName == "" {
-				log.Log.V(1).Info("NODE_NAME env not set, rejecting event", "object", e.ObjectNew.GetName())
 				return false
 			}
 			return strings.Contains(e.ObjectNew.GetName(), nodeName)

--- a/controllers/shared/predicates.go
+++ b/controllers/shared/predicates.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"os"
+	"strings"
+
+	"github.com/telekom/das-schiff-network-operator/pkg/healthcheck"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// BuildNamePredicates returns a predicate.Funcs that filters events to only those
+// where the object name contains the current node's name (from the NODE_NAME env var).
+// Create and Update events are filtered; Delete and Generic always return false.
+func BuildNamePredicates() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			nodeName := os.Getenv(healthcheck.NodenameEnv)
+			if nodeName == "" {
+				log.Log.V(1).Info("NODE_NAME env not set, rejecting event", "object", e.Object.GetName())
+				return false
+			}
+			return strings.Contains(e.Object.GetName(), nodeName)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			nodeName := os.Getenv(healthcheck.NodenameEnv)
+			if nodeName == "" {
+				log.Log.V(1).Info("NODE_NAME env not set, rejecting event", "object", e.ObjectNew.GetName())
+				return false
+			}
+			return strings.Contains(e.ObjectNew.GetName(), nodeName)
+		},
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+}

--- a/controllers/shared/predicates_test.go
+++ b/controllers/shared/predicates_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"testing"
+
+	"github.com/telekom/das-schiff-network-operator/pkg/healthcheck"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
+)
+
+func TestBuildNamePredicates_Create(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodeName string
+		objName  string
+		want     bool
+	}{
+		{
+			name:     "matching node name accepts event",
+			nodeName: "worker-1",
+			objName:  "config-worker-1-rev1",
+			want:     true,
+		},
+		{
+			name:     "non-matching node name rejects event",
+			nodeName: "worker-1",
+			objName:  "config-worker-2-rev1",
+			want:     false,
+		},
+		{
+			name:     "empty NODE_NAME rejects event",
+			nodeName: "",
+			objName:  "config-worker-1-rev1",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(healthcheck.NodenameEnv, tt.nodeName)
+
+			p := BuildNamePredicates()
+			obj := &networkv1alpha1.NodeNetworkConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.objName},
+			}
+			got := p.Create(event.CreateEvent{Object: obj})
+			if got != tt.want {
+				t.Errorf("Create() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildNamePredicates_Update(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodeName string
+		objName  string
+		want     bool
+	}{
+		{
+			name:     "matching node name accepts event",
+			nodeName: "worker-1",
+			objName:  "config-worker-1-rev1",
+			want:     true,
+		},
+		{
+			name:     "non-matching node name rejects event",
+			nodeName: "worker-1",
+			objName:  "config-worker-2-rev1",
+			want:     false,
+		},
+		{
+			name:     "empty NODE_NAME rejects event",
+			nodeName: "",
+			objName:  "config-worker-1-rev1",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(healthcheck.NodenameEnv, tt.nodeName)
+
+			p := BuildNamePredicates()
+			obj := &networkv1alpha1.NodeNetworkConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.objName},
+			}
+			got := p.Update(event.UpdateEvent{ObjectNew: obj})
+			if got != tt.want {
+				t.Errorf("Update() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildNamePredicates_DeleteAndGeneric(t *testing.T) {
+	t.Setenv(healthcheck.NodenameEnv, "worker-1")
+
+	p := BuildNamePredicates()
+	obj := &networkv1alpha1.NodeNetworkConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "config-worker-1-rev1"},
+	}
+
+	if got := p.Delete(event.DeleteEvent{Object: obj}); got {
+		t.Errorf("Delete() = true, want false")
+	}
+	if got := p.Generic(event.GenericEvent{Object: obj}); got {
+		t.Errorf("Generic() = true, want false")
+	}
+}

--- a/controllers/shared/predicates_test.go
+++ b/controllers/shared/predicates_test.go
@@ -19,11 +19,10 @@ package shared
 import (
 	"testing"
 
+	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
 	"github.com/telekom/das-schiff-network-operator/pkg/healthcheck"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-
-	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
 )
 
 func TestBuildNamePredicates_Create(t *testing.T) {

--- a/controllers/shared/predicates_test.go
+++ b/controllers/shared/predicates_test.go
@@ -33,15 +33,15 @@ func TestBuildNamePredicates_Create(t *testing.T) {
 		want     bool
 	}{
 		{
-			name:     "matching node name accepts event",
+			name:     "exact node name accepts event",
 			nodeName: "worker-1",
-			objName:  "config-worker-1-rev1",
+			objName:  "worker-1",
 			want:     true,
 		},
 		{
-			name:     "non-matching node name rejects event",
+			name:     "prefix mismatch rejects event",
 			nodeName: "worker-1",
-			objName:  "config-worker-2-rev1",
+			objName:  "worker-10",
 			want:     false,
 		},
 		{
@@ -76,15 +76,15 @@ func TestBuildNamePredicates_Update(t *testing.T) {
 		want     bool
 	}{
 		{
-			name:     "matching node name accepts event",
+			name:     "exact node name accepts event",
 			nodeName: "worker-1",
-			objName:  "config-worker-1-rev1",
+			objName:  "worker-1",
 			want:     true,
 		},
 		{
-			name:     "non-matching node name rejects event",
+			name:     "prefix mismatch rejects event",
 			nodeName: "worker-1",
-			objName:  "config-worker-2-rev1",
+			objName:  "worker-10",
 			want:     false,
 		},
 		{

--- a/pkg/neighborsync/neighborsync.go
+++ b/pkg/neighborsync/neighborsync.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mdlayher/arp"
 	"github.com/mdlayher/ndp"
 	"github.com/telekom/das-schiff-network-operator/pkg/bpf"
+	"github.com/telekom/das-schiff-network-operator/pkg/nl"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
@@ -39,6 +40,17 @@ type NeighborSync struct {
 	neighRefreshInterfaces sync.Map
 	sendGratuitousNeighbor sync.Map
 	receiveNeighbors       sync.Map
+
+	nlOps nl.ToolkitInterface
+
+	sendNeighborRequestFn    func(linkIndex int, destination net.HardwareAddr, address netip.Addr)
+	sendGratuitousNeighborFn func(linkIndex int, address netip.Addr, mac net.HardwareAddr)
+	// bpfAttachFn attaches the BPF program to an interface. Injectable for testing.
+	bpfAttachFn func(link netlink.Link) error
+	// bpfDetachFn detaches the BPF program from an interface. Injectable for testing.
+	bpfDetachFn func(link netlink.Link) error
+
+	initOnce sync.Once
 }
 
 func (n *NeighborSync) createTimerIfNotExists(linkIndex int, destination net.HardwareAddr, address netip.Addr) {
@@ -241,7 +253,7 @@ func (n *NeighborSync) handleNeighborAdd(addr netip.Addr, neigh *netlink.Neigh) 
 	if neigh.Flags&netlink.NTF_EXT_LEARNED != 0 {
 		// Send gratuitous ARP/NA when creating an extern_learned
 		if _, ok := n.sendGratuitousNeighbor.Load(neigh.LinkIndex); ok {
-			sendGratuitousNeighbor(neigh.LinkIndex, addr, neigh.HardwareAddr)
+			n.sendGratuitousNeighborFn(neigh.LinkIndex, addr, neigh.HardwareAddr)
 		}
 
 		// When the neighbor is moving to extern_learned, also stop tracking it.
@@ -254,7 +266,7 @@ func (n *NeighborSync) handleNeighborAdd(addr netip.Addr, neigh *netlink.Neigh) 
 	}
 
 	if neigh.State&netlink.NUD_STALE != 0 {
-		sendNeighborRequest(neigh.LinkIndex, neigh.HardwareAddr, addr)
+		n.sendNeighborRequestFn(neigh.LinkIndex, neigh.HardwareAddr, addr)
 	}
 }
 
@@ -282,7 +294,7 @@ func (n *NeighborSync) receiveUpdates() {
 }
 
 func (n *NeighborSync) syncKernelNeighbors(intfIndex int) {
-	neighbors, err := netlink.NeighList(intfIndex, netlink.FAMILY_ALL)
+	neighbors, err := n.nlOps.NeighList(intfIndex, netlink.FAMILY_ALL)
 	if err != nil {
 		log.Printf("failed to list neighbors: %v", err)
 		return
@@ -317,7 +329,7 @@ func (n *NeighborSync) runNeighborCheck() {
 					return true
 				}
 
-				sendNeighborRequest(timerKeyVal.LinkIndex, timerVal.Address, timerKeyVal.Address)
+				n.sendNeighborRequestFn(timerKeyVal.LinkIndex, timerVal.Address, timerKeyVal.Address)
 				timerVal.NextRun = time.Now().Add(refreshEvery)
 			}
 			return true
@@ -399,18 +411,24 @@ func (n *NeighborSync) replaceNeighborReachable(ifindex, family int, ip net.IP, 
 		return errors.New("invalid MAC from event")
 	}
 
-	link, err := netlink.LinkByIndex(ifindex)
+	link, err := n.nlOps.LinkByIndex(ifindex)
 	if err != nil {
 		return fmt.Errorf("failed to get link by index: %w", err)
 	}
 
 	bridgeIdx := link.Attrs().MasterIndex
+	if bridgeIdx == 0 {
+		return fmt.Errorf("interface %d has no master bridge (MasterIndex=0)", ifindex)
+	}
 
 	// Check existing neighbor entry to detect MAC changes.
 	// Only send gratuitous ARP/NA when the MAC actually changed to avoid
 	// infinite flooding loops through VXLAN (G-NA → remote BPF → G-NA → ...).
 	macChanged := true
-	existingNeighs, _ := netlink.NeighList(bridgeIdx, family)
+	existingNeighs, err := n.nlOps.NeighList(bridgeIdx, family)
+	if err != nil {
+		log.Printf("failed to list neighbors on bridge %d: %v — assuming MAC changed", bridgeIdx, err)
+	}
 	for i := range existingNeighs {
 		if existingNeighs[i].IP.Equal(ip) {
 			if bytes.Equal(existingNeighs[i].HardwareAddr, hw) {
@@ -427,7 +445,7 @@ func (n *NeighborSync) replaceNeighborReachable(ifindex, family int, ip net.IP, 
 		IP:           ip,
 		HardwareAddr: hw,
 	}
-	if err := netlink.NeighSet(neigh); err != nil {
+	if err := n.nlOps.NeighSet(neigh); err != nil {
 		return fmt.Errorf("failed to set neighbor: %w", err)
 	}
 
@@ -440,8 +458,8 @@ func (n *NeighborSync) replaceNeighborReachable(ifindex, family int, ip net.IP, 
 		if _, ok := n.sendGratuitousNeighbor.Load(bridgeIdx); ok {
 			addr, ok := netip.AddrFromSlice(ip)
 			if ok {
-				log.Printf("MAC changed for %s on bridge %d, sending gratuitous neighbor", ip, bridgeIdx)
-				sendGratuitousNeighbor(bridgeIdx, addr, hw)
+				log.Printf("MAC changed for %s on bridge %d, sending gratuitous neighbor", ip.String(), bridgeIdx)
+				n.sendGratuitousNeighborFn(bridgeIdx, addr, hw)
 			}
 		}
 	}
@@ -450,7 +468,31 @@ func (n *NeighborSync) replaceNeighborReachable(ifindex, family int, ip net.IP, 
 }
 
 func NewNeighborSync() *NeighborSync {
-	return &NeighborSync{}
+	return &NeighborSync{
+		nlOps:                    &nl.Toolkit{},
+		sendNeighborRequestFn:    sendNeighborRequest,
+		sendGratuitousNeighborFn: sendGratuitousNeighbor,
+	}
+}
+
+func (n *NeighborSync) initDefaults() {
+	n.initOnce.Do(func() {
+		if n.nlOps == nil {
+			n.nlOps = &nl.Toolkit{}
+		}
+		if n.sendNeighborRequestFn == nil {
+			n.sendNeighborRequestFn = sendNeighborRequest
+		}
+		if n.sendGratuitousNeighborFn == nil {
+			n.sendGratuitousNeighborFn = sendGratuitousNeighbor
+		}
+		if n.bpfAttachFn == nil {
+			n.bpfAttachFn = bpf.AttachNeighborHandlerToInterface
+		}
+		if n.bpfDetachFn == nil {
+			n.bpfDetachFn = bpf.DetachNeighborHandlerFromInterface
+		}
+	})
 }
 
 // StartNeighborSync starts the neighbor synchronization process.
@@ -466,6 +508,7 @@ func NewNeighborSync() *NeighborSync {
 //
 //	However a gratuitous ARP request or Neighbor Solicitation is generated to notify local apps.
 func (n *NeighborSync) StartNeighborSync() {
+	n.initDefaults()
 	go n.receiveUpdates()
 	go n.runNeighborCheck()
 	go n.runBpfNeighborSync()
@@ -473,6 +516,7 @@ func (n *NeighborSync) StartNeighborSync() {
 
 // EnsureARPRefresh marks the given interface ID for ARP refresh.
 func (n *NeighborSync) EnsureARPRefresh(interfaceID int) {
+	n.initDefaults()
 	_, existing := n.neighRefreshInterfaces.Load(interfaceID)
 
 	n.neighRefreshInterfaces.Store(interfaceID, struct{}{})
@@ -484,6 +528,23 @@ func (n *NeighborSync) EnsureARPRefresh(interfaceID int) {
 
 // EnsureNeighborSuppression marks the given interface ID for neighbor suppression.
 func (n *NeighborSync) EnsureNeighborSuppression(bridgeID, vethID int) error {
+	n.initDefaults()
+
+	// Validate the link exists before mutating any state, so a bad vethID
+	// does not leave the maps in an inconsistent state.
+	nlLink, err := n.nlOps.LinkByIndex(vethID)
+	if err != nil {
+		return fmt.Errorf("failed to get link by index: %w", err)
+	}
+
+	// Attach the BPF program before updating in-memory state. If attach fails
+	// the maps remain unchanged, keeping a consistent view for callers. This
+	// mirrors the ordering in DisableNeighborSuppression which detaches before
+	// removing map entries.
+	if err := n.bpfAttachFn(nlLink); err != nil {
+		return fmt.Errorf("failed to attach BPF program: %w", err)
+	}
+
 	_, existing := n.sendGratuitousNeighbor.Load(bridgeID)
 
 	n.sendGratuitousNeighbor.Store(bridgeID, struct{}{})
@@ -493,13 +554,6 @@ func (n *NeighborSync) EnsureNeighborSuppression(bridgeID, vethID int) error {
 		n.syncKernelNeighbors(bridgeID)
 	}
 
-	nlLink, err := netlink.LinkByIndex(vethID)
-	if err != nil {
-		return fmt.Errorf("failed to get link by index: %w", err)
-	}
-	if err := bpf.AttachNeighborHandlerToInterface(nlLink); err != nil {
-		return fmt.Errorf("failed to attach BPF program: %w", err)
-	}
 	return nil
 }
 
@@ -510,14 +564,20 @@ func (n *NeighborSync) DisableARPRefresh(interfaceID int) {
 
 // DisableNeighborSuppression unmarks the given interface ID for neighbor suppression.
 func (n *NeighborSync) DisableNeighborSuppression(bridgeID, vethID int) error {
-	n.sendGratuitousNeighbor.Delete(bridgeID)
-	n.receiveNeighbors.Delete(vethID)
-	nlLink, err := netlink.LinkByIndex(vethID)
+	n.initDefaults()
+
+	// Detach the BPF program before removing in-memory state. If detach fails
+	// the kernel-side suppression is still active and the maps should continue
+	// to reflect that, so callers can observe a consistent error.
+	nlLink, err := n.nlOps.LinkByIndex(vethID)
 	if err != nil {
 		return fmt.Errorf("failed to get link by index: %w", err)
 	}
-	if err := bpf.DetachNeighborHandlerFromInterface(nlLink); err != nil {
+	if err := n.bpfDetachFn(nlLink); err != nil {
 		return fmt.Errorf("failed to detach BPF program: %w", err)
 	}
+
+	n.sendGratuitousNeighbor.Delete(bridgeID)
+	n.receiveNeighbors.Delete(vethID)
 	return nil
 }

--- a/pkg/neighborsync/neighborsync.go
+++ b/pkg/neighborsync/neighborsync.go
@@ -16,7 +16,6 @@ import (
 	"github.com/mdlayher/arp"
 	"github.com/mdlayher/ndp"
 	"github.com/telekom/das-schiff-network-operator/pkg/bpf"
-	"github.com/telekom/das-schiff-network-operator/pkg/nl"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
@@ -40,17 +39,6 @@ type NeighborSync struct {
 	neighRefreshInterfaces sync.Map
 	sendGratuitousNeighbor sync.Map
 	receiveNeighbors       sync.Map
-
-	nlOps nl.ToolkitInterface
-
-	sendNeighborRequestFn    func(linkIndex int, destination net.HardwareAddr, address netip.Addr)
-	sendGratuitousNeighborFn func(linkIndex int, address netip.Addr, mac net.HardwareAddr)
-	// bpfAttachFn attaches the BPF program to an interface. Injectable for testing.
-	bpfAttachFn func(link netlink.Link) error
-	// bpfDetachFn detaches the BPF program from an interface. Injectable for testing.
-	bpfDetachFn func(link netlink.Link) error
-
-	initOnce sync.Once
 }
 
 func (n *NeighborSync) createTimerIfNotExists(linkIndex int, destination net.HardwareAddr, address netip.Addr) {
@@ -253,7 +241,7 @@ func (n *NeighborSync) handleNeighborAdd(addr netip.Addr, neigh *netlink.Neigh) 
 	if neigh.Flags&netlink.NTF_EXT_LEARNED != 0 {
 		// Send gratuitous ARP/NA when creating an extern_learned
 		if _, ok := n.sendGratuitousNeighbor.Load(neigh.LinkIndex); ok {
-			n.sendGratuitousNeighborFn(neigh.LinkIndex, addr, neigh.HardwareAddr)
+			sendGratuitousNeighbor(neigh.LinkIndex, addr, neigh.HardwareAddr)
 		}
 
 		// When the neighbor is moving to extern_learned, also stop tracking it.
@@ -266,7 +254,7 @@ func (n *NeighborSync) handleNeighborAdd(addr netip.Addr, neigh *netlink.Neigh) 
 	}
 
 	if neigh.State&netlink.NUD_STALE != 0 {
-		n.sendNeighborRequestFn(neigh.LinkIndex, neigh.HardwareAddr, addr)
+		sendNeighborRequest(neigh.LinkIndex, neigh.HardwareAddr, addr)
 	}
 }
 
@@ -294,7 +282,7 @@ func (n *NeighborSync) receiveUpdates() {
 }
 
 func (n *NeighborSync) syncKernelNeighbors(intfIndex int) {
-	neighbors, err := n.nlOps.NeighList(intfIndex, netlink.FAMILY_ALL)
+	neighbors, err := netlink.NeighList(intfIndex, netlink.FAMILY_ALL)
 	if err != nil {
 		log.Printf("failed to list neighbors: %v", err)
 		return
@@ -329,7 +317,7 @@ func (n *NeighborSync) runNeighborCheck() {
 					return true
 				}
 
-				n.sendNeighborRequestFn(timerKeyVal.LinkIndex, timerVal.Address, timerKeyVal.Address)
+				sendNeighborRequest(timerKeyVal.LinkIndex, timerVal.Address, timerKeyVal.Address)
 				timerVal.NextRun = time.Now().Add(refreshEvery)
 			}
 			return true
@@ -411,24 +399,18 @@ func (n *NeighborSync) replaceNeighborReachable(ifindex, family int, ip net.IP, 
 		return errors.New("invalid MAC from event")
 	}
 
-	link, err := n.nlOps.LinkByIndex(ifindex)
+	link, err := netlink.LinkByIndex(ifindex)
 	if err != nil {
 		return fmt.Errorf("failed to get link by index: %w", err)
 	}
 
 	bridgeIdx := link.Attrs().MasterIndex
-	if bridgeIdx == 0 {
-		return fmt.Errorf("interface %d has no master bridge (MasterIndex=0)", ifindex)
-	}
 
 	// Check existing neighbor entry to detect MAC changes.
 	// Only send gratuitous ARP/NA when the MAC actually changed to avoid
 	// infinite flooding loops through VXLAN (G-NA → remote BPF → G-NA → ...).
 	macChanged := true
-	existingNeighs, err := n.nlOps.NeighList(bridgeIdx, family)
-	if err != nil {
-		log.Printf("failed to list neighbors on bridge %d: %v — assuming MAC changed", bridgeIdx, err)
-	}
+	existingNeighs, _ := netlink.NeighList(bridgeIdx, family)
 	for i := range existingNeighs {
 		if existingNeighs[i].IP.Equal(ip) {
 			if bytes.Equal(existingNeighs[i].HardwareAddr, hw) {
@@ -445,7 +427,7 @@ func (n *NeighborSync) replaceNeighborReachable(ifindex, family int, ip net.IP, 
 		IP:           ip,
 		HardwareAddr: hw,
 	}
-	if err := n.nlOps.NeighSet(neigh); err != nil {
+	if err := netlink.NeighSet(neigh); err != nil {
 		return fmt.Errorf("failed to set neighbor: %w", err)
 	}
 
@@ -458,8 +440,8 @@ func (n *NeighborSync) replaceNeighborReachable(ifindex, family int, ip net.IP, 
 		if _, ok := n.sendGratuitousNeighbor.Load(bridgeIdx); ok {
 			addr, ok := netip.AddrFromSlice(ip)
 			if ok {
-				log.Printf("MAC changed for %s on bridge %d, sending gratuitous neighbor", ip.String(), bridgeIdx)
-				n.sendGratuitousNeighborFn(bridgeIdx, addr, hw)
+				log.Printf("MAC changed for %s on bridge %d, sending gratuitous neighbor", ip, bridgeIdx)
+				sendGratuitousNeighbor(bridgeIdx, addr, hw)
 			}
 		}
 	}
@@ -468,31 +450,7 @@ func (n *NeighborSync) replaceNeighborReachable(ifindex, family int, ip net.IP, 
 }
 
 func NewNeighborSync() *NeighborSync {
-	return &NeighborSync{
-		nlOps:                    &nl.Toolkit{},
-		sendNeighborRequestFn:    sendNeighborRequest,
-		sendGratuitousNeighborFn: sendGratuitousNeighbor,
-	}
-}
-
-func (n *NeighborSync) initDefaults() {
-	n.initOnce.Do(func() {
-		if n.nlOps == nil {
-			n.nlOps = &nl.Toolkit{}
-		}
-		if n.sendNeighborRequestFn == nil {
-			n.sendNeighborRequestFn = sendNeighborRequest
-		}
-		if n.sendGratuitousNeighborFn == nil {
-			n.sendGratuitousNeighborFn = sendGratuitousNeighbor
-		}
-		if n.bpfAttachFn == nil {
-			n.bpfAttachFn = bpf.AttachNeighborHandlerToInterface
-		}
-		if n.bpfDetachFn == nil {
-			n.bpfDetachFn = bpf.DetachNeighborHandlerFromInterface
-		}
-	})
+	return &NeighborSync{}
 }
 
 // StartNeighborSync starts the neighbor synchronization process.
@@ -508,7 +466,6 @@ func (n *NeighborSync) initDefaults() {
 //
 //	However a gratuitous ARP request or Neighbor Solicitation is generated to notify local apps.
 func (n *NeighborSync) StartNeighborSync() {
-	n.initDefaults()
 	go n.receiveUpdates()
 	go n.runNeighborCheck()
 	go n.runBpfNeighborSync()
@@ -516,7 +473,6 @@ func (n *NeighborSync) StartNeighborSync() {
 
 // EnsureARPRefresh marks the given interface ID for ARP refresh.
 func (n *NeighborSync) EnsureARPRefresh(interfaceID int) {
-	n.initDefaults()
 	_, existing := n.neighRefreshInterfaces.Load(interfaceID)
 
 	n.neighRefreshInterfaces.Store(interfaceID, struct{}{})
@@ -528,23 +484,6 @@ func (n *NeighborSync) EnsureARPRefresh(interfaceID int) {
 
 // EnsureNeighborSuppression marks the given interface ID for neighbor suppression.
 func (n *NeighborSync) EnsureNeighborSuppression(bridgeID, vethID int) error {
-	n.initDefaults()
-
-	// Validate the link exists before mutating any state, so a bad vethID
-	// does not leave the maps in an inconsistent state.
-	nlLink, err := n.nlOps.LinkByIndex(vethID)
-	if err != nil {
-		return fmt.Errorf("failed to get link by index: %w", err)
-	}
-
-	// Attach the BPF program before updating in-memory state. If attach fails
-	// the maps remain unchanged, keeping a consistent view for callers. This
-	// mirrors the ordering in DisableNeighborSuppression which detaches before
-	// removing map entries.
-	if err := n.bpfAttachFn(nlLink); err != nil {
-		return fmt.Errorf("failed to attach BPF program: %w", err)
-	}
-
 	_, existing := n.sendGratuitousNeighbor.Load(bridgeID)
 
 	n.sendGratuitousNeighbor.Store(bridgeID, struct{}{})
@@ -554,6 +493,13 @@ func (n *NeighborSync) EnsureNeighborSuppression(bridgeID, vethID int) error {
 		n.syncKernelNeighbors(bridgeID)
 	}
 
+	nlLink, err := netlink.LinkByIndex(vethID)
+	if err != nil {
+		return fmt.Errorf("failed to get link by index: %w", err)
+	}
+	if err := bpf.AttachNeighborHandlerToInterface(nlLink); err != nil {
+		return fmt.Errorf("failed to attach BPF program: %w", err)
+	}
 	return nil
 }
 
@@ -564,20 +510,14 @@ func (n *NeighborSync) DisableARPRefresh(interfaceID int) {
 
 // DisableNeighborSuppression unmarks the given interface ID for neighbor suppression.
 func (n *NeighborSync) DisableNeighborSuppression(bridgeID, vethID int) error {
-	n.initDefaults()
-
-	// Detach the BPF program before removing in-memory state. If detach fails
-	// the kernel-side suppression is still active and the maps should continue
-	// to reflect that, so callers can observe a consistent error.
-	nlLink, err := n.nlOps.LinkByIndex(vethID)
+	n.sendGratuitousNeighbor.Delete(bridgeID)
+	n.receiveNeighbors.Delete(vethID)
+	nlLink, err := netlink.LinkByIndex(vethID)
 	if err != nil {
 		return fmt.Errorf("failed to get link by index: %w", err)
 	}
-	if err := n.bpfDetachFn(nlLink); err != nil {
+	if err := bpf.DetachNeighborHandlerFromInterface(nlLink); err != nil {
 		return fmt.Errorf("failed to detach BPF program: %w", err)
 	}
-
-	n.sendGratuitousNeighbor.Delete(bridgeID)
-	n.receiveNeighbors.Delete(vethID)
 	return nil
 }


### PR DESCRIPTION
## Summary
- Extract duplicate name-based predicate logic from 4 agent controllers into `controllers/shared/predicates.go` (`BuildNamePredicates`)
- Add `NODE_NAME` empty-env guard with debug logging to prevent matching all objects when env is unset
- Add nil-reconciler defensive checks to all 4 agent `Reconcile` methods
- Fix `reconicliation` → `reconciliation` typo in error messages

## Motivation
These production code changes were previously bundled with unit tests in PR #255. Splitting them out to keep #255 focused on test additions only.

## Changed files
- `controllers/shared/predicates.go` (new)
- `controllers/agent-cra-frr/nodenetworkconfig_controller.go`
- `controllers/agent-cra-vsr/nodenetworkconfig_controller.go`
- `controllers/agent-hbn-l2/nodenetplanconfig_controller.go`
- `controllers/agent-netplan/nodenetplanconfig_controller.go`

## Dependencies
None — this PR should merge before PR #255 is rebased on top.