### PR TITLE
ci: build golangci-lint with workflow Go

### DIFF
--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.8.0
+          install-mode: goinstall
           args: --timeout=10m
 
   test:


### PR DESCRIPTION
## Summary
- keep golangci-lint pinned to v2.8.0
- install golangci-lint via `goinstall` so it is built by the Go version from `go.mod`
- keep the linter version stable while following the workflow Go toolchain

## CI failure addressed
- Addresses lint/toolchain drift without adopting newer golangci-lint lint behavior.

## Validation
- Parsed `.github/workflows/pullrequests.yaml` with Ruby `YAML.load_file`.
- Earlier attempt with golangci-lint v2.12.2 failed by surfacing unrelated new lint findings, so this PR keeps the linter version stable.
- `actionlint` is not installed in this environment, so I could not run it locally.
