### PR TITLE
fix(e2e): increase IPv6 ping timeouts to reduce flakiness

### DIFF
--- a/e2etests/tests/gateway_connectivity.go
+++ b/e2etests/tests/gateway_connectivity.go
@@ -60,8 +60,15 @@ var _ = Describe("Gateway Connectivity", Label("gateway", "smoke"), func() {
 			By("Verifying macvlan-01 can ping m2mgw (IPv6)")
 			Eventually(func() bool {
 				r, _ := f.PingFromPod(ctx, ns, "macvlan-01", cfg.M2MGWIPv6, 3)
+				if r != nil && !r.Success {
+					GinkgoWriter.Printf("IPv6 ping to m2mgw failed: %s\n", r.Output)
+					neighOut, _, _ := f.ExecInPod(ctx, ns, "macvlan-01", "", []string{"ip", "-6", "neigh", "show"})
+					addrOut, _, _ := f.ExecInPod(ctx, ns, "macvlan-01", "", []string{"ip", "-6", "addr", "show"})
+					GinkgoWriter.Printf("macvlan-01 IPv6 neigh:\n%s\n", neighOut)
+					GinkgoWriter.Printf("macvlan-01 IPv6 addr:\n%s\n", addrOut)
+				}
 				return r != nil && r.Success
-			}).WithTimeout(30*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Ping to m2mgw IPv6 failed")
+			}).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Ping to m2mgw IPv6 failed")
 
 			By("Verifying m2mgw can ping macvlan-01 (IPv4)")
 			result, err = f.PingFromCluster2Pod(ctx, "e2e-gateways", "m2m-gateway", cfg.Macvlan01IPv4, 5)
@@ -96,8 +103,15 @@ var _ = Describe("Gateway Connectivity", Label("gateway", "smoke"), func() {
 			By("Verifying macvlan-04 can ping c2mgw (IPv6)")
 			Eventually(func() bool {
 				r, _ := f.PingFromPod(ctx, ns, "macvlan-04", cfg.C2MGWIPv6, 3)
+				if r != nil && !r.Success {
+					GinkgoWriter.Printf("IPv6 ping to c2mgw failed: %s\n", r.Output)
+					neighOut, _, _ := f.ExecInPod(ctx, ns, "macvlan-04", "", []string{"ip", "-6", "neigh", "show"})
+					addrOut, _, _ := f.ExecInPod(ctx, ns, "macvlan-04", "", []string{"ip", "-6", "addr", "show"})
+					GinkgoWriter.Printf("macvlan-04 IPv6 neigh:\n%s\n", neighOut)
+					GinkgoWriter.Printf("macvlan-04 IPv6 addr:\n%s\n", addrOut)
+				}
 				return r != nil && r.Success
-			}).WithTimeout(30*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Ping to c2mgw IPv6 failed")
+			}).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Ping to c2mgw IPv6 failed")
 
 			By("Verifying c2mgw can ping macvlan-04 (IPv4)")
 			result, err = f.PingFromCluster2Pod(ctx, "e2e-gateways", "c2m-gateway", cfg.Macvlan04IPv4, 5)

--- a/e2etests/tests/gateway_connectivity.go
+++ b/e2etests/tests/gateway_connectivity.go
@@ -62,10 +62,10 @@ var _ = Describe("Gateway Connectivity", Label("gateway", "smoke"), func() {
 				r, _ := f.PingFromPod(ctx, ns, "macvlan-01", cfg.M2MGWIPv6, 3)
 				if r != nil && !r.Success {
 					GinkgoWriter.Printf("IPv6 ping to m2mgw failed: %s\n", r.Output)
-					neighOut, _, _ := f.ExecInPod(ctx, ns, "macvlan-01", "", []string{"ip", "-6", "neigh", "show"})
-					addrOut, _, _ := f.ExecInPod(ctx, ns, "macvlan-01", "", []string{"ip", "-6", "addr", "show"})
-					GinkgoWriter.Printf("macvlan-01 IPv6 neigh:\n%s\n", neighOut)
-					GinkgoWriter.Printf("macvlan-01 IPv6 addr:\n%s\n", addrOut)
+					neighOut, neighErr, neighExecErr := f.ExecInPod(ctx, ns, "macvlan-01", "", []string{"ip", "-6", "neigh", "show"})
+					addrOut, addrErr, addrExecErr := f.ExecInPod(ctx, ns, "macvlan-01", "", []string{"ip", "-6", "addr", "show"})
+					GinkgoWriter.Printf("macvlan-01 IPv6 neigh:\n%s\nstderr: %s\nerr: %v\n", neighOut, neighErr, neighExecErr)
+					GinkgoWriter.Printf("macvlan-01 IPv6 addr:\n%s\nstderr: %s\nerr: %v\n", addrOut, addrErr, addrExecErr)
 				}
 				return r != nil && r.Success
 			}).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Ping to m2mgw IPv6 failed")
@@ -105,10 +105,10 @@ var _ = Describe("Gateway Connectivity", Label("gateway", "smoke"), func() {
 				r, _ := f.PingFromPod(ctx, ns, "macvlan-04", cfg.C2MGWIPv6, 3)
 				if r != nil && !r.Success {
 					GinkgoWriter.Printf("IPv6 ping to c2mgw failed: %s\n", r.Output)
-					neighOut, _, _ := f.ExecInPod(ctx, ns, "macvlan-04", "", []string{"ip", "-6", "neigh", "show"})
-					addrOut, _, _ := f.ExecInPod(ctx, ns, "macvlan-04", "", []string{"ip", "-6", "addr", "show"})
-					GinkgoWriter.Printf("macvlan-04 IPv6 neigh:\n%s\n", neighOut)
-					GinkgoWriter.Printf("macvlan-04 IPv6 addr:\n%s\n", addrOut)
+					neighOut, neighErr, neighExecErr := f.ExecInPod(ctx, ns, "macvlan-04", "", []string{"ip", "-6", "neigh", "show"})
+					addrOut, addrErr, addrExecErr := f.ExecInPod(ctx, ns, "macvlan-04", "", []string{"ip", "-6", "addr", "show"})
+					GinkgoWriter.Printf("macvlan-04 IPv6 neigh:\n%s\nstderr: %s\nerr: %v\n", neighOut, neighErr, neighExecErr)
+					GinkgoWriter.Printf("macvlan-04 IPv6 addr:\n%s\nstderr: %s\nerr: %v\n", addrOut, addrErr, addrExecErr)
 				}
 				return r != nil && r.Success
 			}).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Ping to c2mgw IPv6 failed")

--- a/e2etests/tests/l2_connectivity.go
+++ b/e2etests/tests/l2_connectivity.go
@@ -97,7 +97,7 @@ var _ = Describe("L2 Connectivity", Label("l2", "smoke"), func() {
 				}
 			}
 			return result != nil && result.Success
-		}).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "IPv6 ping failed")
+		}).WithTimeout(90*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "IPv6 ping failed")
 
 		By("Verifying IPv4 connectivity: macvlan-02 → macvlan-01")
 		Eventually(func() bool {
@@ -119,6 +119,6 @@ var _ = Describe("L2 Connectivity", Label("l2", "smoke"), func() {
 				GinkgoWriter.Printf("macvlan-02 IPv6 addr:\n%s\n", addrOut)
 			}
 			return result != nil && result.Success
-		}).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Reverse IPv6 ping failed")
+		}).WithTimeout(90*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Reverse IPv6 ping failed")
 	})
 })


### PR DESCRIPTION
## Summary
- Increase IPv6 ping `Eventually` timeouts in L2 connectivity and gateway connectivity E2E tests
- L2 connectivity: 60s → 90s for IPv6 ping checks (both directions)
- Gateway connectivity: 30s → 60s for m2m and c2m gateway IPv6 ping
- Add debug logging (neighbor tables, addr tables) on retry failure in gateway tests for better diagnostics

## Motivation
Two different E2E tests have been failing intermittently with IPv6 ping timeouts:
- `l2_connectivity.go:100` after 63s
- `gateway_connectivity.go:64` after 30s

IPv6 neighbor discovery and DAD take variable time in the containerlab environment. The current timeouts are too tight. PR #262 disabled IPv6 DAD via `accept_dad` tuning on macvlan NADs, but residual ND timing issues remain in some runs.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)