### PR TITLE
refactor: add dependency injection to NeighborSync for testability

### DIFF
--- a/pkg/neighborsync/neighborsync.go
+++ b/pkg/neighborsync/neighborsync.go
@@ -49,7 +49,7 @@ type NeighborSync struct {
 	bpfAttachFn func(link netlink.Link) error
 	// bpfDetachFn detaches the BPF program from an interface. Injectable for testing.
 	bpfDetachFn        func(link netlink.Link) error
-	neighSubscribeFn   func(updates chan netlink.NeighUpdate, done chan struct{}, options netlink.NeighSubscribeOptions) error
+	neighSubscribeFn   func(updates chan<- netlink.NeighUpdate, done <-chan struct{}, options netlink.NeighSubscribeOptions) error
 	newRingbufReaderFn func() (*ringbuf.Reader, error)
 
 	initOnce sync.Once

--- a/pkg/neighborsync/neighborsync.go
+++ b/pkg/neighborsync/neighborsync.go
@@ -538,6 +538,10 @@ func (n *NeighborSync) EnsureARPRefresh(interfaceID int) {
 func (n *NeighborSync) EnsureNeighborSuppression(bridgeID, vethID int) error {
 	n.initDefaults()
 
+	if _, alreadyTracked := n.receiveNeighbors.Load(vethID); alreadyTracked {
+		return nil
+	}
+
 	// Validate the link exists before mutating any state, so a bad vethID
 	// does not leave the maps in an inconsistent state.
 	nlLink, err := n.nlOps.LinkByIndex(vethID)
@@ -554,7 +558,7 @@ func (n *NeighborSync) EnsureNeighborSuppression(bridgeID, vethID int) error {
 	}
 
 	_, existing := n.sendGratuitousNeighbor.LoadOrStore(bridgeID, struct{}{})
-	n.receiveNeighbors.LoadOrStore(vethID, struct{}{})
+	n.receiveNeighbors.Store(vethID, struct{}{})
 
 	if !existing {
 		n.syncKernelNeighbors(bridgeID)

--- a/pkg/neighborsync/neighborsync.go
+++ b/pkg/neighborsync/neighborsync.go
@@ -579,11 +579,18 @@ func (n *NeighborSync) DisableNeighborSuppression(bridgeID, vethID int) error {
 	// Detach the BPF program before removing in-memory state. If detach fails
 	// the kernel-side suppression is still active and the maps should continue
 	// to reflect that, so callers can observe a consistent error.
+	//
+	// A "link not found" error from LinkByIndex means the veth has already been
+	// deleted; there is nothing left to detach, so proceed to clear in-memory
+	// state to avoid leaking stale suppression entries.
 	nlLink, err := n.nlOps.LinkByIndex(vethID)
 	if err != nil {
-		return fmt.Errorf("failed to get link by index: %w", err)
-	}
-	if err := n.bpfDetachFn(nlLink); err != nil {
+		var notFoundErr netlink.LinkNotFoundError
+		if !errors.As(err, &notFoundErr) {
+			return fmt.Errorf("failed to get link by index: %w", err)
+		}
+		// Veth already gone — no BPF to detach; fall through to clear maps.
+	} else if err := n.bpfDetachFn(nlLink); err != nil {
 		var notFoundErr netlink.LinkNotFoundError
 		if !errors.As(err, &notFoundErr) {
 			return fmt.Errorf("failed to detach BPF program: %w", err)

--- a/pkg/neighborsync/neighborsync.go
+++ b/pkg/neighborsync/neighborsync.go
@@ -417,6 +417,9 @@ func (n *NeighborSync) replaceNeighborReachable(ifindex, family int, ip net.IP, 
 	}
 
 	bridgeIdx := link.Attrs().MasterIndex
+	if bridgeIdx == 0 {
+		return fmt.Errorf("interface %d has no master bridge (MasterIndex=0)", ifindex)
+	}
 
 	// Check existing neighbor entry to detect MAC changes.
 	// Only send gratuitous ARP/NA when the MAC actually changed to avoid

--- a/pkg/neighborsync/neighborsync.go
+++ b/pkg/neighborsync/neighborsync.go
@@ -537,6 +537,14 @@ func (n *NeighborSync) EnsureNeighborSuppression(bridgeID, vethID int) error {
 		return fmt.Errorf("failed to get link by index: %w", err)
 	}
 
+	// Attach the BPF program before updating in-memory state. If attach fails
+	// the maps remain unchanged, keeping a consistent view for callers. This
+	// mirrors the ordering in DisableNeighborSuppression which detaches before
+	// removing map entries.
+	if err := n.bpfAttachFn(nlLink); err != nil {
+		return fmt.Errorf("failed to attach BPF program: %w", err)
+	}
+
 	_, existing := n.sendGratuitousNeighbor.Load(bridgeID)
 
 	n.sendGratuitousNeighbor.Store(bridgeID, struct{}{})
@@ -546,9 +554,6 @@ func (n *NeighborSync) EnsureNeighborSuppression(bridgeID, vethID int) error {
 		n.syncKernelNeighbors(bridgeID)
 	}
 
-	if err := n.bpfAttachFn(nlLink); err != nil {
-		return fmt.Errorf("failed to attach BPF program: %w", err)
-	}
 	return nil
 }
 

--- a/pkg/neighborsync/neighborsync.go
+++ b/pkg/neighborsync/neighborsync.go
@@ -48,7 +48,9 @@ type NeighborSync struct {
 	// bpfAttachFn attaches the BPF program to an interface. Injectable for testing.
 	bpfAttachFn func(link netlink.Link) error
 	// bpfDetachFn detaches the BPF program from an interface. Injectable for testing.
-	bpfDetachFn func(link netlink.Link) error
+	bpfDetachFn        func(link netlink.Link) error
+	neighSubscribeFn   func(updates chan netlink.NeighUpdate, done chan struct{}, options netlink.NeighSubscribeOptions) error
+	newRingbufReaderFn func() (*ringbuf.Reader, error)
 
 	initOnce sync.Once
 }
@@ -278,7 +280,7 @@ func (n *NeighborSync) receiveUpdates() {
 	for {
 		updates := make(chan netlink.NeighUpdate)
 		done := make(chan struct{})
-		err := netlink.NeighSubscribeWithOptions(updates, done, netlink.NeighSubscribeOptions{ListExisting: true})
+		err := n.neighSubscribeFn(updates, done, netlink.NeighSubscribeOptions{ListExisting: true})
 		if err != nil {
 			log.Printf("failed to subscribe to neighbor updates: %v", err)
 			break
@@ -342,7 +344,7 @@ func (n *NeighborSync) runNeighborCheck() {
 
 func (n *NeighborSync) runBpfNeighborSync() {
 	log.Println("BPF ringbuf reader goroutine started")
-	rd, err := ringbuf.NewReader(bpf.EbpfNeighborRingbuf())
+	rd, err := n.newRingbufReaderFn()
 	if err != nil {
 		log.Printf("failed to open ringbuf reader: %v", err)
 		return
@@ -492,6 +494,12 @@ func (n *NeighborSync) initDefaults() {
 		if n.bpfDetachFn == nil {
 			n.bpfDetachFn = bpf.DetachNeighborHandlerFromInterface
 		}
+		if n.neighSubscribeFn == nil {
+			n.neighSubscribeFn = netlink.NeighSubscribeWithOptions
+		}
+		if n.newRingbufReaderFn == nil {
+			n.newRingbufReaderFn = func() (*ringbuf.Reader, error) { return ringbuf.NewReader(bpf.EbpfNeighborRingbuf()) }
+		}
 	})
 }
 
@@ -545,10 +553,8 @@ func (n *NeighborSync) EnsureNeighborSuppression(bridgeID, vethID int) error {
 		return fmt.Errorf("failed to attach BPF program: %w", err)
 	}
 
-	_, existing := n.sendGratuitousNeighbor.Load(bridgeID)
-
-	n.sendGratuitousNeighbor.Store(bridgeID, struct{}{})
-	n.receiveNeighbors.Store(vethID, struct{}{})
+	_, existing := n.sendGratuitousNeighbor.LoadOrStore(bridgeID, struct{}{})
+	n.receiveNeighbors.LoadOrStore(vethID, struct{}{})
 
 	if !existing {
 		n.syncKernelNeighbors(bridgeID)
@@ -574,7 +580,10 @@ func (n *NeighborSync) DisableNeighborSuppression(bridgeID, vethID int) error {
 		return fmt.Errorf("failed to get link by index: %w", err)
 	}
 	if err := n.bpfDetachFn(nlLink); err != nil {
-		return fmt.Errorf("failed to detach BPF program: %w", err)
+		var notFoundErr netlink.LinkNotFoundError
+		if !errors.As(err, &notFoundErr) {
+			return fmt.Errorf("failed to detach BPF program: %w", err)
+		}
 	}
 
 	n.sendGratuitousNeighbor.Delete(bridgeID)

--- a/pkg/neighborsync/neighborsync.go
+++ b/pkg/neighborsync/neighborsync.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mdlayher/arp"
 	"github.com/mdlayher/ndp"
 	"github.com/telekom/das-schiff-network-operator/pkg/bpf"
+	"github.com/telekom/das-schiff-network-operator/pkg/nl"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
@@ -39,6 +40,17 @@ type NeighborSync struct {
 	neighRefreshInterfaces sync.Map
 	sendGratuitousNeighbor sync.Map
 	receiveNeighbors       sync.Map
+
+	nlOps nl.ToolkitInterface
+
+	sendNeighborRequestFn    func(linkIndex int, destination net.HardwareAddr, address netip.Addr)
+	sendGratuitousNeighborFn func(linkIndex int, address netip.Addr, mac net.HardwareAddr)
+	// bpfAttachFn attaches the BPF program to an interface. Injectable for testing.
+	bpfAttachFn func(link netlink.Link) error
+	// bpfDetachFn detaches the BPF program from an interface. Injectable for testing.
+	bpfDetachFn func(link netlink.Link) error
+
+	initOnce sync.Once
 }
 
 func (n *NeighborSync) createTimerIfNotExists(linkIndex int, destination net.HardwareAddr, address netip.Addr) {
@@ -241,7 +253,7 @@ func (n *NeighborSync) handleNeighborAdd(addr netip.Addr, neigh *netlink.Neigh) 
 	if neigh.Flags&netlink.NTF_EXT_LEARNED != 0 {
 		// Send gratuitous ARP/NA when creating an extern_learned
 		if _, ok := n.sendGratuitousNeighbor.Load(neigh.LinkIndex); ok {
-			sendGratuitousNeighbor(neigh.LinkIndex, addr, neigh.HardwareAddr)
+			n.sendGratuitousNeighborFn(neigh.LinkIndex, addr, neigh.HardwareAddr)
 		}
 
 		// When the neighbor is moving to extern_learned, also stop tracking it.
@@ -254,7 +266,7 @@ func (n *NeighborSync) handleNeighborAdd(addr netip.Addr, neigh *netlink.Neigh) 
 	}
 
 	if neigh.State&netlink.NUD_STALE != 0 {
-		sendNeighborRequest(neigh.LinkIndex, neigh.HardwareAddr, addr)
+		n.sendNeighborRequestFn(neigh.LinkIndex, neigh.HardwareAddr, addr)
 	}
 }
 
@@ -282,7 +294,7 @@ func (n *NeighborSync) receiveUpdates() {
 }
 
 func (n *NeighborSync) syncKernelNeighbors(intfIndex int) {
-	neighbors, err := netlink.NeighList(intfIndex, netlink.FAMILY_ALL)
+	neighbors, err := n.nlOps.NeighList(intfIndex, netlink.FAMILY_ALL)
 	if err != nil {
 		log.Printf("failed to list neighbors: %v", err)
 		return
@@ -317,7 +329,7 @@ func (n *NeighborSync) runNeighborCheck() {
 					return true
 				}
 
-				sendNeighborRequest(timerKeyVal.LinkIndex, timerVal.Address, timerKeyVal.Address)
+				n.sendNeighborRequestFn(timerKeyVal.LinkIndex, timerVal.Address, timerKeyVal.Address)
 				timerVal.NextRun = time.Now().Add(refreshEvery)
 			}
 			return true
@@ -399,7 +411,7 @@ func (n *NeighborSync) replaceNeighborReachable(ifindex, family int, ip net.IP, 
 		return errors.New("invalid MAC from event")
 	}
 
-	link, err := netlink.LinkByIndex(ifindex)
+	link, err := n.nlOps.LinkByIndex(ifindex)
 	if err != nil {
 		return fmt.Errorf("failed to get link by index: %w", err)
 	}
@@ -410,7 +422,10 @@ func (n *NeighborSync) replaceNeighborReachable(ifindex, family int, ip net.IP, 
 	// Only send gratuitous ARP/NA when the MAC actually changed to avoid
 	// infinite flooding loops through VXLAN (G-NA → remote BPF → G-NA → ...).
 	macChanged := true
-	existingNeighs, _ := netlink.NeighList(bridgeIdx, family)
+	existingNeighs, err := n.nlOps.NeighList(bridgeIdx, family)
+	if err != nil {
+		log.Printf("failed to list neighbors on bridge %d: %v — assuming MAC changed", bridgeIdx, err)
+	}
 	for i := range existingNeighs {
 		if existingNeighs[i].IP.Equal(ip) {
 			if bytes.Equal(existingNeighs[i].HardwareAddr, hw) {
@@ -427,7 +442,7 @@ func (n *NeighborSync) replaceNeighborReachable(ifindex, family int, ip net.IP, 
 		IP:           ip,
 		HardwareAddr: hw,
 	}
-	if err := netlink.NeighSet(neigh); err != nil {
+	if err := n.nlOps.NeighSet(neigh); err != nil {
 		return fmt.Errorf("failed to set neighbor: %w", err)
 	}
 
@@ -440,8 +455,8 @@ func (n *NeighborSync) replaceNeighborReachable(ifindex, family int, ip net.IP, 
 		if _, ok := n.sendGratuitousNeighbor.Load(bridgeIdx); ok {
 			addr, ok := netip.AddrFromSlice(ip)
 			if ok {
-				log.Printf("MAC changed for %s on bridge %d, sending gratuitous neighbor", ip, bridgeIdx)
-				sendGratuitousNeighbor(bridgeIdx, addr, hw)
+				log.Printf("MAC changed for %s on bridge %d, sending gratuitous neighbor", ip.String(), bridgeIdx)
+				n.sendGratuitousNeighborFn(bridgeIdx, addr, hw)
 			}
 		}
 	}
@@ -450,7 +465,31 @@ func (n *NeighborSync) replaceNeighborReachable(ifindex, family int, ip net.IP, 
 }
 
 func NewNeighborSync() *NeighborSync {
-	return &NeighborSync{}
+	return &NeighborSync{
+		nlOps:                    &nl.Toolkit{},
+		sendNeighborRequestFn:    sendNeighborRequest,
+		sendGratuitousNeighborFn: sendGratuitousNeighbor,
+	}
+}
+
+func (n *NeighborSync) initDefaults() {
+	n.initOnce.Do(func() {
+		if n.nlOps == nil {
+			n.nlOps = &nl.Toolkit{}
+		}
+		if n.sendNeighborRequestFn == nil {
+			n.sendNeighborRequestFn = sendNeighborRequest
+		}
+		if n.sendGratuitousNeighborFn == nil {
+			n.sendGratuitousNeighborFn = sendGratuitousNeighbor
+		}
+		if n.bpfAttachFn == nil {
+			n.bpfAttachFn = bpf.AttachNeighborHandlerToInterface
+		}
+		if n.bpfDetachFn == nil {
+			n.bpfDetachFn = bpf.DetachNeighborHandlerFromInterface
+		}
+	})
 }
 
 // StartNeighborSync starts the neighbor synchronization process.
@@ -466,6 +505,7 @@ func NewNeighborSync() *NeighborSync {
 //
 //	However a gratuitous ARP request or Neighbor Solicitation is generated to notify local apps.
 func (n *NeighborSync) StartNeighborSync() {
+	n.initDefaults()
 	go n.receiveUpdates()
 	go n.runNeighborCheck()
 	go n.runBpfNeighborSync()
@@ -473,6 +513,7 @@ func (n *NeighborSync) StartNeighborSync() {
 
 // EnsureARPRefresh marks the given interface ID for ARP refresh.
 func (n *NeighborSync) EnsureARPRefresh(interfaceID int) {
+	n.initDefaults()
 	_, existing := n.neighRefreshInterfaces.Load(interfaceID)
 
 	n.neighRefreshInterfaces.Store(interfaceID, struct{}{})
@@ -484,6 +525,15 @@ func (n *NeighborSync) EnsureARPRefresh(interfaceID int) {
 
 // EnsureNeighborSuppression marks the given interface ID for neighbor suppression.
 func (n *NeighborSync) EnsureNeighborSuppression(bridgeID, vethID int) error {
+	n.initDefaults()
+
+	// Validate the link exists before mutating any state, so a bad vethID
+	// does not leave the maps in an inconsistent state.
+	nlLink, err := n.nlOps.LinkByIndex(vethID)
+	if err != nil {
+		return fmt.Errorf("failed to get link by index: %w", err)
+	}
+
 	_, existing := n.sendGratuitousNeighbor.Load(bridgeID)
 
 	n.sendGratuitousNeighbor.Store(bridgeID, struct{}{})
@@ -493,11 +543,7 @@ func (n *NeighborSync) EnsureNeighborSuppression(bridgeID, vethID int) error {
 		n.syncKernelNeighbors(bridgeID)
 	}
 
-	nlLink, err := netlink.LinkByIndex(vethID)
-	if err != nil {
-		return fmt.Errorf("failed to get link by index: %w", err)
-	}
-	if err := bpf.AttachNeighborHandlerToInterface(nlLink); err != nil {
+	if err := n.bpfAttachFn(nlLink); err != nil {
 		return fmt.Errorf("failed to attach BPF program: %w", err)
 	}
 	return nil
@@ -510,14 +556,20 @@ func (n *NeighborSync) DisableARPRefresh(interfaceID int) {
 
 // DisableNeighborSuppression unmarks the given interface ID for neighbor suppression.
 func (n *NeighborSync) DisableNeighborSuppression(bridgeID, vethID int) error {
-	n.sendGratuitousNeighbor.Delete(bridgeID)
-	n.receiveNeighbors.Delete(vethID)
-	nlLink, err := netlink.LinkByIndex(vethID)
+	n.initDefaults()
+
+	// Detach the BPF program before removing in-memory state. If detach fails
+	// the kernel-side suppression is still active and the maps should continue
+	// to reflect that, so callers can observe a consistent error.
+	nlLink, err := n.nlOps.LinkByIndex(vethID)
 	if err != nil {
 		return fmt.Errorf("failed to get link by index: %w", err)
 	}
-	if err := bpf.DetachNeighborHandlerFromInterface(nlLink); err != nil {
+	if err := n.bpfDetachFn(nlLink); err != nil {
 		return fmt.Errorf("failed to detach BPF program: %w", err)
 	}
+
+	n.sendGratuitousNeighbor.Delete(bridgeID)
+	n.receiveNeighbors.Delete(vethID)
 	return nil
 }

--- a/pkg/neighborsync/neighborsync_test.go
+++ b/pkg/neighborsync/neighborsync_test.go
@@ -186,3 +186,78 @@ var _ = Describe("EnsureNeighborSuppression", func() {
 		Expect(gratuitous).To(BeFalse())
 	})
 })
+
+var _ = Describe("DisableNeighborSuppression", func() {
+	var ns *NeighborSync
+	var fakeLink netlink.Link
+
+	BeforeEach(func() {
+		fakeLink = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Index: 10, MasterIndex: 20}}
+
+		ns = &NeighborSync{
+			nlOps:                    mockNlOps,
+			sendNeighborRequestFn:    noopSendNeighborRequest,
+			sendGratuitousNeighborFn: noopSendGratuitous,
+			bpfAttachFn:              func(_ netlink.Link) error { return nil },
+			bpfDetachFn:              func(_ netlink.Link) error { return nil },
+		}
+		ns.initOnce = sync.Once{}
+	})
+
+	It("clears in-memory maps on success", func() {
+		mockNlOps.EXPECT().LinkByIndex(10).Return(fakeLink, nil).Times(1)
+		ns.sendGratuitousNeighbor.Store(20, struct{}{})
+		ns.receiveNeighbors.Store(10, struct{}{})
+
+		err := ns.DisableNeighborSuppression(20, 10)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, tracked := ns.receiveNeighbors.Load(10)
+		Expect(tracked).To(BeFalse())
+		_, gratuitous := ns.sendGratuitousNeighbor.Load(20)
+		Expect(gratuitous).To(BeFalse())
+	})
+
+	It("returns error when LinkByIndex fails with a non-not-found error", func() {
+		mockNlOps.EXPECT().LinkByIndex(10).Return(nil, errors.New("netlink io error")).Times(1)
+		ns.sendGratuitousNeighbor.Store(20, struct{}{})
+		ns.receiveNeighbors.Store(10, struct{}{})
+
+		err := ns.DisableNeighborSuppression(20, 10)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to get link by index"))
+
+		_, tracked := ns.receiveNeighbors.Load(10)
+		Expect(tracked).To(BeTrue())
+	})
+
+	It("treats LinkByIndex link-not-found as benign and clears in-memory maps", func() {
+		mockNlOps.EXPECT().LinkByIndex(10).Return(nil, netlink.LinkNotFoundError{}).Times(1)
+		ns.sendGratuitousNeighbor.Store(20, struct{}{})
+		ns.receiveNeighbors.Store(10, struct{}{})
+
+		err := ns.DisableNeighborSuppression(20, 10)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, tracked := ns.receiveNeighbors.Load(10)
+		Expect(tracked).To(BeFalse())
+		_, gratuitous := ns.sendGratuitousNeighbor.Load(20)
+		Expect(gratuitous).To(BeFalse())
+	})
+
+	It("returns error when bpfDetachFn fails with non-not-found error", func() {
+		ns.bpfDetachFn = func(_ netlink.Link) error {
+			return errors.New("bpf detach failed")
+		}
+		mockNlOps.EXPECT().LinkByIndex(10).Return(fakeLink, nil).Times(1)
+		ns.sendGratuitousNeighbor.Store(20, struct{}{})
+		ns.receiveNeighbors.Store(10, struct{}{})
+
+		err := ns.DisableNeighborSuppression(20, 10)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to detach BPF program"))
+
+		_, tracked := ns.receiveNeighbors.Load(10)
+		Expect(tracked).To(BeTrue())
+	})
+})

--- a/pkg/neighborsync/neighborsync_test.go
+++ b/pkg/neighborsync/neighborsync_test.go
@@ -1,0 +1,188 @@
+package neighborsync
+
+import (
+	"errors"
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+
+	"github.com/cilium/ebpf/ringbuf"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	mock_nl "github.com/telekom/das-schiff-network-operator/pkg/nl/mock"
+	"github.com/vishvananda/netlink"
+	"go.uber.org/mock/gomock"
+)
+
+var (
+	mockCtrl  *gomock.Controller
+	mockNlOps *mock_nl.MockToolkitInterface
+)
+
+func TestNeighborSync(t *testing.T) {
+	RegisterFailHandler(Fail)
+	mockCtrl = gomock.NewController(t)
+	defer mockCtrl.Finish()
+	RunSpecs(t, "NeighborSync Suite")
+}
+
+var _ = BeforeSuite(func() {
+	mockNlOps = mock_nl.NewMockToolkitInterface(mockCtrl)
+})
+
+func noopSendNeighborRequest(_ int, _ net.HardwareAddr, _ netip.Addr) {}
+func noopSendGratuitous(_ int, _ netip.Addr, _ net.HardwareAddr)      {}
+
+var _ = Describe("neighSubscribeFn DI hook", func() {
+	var ns *NeighborSync
+	var subscribeCalled bool
+
+	BeforeEach(func() {
+		subscribeCalled = false
+		ns = &NeighborSync{
+			nlOps:                    mockNlOps,
+			sendNeighborRequestFn:    noopSendNeighborRequest,
+			sendGratuitousNeighborFn: noopSendGratuitous,
+		}
+	})
+
+	It("calls neighSubscribeFn with ListExisting=true and correct channel directions", func() {
+		ns.neighSubscribeFn = func(_ chan<- netlink.NeighUpdate, _ <-chan struct{}, opts netlink.NeighSubscribeOptions) error {
+			subscribeCalled = true
+			Expect(opts.ListExisting).To(BeTrue())
+			// Return an error to stop the receiveUpdates loop after verifying options.
+			return errors.New("stop")
+		}
+
+		done := make(chan struct{})
+		go func() {
+			ns.receiveUpdates()
+			close(done)
+		}()
+
+		Eventually(func() bool { return subscribeCalled }, "2s").Should(BeTrue())
+		Eventually(done, "2s").Should(BeClosed())
+	})
+
+	It("stops receiveUpdates loop when neighSubscribeFn returns an error", func() {
+		callCount := 0
+		ns.neighSubscribeFn = func(_ chan<- netlink.NeighUpdate, _ <-chan struct{}, _ netlink.NeighSubscribeOptions) error {
+			callCount++
+			return errors.New("subscribe failed")
+		}
+
+		done := make(chan struct{})
+		go func() {
+			ns.receiveUpdates()
+			close(done)
+		}()
+
+		Eventually(done, "2s").Should(BeClosed())
+		Expect(callCount).To(Equal(1))
+	})
+})
+
+var _ = Describe("newRingbufReaderFn DI hook", func() {
+	var ns *NeighborSync
+
+	BeforeEach(func() {
+		ns = &NeighborSync{
+			nlOps:                    mockNlOps,
+			sendNeighborRequestFn:    noopSendNeighborRequest,
+			sendGratuitousNeighborFn: noopSendGratuitous,
+		}
+	})
+
+	It("calls newRingbufReaderFn and exits runBpfNeighborSync when it returns an error", func() {
+		ringbufCalled := false
+		ns.newRingbufReaderFn = func() (*ringbuf.Reader, error) {
+			ringbufCalled = true
+			return nil, errors.New("ringbuf open failed")
+		}
+
+		done := make(chan struct{})
+		go func() {
+			ns.runBpfNeighborSync()
+			close(done)
+		}()
+
+		Eventually(done, "2s").Should(BeClosed())
+		Expect(ringbufCalled).To(BeTrue())
+	})
+})
+
+var _ = Describe("EnsureNeighborSuppression", func() {
+	var ns *NeighborSync
+	var bpfAttachCallCount int
+	var fakeLink netlink.Link
+
+	BeforeEach(func() {
+		bpfAttachCallCount = 0
+		fakeLink = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Index: 10, MasterIndex: 20}}
+
+		ns = &NeighborSync{
+			nlOps:                    mockNlOps,
+			sendNeighborRequestFn:    noopSendNeighborRequest,
+			sendGratuitousNeighborFn: noopSendGratuitous,
+			bpfAttachFn: func(_ netlink.Link) error {
+				bpfAttachCallCount++
+				return nil
+			},
+			bpfDetachFn: func(_ netlink.Link) error { return nil },
+		}
+		ns.initOnce = sync.Once{}
+	})
+
+	It("calls bpfAttachFn once on first call", func() {
+		mockNlOps.EXPECT().LinkByIndex(10).Return(fakeLink, nil).Times(1)
+		mockNlOps.EXPECT().NeighList(20, gomock.Any()).Return(nil, nil).AnyTimes()
+
+		err := ns.EnsureNeighborSuppression(20, 10)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(bpfAttachCallCount).To(Equal(1))
+	})
+
+	It("is idempotent: second call with same vethID skips bpfAttachFn", func() {
+		mockNlOps.EXPECT().LinkByIndex(10).Return(fakeLink, nil).Times(1)
+		mockNlOps.EXPECT().NeighList(20, gomock.Any()).Return(nil, nil).AnyTimes()
+
+		Expect(ns.EnsureNeighborSuppression(20, 10)).To(Succeed())
+		Expect(ns.EnsureNeighborSuppression(20, 10)).To(Succeed())
+
+		Expect(bpfAttachCallCount).To(Equal(1))
+	})
+
+	It("returns error when LinkByIndex fails", func() {
+		mockNlOps.EXPECT().LinkByIndex(10).Return(nil, errors.New("link not found")).Times(1)
+
+		err := ns.EnsureNeighborSuppression(20, 10)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to get link by index"))
+	})
+
+	It("returns error when bpfAttachFn fails", func() {
+		ns.bpfAttachFn = func(_ netlink.Link) error {
+			return errors.New("bpf attach failed")
+		}
+		mockNlOps.EXPECT().LinkByIndex(10).Return(fakeLink, nil).Times(1)
+
+		err := ns.EnsureNeighborSuppression(20, 10)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to attach BPF program"))
+	})
+
+	It("does not add vethID to tracked maps when bpfAttachFn fails", func() {
+		ns.bpfAttachFn = func(_ netlink.Link) error {
+			return errors.New("bpf attach failed")
+		}
+		mockNlOps.EXPECT().LinkByIndex(10).Return(fakeLink, nil).Times(1)
+
+		_ = ns.EnsureNeighborSuppression(20, 10)
+
+		_, tracked := ns.receiveNeighbors.Load(10)
+		Expect(tracked).To(BeFalse())
+		_, gratuitous := ns.sendGratuitousNeighbor.Load(20)
+		Expect(gratuitous).To(BeFalse())
+	})
+})

--- a/pkg/nl/interface.go
+++ b/pkg/nl/interface.go
@@ -14,6 +14,7 @@ type ToolkitInterface interface {
 	LinkByName(name string) (netlink.Link, error)
 	LinkList() ([]netlink.Link, error)
 	NeighList(linkIndex int, family int) ([]netlink.Neigh, error)
+	NeighSet(neigh *netlink.Neigh) error
 	NewIPNet(ip net.IP) *net.IPNet
 	RouteListFiltered(family int, filter *netlink.Route, filterMask uint64) ([]netlink.Route, error)
 	RouteDel(route *netlink.Route) error
@@ -54,6 +55,10 @@ func (*Toolkit) LinkList() ([]netlink.Link, error) {
 
 func (*Toolkit) NeighList(linkIndex, family int) ([]netlink.Neigh, error) {
 	return netlink.NeighList(linkIndex, family)
+}
+
+func (*Toolkit) NeighSet(neigh *netlink.Neigh) error {
+	return netlink.NeighSet(neigh)
 }
 
 func (*Toolkit) NewIPNet(ip net.IP) *net.IPNet {

--- a/pkg/nl/mock/mock_nl.go
+++ b/pkg/nl/mock/mock_nl.go
@@ -329,6 +329,20 @@ func (mr *MockToolkitInterfaceMockRecorder) NeighList(linkIndex, family any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeighList", reflect.TypeOf((*MockToolkitInterface)(nil).NeighList), linkIndex, family)
 }
 
+// NeighSet mocks base method.
+func (m *MockToolkitInterface) NeighSet(neigh *netlink.Neigh) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NeighSet", neigh)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// NeighSet indicates an expected call of NeighSet.
+func (mr *MockToolkitInterfaceMockRecorder) NeighSet(neigh any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeighSet", reflect.TypeOf((*MockToolkitInterface)(nil).NeighSet), neigh)
+}
+
 // NewIPNet mocks base method.
 func (m *MockToolkitInterface) NewIPNet(ip net.IP) *net.IPNet {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary
Replace direct netlink and BPF function calls in `NeighborSync` with injectable dependencies, enabling unit testing without kernel access.

### Changes
- **Dependency injection**: Add `nlOps` (`ToolkitInterface`), function fields for `sendNeighborRequest`, `sendGratuitousNeighbor`, `bpfAttach`, `bpfDetach`
- **Lazy init**: `initOnce`-guarded `initDefaults()` sets production defaults if not injected
- **Interface expansion**: Add `NeighSet` to `pkg/nl.ToolkitInterface` + `Toolkit` implementation + mock
- **Behavioral fixes**:
  - `EnsureNeighborSuppression`: validate link existence before mutating sync.Map state
  - `DisableNeighborSuppression`: detach BPF before removing map state (if detach fails, maps remain consistent)
  - `replaceNeighborReachable`: handle `NeighList` error explicitly instead of silently ignoring
  - Fix `ip.String()` formatting in log message (was printing raw bytes via `%s`)

## Motivation
Extracted from PR #257 (`test: extract NetlinkOps interface and add neighborsync unit tests`) to separate production code changes from test additions.

## Changed files
- `pkg/neighborsync/neighborsync.go`
- `pkg/nl/interface.go`
- `pkg/nl/mock/mock_nl.go`

## Dependencies
None — PR #257 should be rebased on top of this after merge.