### PR TITLE
fix(e2e): bump tester image Go version to 1.25

### DIFF
--- a/e2e/images/tester/Dockerfile
+++ b/e2e/images/tester/Dockerfile
@@ -1,9 +1,9 @@
 # Test runner image for das-schiff-network-operator e2e tests.
 # Includes ginkgo CLI, kubectl, Go, and network diagnostic tools.
-FROM golang:1.24 AS builder
+FROM golang:1.25 AS builder
 
 # Install ginkgo CLI
-RUN go install github.com/onsi/ginkgo/v2/ginkgo@latest
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.27.2
 
 FROM ubuntu:24.04
 


### PR DESCRIPTION
## Summary
- Bump E2E tester Dockerfile from `golang:1.24` to `golang:1.25` to match `go.mod`
- Pin ginkgo install to `v2.27.2` (matching go.mod) instead of `@latest` to prevent future breakage

## Context
ginkgo v2.29.0 (resolved by `@latest`) requires go >= 1.25.0, causing E2E tests to fail with:
```
go: github.com/onsi/ginkgo/v2@v2.29.0 requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

This is a preexisting issue on main affecting all PRs with E2E test checks.

## Test plan
- [ ] E2E Tests workflow passes (tester image builds successfully)
- [ ] E2E tests execute without infrastructure failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)