### PR TITLE
fix(netplan): make agent-netplan apply hitless to prevent neighbor flush

### DIFF
--- a/pkg/network/netplan/client/dbus/config.go
+++ b/pkg/network/netplan/client/dbus/config.go
@@ -217,15 +217,11 @@ func (config *Config) Apply() netplan.Error {
 	source := config.initialState
 	if target, err := config.Get(); err != nil {
 		return err
-	} else {
-		if virtualInterfacesToRemove, err := netplan.GetChangedVirtualInterfaces(source, target); err != nil {
-			return netplan.ParseError(err)
-		} else if len(virtualInterfacesToRemove) > 0 {
-			config.log.Warnf("removing existing links for virtual interfaces before netplan apply")
-			for _, link := range virtualInterfacesToRemove {
-				if err := config.netManager.Delete(link); err != nil {
-					config.log.Warnf("error deleting %s link %s. err: %s", link.Type, link.Name, err)
-				}
+	} else if virtualInterfacesToRemove := netplan.GetRemovedVirtualInterfaces(source, target); len(virtualInterfacesToRemove) > 0 {
+		config.log.Warnf("removing links for virtual interfaces removed from configuration before netplan apply")
+		for _, link := range virtualInterfacesToRemove {
+			if err := config.netManager.Delete(link); err != nil {
+				config.log.Warnf("error deleting %s link %s. err: %s", link.Type, link.Name, err)
 			}
 		}
 	}

--- a/pkg/network/netplan/client/dummy/config.go
+++ b/pkg/network/netplan/client/dummy/config.go
@@ -106,12 +106,9 @@ func (config *Config) Apply() (applyErr netplan.Error) {
 	if nperr != nil {
 		return nperr
 	}
-	virtualInterfacesToRemove, err := netplan.GetChangedVirtualInterfaces(source, target)
-	if err != nil {
-		return netplan.ParseError(err)
-	}
+	virtualInterfacesToRemove := netplan.GetRemovedVirtualInterfaces(source, target)
 	if len(virtualInterfacesToRemove) > 0 {
-		config.log.Warnf("removing existing links for virtual interfaces before netplan apply")
+		config.log.Warnf("removing links for virtual interfaces removed from configuration before netplan apply")
 		for _, link := range virtualInterfacesToRemove {
 			config.log.Warnf("would remove link %s if not dummy", link.Name)
 		}

--- a/pkg/network/netplan/state.go
+++ b/pkg/network/netplan/state.go
@@ -240,59 +240,30 @@ func less(a, b interface{}) bool {
 func SanitizeDeviceName(name string) string {
 	return strings.ReplaceAll(name, ".", "\\.")
 }
-func GetChangedVirtualInterfaces(source, target *State) ([]net.Interface, error) {
+
+// GetRemovedVirtualInterfaces returns the virtual interfaces (VLANs, bonds, bridges) that
+// exist in source but no longer exist in target, i.e. interfaces removed from the desired
+// configuration. Only these must be deleted before running `netplan apply`: netplan does
+// not clean up orphaned virtual interfaces on its own. Interfaces that merely changed are
+// reconfigured in place by netplan/networkctl, so deleting them would needlessly flush
+// their neighbor/FDB tables and disrupt live traffic (e.g. EVPN type-2 withdrawal).
+func GetRemovedVirtualInterfaces(source, target *State) []net.Interface {
 	log := logrus.WithField("name", "netplan")
 	result := make([]net.Interface, 0)
-	compare := func(t net.InterfaceType, sourceMap, targetMap map[string]Device) ([]net.Interface, error) {
-		compareResult := make([]net.Interface, 0)
+	collect := func(t net.InterfaceType, sourceMap, targetMap map[string]Device) {
 		for sourceKey := range sourceMap {
 			if _, targetExists := targetMap[sourceKey]; !targetExists {
 				log.Infof("virtual interface %s was removed", sourceKey)
-				i := net.Interface{
-					Type: t,
-					Name: sourceKey,
-				}
-				compareResult = append(compareResult, i)
+				result = append(result, net.Interface{Type: t, Name: sourceKey})
 			}
 		}
-		for targetKey, targetValue := range targetMap {
-			if sourceValue, sourceExists := sourceMap[targetKey]; sourceExists {
-				isEqual, err := sourceValue.EqualsIgnoringSorting(targetValue)
-				if err != nil {
-					return nil, fmt.Errorf("failed to compare YAMLs: %w", err)
-				}
-				if !isEqual {
-					log.Infof("virtual interface %s changed from %s to %s", targetKey, sourceValue, targetValue)
-					i := net.Interface{
-						Type: t,
-						Name: targetKey,
-					}
-					result = append(result, i)
-				}
-			}
-		}
-		return compareResult, nil
 	}
 
-	vlans, err := compare(net.InterfaceTypeVLan, source.Network.VLans, target.Network.VLans)
-	if err != nil {
-		return nil, fmt.Errorf("failed to compare vlans: %w", err)
-	}
-	result = append(result, vlans...)
+	collect(net.InterfaceTypeVLan, source.Network.VLans, target.Network.VLans)
+	collect(net.InterfaceTypeBond, source.Network.Bonds, target.Network.Bonds)
+	collect(net.InterfaceTypeBridge, source.Network.Bridges, target.Network.Bridges)
 
-	bonds, err := compare(net.InterfaceTypeBond, source.Network.Bonds, target.Network.Bonds)
-	if err != nil {
-		return nil, fmt.Errorf("failed to compare bonds: %w", err)
-	}
-	result = append(result, bonds...)
-
-	bridges, err := compare(net.InterfaceTypeBridge, source.Network.Bridges, target.Network.Bridges)
-	if err != nil {
-		return nil, fmt.Errorf("failed to compare bridges: %w", err)
-	}
-	result = append(result, bridges...)
-
-	return result, nil
+	return result
 }
 
 func (d *Device) merge(d2 Device) error {

--- a/pkg/reconciler/agent-netplan/nodenetplanconfig_reconciler.go
+++ b/pkg/reconciler/agent-netplan/nodenetplanconfig_reconciler.go
@@ -100,7 +100,12 @@ func (reconciler *NodeNetplanConfigReconciler) Reconcile(ctx context.Context) er
 		return fmt.Errorf("error setting desired state: %w", err)
 	}
 
-	if err := netplanConfig.Apply(); err != nil {
+	if netplanConfig.IsSynced() {
+		reconciler.logger.Info("netplan configuration already in sync, skipping apply")
+		if err := netplanConfig.Discard(); err != nil {
+			reconciler.logger.Error(err, "failed to discard pending netplan configuration")
+		}
+	} else if err := netplanConfig.Apply(); err != nil {
 		_ = reconciler.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionFalse, healthcheck.ReasonNetplanApplyFailed, err.Error())
 		return fmt.Errorf("error applying desired state: %w", err)
 	}

--- a/pkg/reconciler/operator/layer2.go
+++ b/pkg/reconciler/operator/layer2.go
@@ -58,9 +58,10 @@ func buildNetplanVLANs(node *corev1.Node, revision *v1alpha1.NetworkConfigRevisi
 		}
 
 		vlan := map[string]interface{}{
-			"id":   l2.ID,
-			"link": "hbn",
-			"mtu":  l2.MTU,
+			"id":       l2.ID,
+			"link":     "hbn",
+			"mtu":      l2.MTU,
+			"critical": true,
 		}
 
 		rawVlan, err := json.Marshal(vlan)


### PR DESCRIPTION
Cherry-picked from `feature/intent-based-crds` (#248, commit 4f1203f) so the netplan-agent hitless-apply fix can land independently.

## Problem
The agent-netplan reconciler deleted (`LinkDel`) any virtual interface whose rendered netplan changed before running `netplan apply`. Deleting a live VLAN bridge flushes its kernel neighbor/FDB table, which withdraws the EVPN type-2 advertisement for any pod on that VLAN. When a NodeIPConfig address/route change triggered a reconcile, this wiped a freshly-learned (passive) destination pod neighbor, blackholing cross-L2 over L3-VRF traffic.

netplan/networkctl reconfigures changed-but-present interfaces in place, so the link only needs to be deleted when it is actually removed from the desired config.

## Changes
- Replace `GetChangedVirtualInterfaces` (changed + removed) with `GetRemovedVirtualInterfaces` (removed-only); `Apply()` now only `LinkDel`s interfaces removed from config, never changed-but-present ones.
- Gate `Apply()` behind `IsSynced()` in agent-netplan so no-op reconciles skip `netplan apply` entirely.
- Add `critical: true` to the legacy operator VLAN render for parity with the intent path (KeepConfiguration=yes / hitless apply).