### PR TITLE
fix(e2e): increase L3 cross-VLAN IPv6 ping timeout to 60s

### DIFF
--- a/e2etests/tests/gateway_connectivity.go
+++ b/e2etests/tests/gateway_connectivity.go
@@ -61,7 +61,7 @@ var _ = Describe("Gateway Connectivity", Label("gateway", "smoke"), func() {
 			Eventually(func() bool {
 				r, _ := f.PingFromPod(ctx, ns, "macvlan-01", cfg.M2MGWIPv6, 3)
 				return r != nil && r.Success
-			}).WithTimeout(30*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Ping to m2mgw IPv6 failed")
+			}).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Ping to m2mgw IPv6 failed")
 
 			By("Verifying m2mgw can ping macvlan-01 (IPv4)")
 			result, err = f.PingFromCluster2Pod(ctx, "e2e-gateways", "m2m-gateway", cfg.Macvlan01IPv4, 5)
@@ -97,7 +97,7 @@ var _ = Describe("Gateway Connectivity", Label("gateway", "smoke"), func() {
 			Eventually(func() bool {
 				r, _ := f.PingFromPod(ctx, ns, "macvlan-04", cfg.C2MGWIPv6, 3)
 				return r != nil && r.Success
-			}).WithTimeout(30*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Ping to c2mgw IPv6 failed")
+			}).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Ping to c2mgw IPv6 failed")
 
 			By("Verifying c2mgw can ping macvlan-04 (IPv4)")
 			result, err = f.PingFromCluster2Pod(ctx, "e2e-gateways", "c2m-gateway", cfg.Macvlan04IPv4, 5)

--- a/e2etests/tests/l3_connectivity.go
+++ b/e2etests/tests/l3_connectivity.go
@@ -66,6 +66,6 @@ var _ = Describe("L3 Connectivity", Label("l3", "smoke"), func() {
 		Eventually(func() bool {
 			r, _ := f.PingFromPod(ctx, ns, "macvlan-01", cfg.Macvlan03IPv6, 3)
 			return r != nil && r.Success
-		}).WithTimeout(30*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Cross-VLAN IPv6 ping failed")
+		}).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Cross-VLAN IPv6 ping failed")
 	})
 })


### PR DESCRIPTION
## Summary
- Increases IPv6 ping timeouts from 30s to 60s in L3 connectivity and gateway connectivity E2E tests
- Aligns with L2 connectivity tests which already use 60s for IPv6 pings
- Fixes intermittent E2E failures where IPv6 neighbor discovery + VRF routing in containerlab needs more time

## Changed files
- `e2etests/tests/l3_connectivity.go` — cross-VLAN IPv6 ping timeout 30s → 60s
- `e2etests/tests/gateway_connectivity.go` — m2m and c2m gateway IPv6 ping timeouts 30s → 60s

## Context
This flake was observed on PR #233 (L3) and PR #279 CI (gateway). The L2 connectivity tests already use 60s for IPv6 pings within the same VLAN. Cross-VLAN L3 routing and gateway connectivity through the VRF should use at least the same timeout.

Split out from PR #233 to avoid scope creep.