### PR TITLE
ci: stop auto-closing stale pull requests

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -22,7 +22,7 @@ jobs:
             Thank you for your contributions.
           stale-pr-message: >
             This pull request has been automatically marked as stale because it has not had
-            recent activity. It will be closed in 14 days if no further activity occurs.
+            recent activity. Please update this PR or comment if it is still in progress.
             Thank you for your contributions.
           close-issue-message: >
             This issue was closed because it has been stale for 14 days with no activity.
@@ -32,6 +32,7 @@ jobs:
             Feel free to reopen if you'd like to continue working on this.
           days-before-stale: 60
           days-before-close: 14
+          days-before-pr-close: -1
           stale-issue-label: stale
           stale-pr-label: stale
           exempt-issue-labels: pinned,security,bug,enhancement


### PR DESCRIPTION
## Summary
- keep marking inactive pull requests as stale
- stop closing stale pull requests automatically
- keep existing stale issue close behavior unchanged

## Verification
- Ruby YAML parser loaded .github/workflows/stale.yaml successfully