### PR TITLE
ci: pass go.mod version to Docker builds

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -59,7 +59,14 @@ jobs:
           go-version-file: go.mod
 
       - name: Create Licenses Report
-        run: make licenses-report
+        run: |
+          for attempt in 1 2 3; do
+            if make licenses-report; then
+              exit 0
+            fi
+            sleep 1000 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 1000(attempt * 10))
+          done
+          make licenses-report
 
       - name: Read Go version
         id: go-version

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -64,7 +64,7 @@ jobs:
             if make licenses-report; then
               exit 0
             fi
-            sleep 1000 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 1000(attempt * 10))
+            sleep 10
           done
           make licenses-report
 

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Read Go version
         id: go-version
-        run: echo "version=$(awk '/^go / { print $2 }' go.mod)" >> $GITHUB_OUTPUT
+        run: echo "version=$(awk '/^go / { print $2; exit }' go.mod)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,9 +47,14 @@ jobs:
         id: ldflags
         run: echo "value=$(bash hack/version.sh)" >> "$GITHUB_OUTPUT"
 
+      - name: Compute Go version
+        id: go-version
+        run: echo "value=$(awk '/^go / {print $2; exit}' go.mod)" >> "$GITHUB_OUTPUT"
+
       - name: Build cra-frr image
         run: |
           docker build \
+            --build-arg GO_VERSION="${{ steps.go-version.outputs.value }}" \
             --build-arg ldflags="${{ steps.ldflags.outputs.value }}" \
             -f das-schiff-cra-frr.Dockerfile \
             -t das-schiff-cra-frr:latest .
@@ -105,9 +110,14 @@ jobs:
         id: ldflags
         run: echo "value=$(bash hack/version.sh)" >> "$GITHUB_OUTPUT"
 
+      - name: Compute Go version
+        id: go-version
+        run: echo "value=$(awk '/^go / {print $2; exit}' go.mod)" >> "$GITHUB_OUTPUT"
+
       - name: Build image
         run: |
           docker build \
+            --build-arg GO_VERSION="${{ steps.go-version.outputs.value }}" \
             --build-arg ldflags="${{ steps.ldflags.outputs.value }}" \
             -f ${{ matrix.image }}.Dockerfile \
             -t ${{ env.IMG_BASE }}/${{ matrix.image }}:latest .
@@ -135,6 +145,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Compute Go version
+        id: go-version
+        run: echo "value=$(awk '/^go / {print $2; exit}' go.mod)" >> "$GITHUB_OUTPUT"
+
       - name: Build nat64 image
         run: |
           docker build \
@@ -145,6 +159,7 @@ jobs:
       - name: Build tester image
         run: |
           docker build \
+            --build-arg GO_VERSION="${{ steps.go-version.outputs.value }}" \
             -t ${{ env.IMG_BASE }}/das-schiff-e2e-tester:latest \
             -f e2e/images/tester/Dockerfile \
             e2e/images/tester/
@@ -182,6 +197,7 @@ jobs:
 
       - name: system-level-dependencies
         run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
           sudo apt update
           sudo apt -y install linux-modules-extra-$(uname -r)
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,9 +47,14 @@ jobs:
         id: ldflags
         run: echo "value=$(bash hack/version.sh)" >> "$GITHUB_OUTPUT"
 
+      - name: Compute Go version
+        id: go-version
+        run: echo "value=$(awk '/^go / {print $2; exit}' go.mod)" >> "$GITHUB_OUTPUT"
+
       - name: Build cra-frr image
         run: |
           docker build \
+            --build-arg GO_VERSION="${{ steps.go-version.outputs.value }}" \
             --build-arg ldflags="${{ steps.ldflags.outputs.value }}" \
             -f das-schiff-cra-frr.Dockerfile \
             -t das-schiff-cra-frr:latest .
@@ -105,9 +110,14 @@ jobs:
         id: ldflags
         run: echo "value=$(bash hack/version.sh)" >> "$GITHUB_OUTPUT"
 
+      - name: Compute Go version
+        id: go-version
+        run: echo "value=$(awk '/^go / {print $2; exit}' go.mod)" >> "$GITHUB_OUTPUT"
+
       - name: Build image
         run: |
           docker build \
+            --build-arg GO_VERSION="${{ steps.go-version.outputs.value }}" \
             --build-arg ldflags="${{ steps.ldflags.outputs.value }}" \
             -f ${{ matrix.image }}.Dockerfile \
             -t ${{ env.IMG_BASE }}/${{ matrix.image }}:latest .
@@ -135,6 +145,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Compute Go version
+        id: go-version
+        run: echo "value=$(awk '/^go / {print $2; exit}' go.mod)" >> "$GITHUB_OUTPUT"
+
       - name: Build nat64 image
         run: |
           docker build \
@@ -145,6 +159,7 @@ jobs:
       - name: Build tester image
         run: |
           docker build \
+            --build-arg GO_VERSION="${{ steps.go-version.outputs.value }}" \
             -t ${{ env.IMG_BASE }}/das-schiff-e2e-tester:latest \
             -f e2e/images/tester/Dockerfile \
             e2e/images/tester/
@@ -182,6 +197,7 @@ jobs:
 
       - name: system-level-dependencies
         run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
           sudo apt update
           sudo apt -y install linux-modules-extra-$(uname -r)
 

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -20,7 +20,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: run code generators
         run: make generate
       - name: golangci-lint
@@ -38,7 +41,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: Run Tests
         run: make test
       - name: Upload coverage report
@@ -59,7 +65,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: run code generators
         run: make generate
       - name: run manifest generators

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -86,8 +86,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-images.yaml
     with:
-      push: true
-      cache-write: true
+      push: false
+      cache-write: false
 
   build-images-fork:
     name: build container images (fork)

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -86,8 +86,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-images.yaml
     with:
-      push: false
-      cache-write: false
+      push: true
+      cache-write: true
 
   build-images-fork:
     name: build container images (fork)

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 LDFLAGS := $(shell hack/version.sh)
+GO_VERSION ?= $(shell awk '/^go / {print $$2; exit}' go.mod)
 
 .PHONY: all
 all: build
@@ -102,15 +103,15 @@ bpf-generate: ## Run go generate for the BPF program (builds it as well)
 
 .PHONY: docker-build
 docker-build: #test ## Build docker image with the manager.
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-cra-frr.Dockerfile -t ${IMG_BASE}/das-schiff-cra-frr:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-network-operator.Dockerfile -t ${IMG_BASE}/das-schiff-network-operator:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-cra-frr.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-cra-frr:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-cra-vsr.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-cra-vsr:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-hbn-l2.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-hbn-l2:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-netplan.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-netplan:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-platform-coil.Dockerfile -t ${IMG_BASE}/das-schiff-platform-coil:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-platform-metallb.Dockerfile -t ${IMG_BASE}/das-schiff-platform-metallb:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-network-sync.Dockerfile -t ${IMG_BASE}/das-schiff-network-sync:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-cra-frr.Dockerfile -t ${IMG_BASE}/das-schiff-cra-frr:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-network-operator.Dockerfile -t ${IMG_BASE}/das-schiff-network-operator:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-cra-frr.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-cra-frr:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-cra-vsr.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-cra-vsr:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-hbn-l2.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-hbn-l2:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-netplan.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-netplan:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-platform-coil.Dockerfile -t ${IMG_BASE}/das-schiff-platform-coil:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-platform-metallb.Dockerfile -t ${IMG_BASE}/das-schiff-platform-metallb:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-network-sync.Dockerfile -t ${IMG_BASE}/das-schiff-network-sync:latest .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -185,7 +186,7 @@ E2E_TESTER_IMAGE ?= $(IMG_BASE)/das-schiff-e2e-tester:latest
 
 .PHONY: e2e-build-cra-frr
 e2e-build-cra-frr: ## Build the CRA-FRR image.
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-cra-frr.Dockerfile -t das-schiff-cra-frr:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-cra-frr.Dockerfile -t das-schiff-cra-frr:latest .
 
 .PHONY: e2e-build-node-image
 e2e-build-node-image: e2e-build-cra-frr ## Build kind node image with CRA-FRR baked in.

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 LDFLAGS := $(shell hack/version.sh)
-GO_VERSION := $(if $(GO_VERSION),$(GO_VERSION),$(shell awk '/^go / {print $$2; exit}' go.mod))
+GO_VERSION ?= $(shell awk '/^go / {print $$2; exit}' go.mod)
 
 .PHONY: all
 all: build

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 LDFLAGS := $(shell hack/version.sh)
-GO_VERSION ?= $(shell awk '/^go / {print $$2; exit}' go.mod)
+GO_VERSION := $(if $(GO_VERSION),$(GO_VERSION),$(shell awk '/^go / {print $$2; exit}' go.mod))
 
 .PHONY: all
 all: build

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 LDFLAGS := $(shell hack/version.sh)
+GO_VERSION ?= $(shell awk '/^go / {print $$2; exit}' go.mod)
 
 .PHONY: all
 all: build
@@ -132,15 +133,15 @@ bpf-generate: ## Run go generate for the BPF program (builds it as well)
 
 .PHONY: docker-build
 docker-build: #test ## Build docker image with the manager.
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-cra-frr.Dockerfile -t ${IMG_BASE}/das-schiff-cra-frr:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-network-operator.Dockerfile -t ${IMG_BASE}/das-schiff-network-operator:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-cra-frr.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-cra-frr:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-cra-vsr.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-cra-vsr:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-hbn-l2.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-hbn-l2:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-netplan.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-netplan:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-platform-coil.Dockerfile -t ${IMG_BASE}/das-schiff-platform-coil:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-platform-metallb.Dockerfile -t ${IMG_BASE}/das-schiff-platform-metallb:latest .
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-network-sync.Dockerfile -t ${IMG_BASE}/das-schiff-network-sync:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-cra-frr.Dockerfile -t ${IMG_BASE}/das-schiff-cra-frr:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-network-operator.Dockerfile -t ${IMG_BASE}/das-schiff-network-operator:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-cra-frr.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-cra-frr:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-cra-vsr.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-cra-vsr:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-hbn-l2.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-hbn-l2:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-nwop-agent-netplan.Dockerfile -t ${IMG_BASE}/das-schiff-nwop-agent-netplan:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-platform-coil.Dockerfile -t ${IMG_BASE}/das-schiff-platform-coil:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-platform-metallb.Dockerfile -t ${IMG_BASE}/das-schiff-platform-metallb:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-network-sync.Dockerfile -t ${IMG_BASE}/das-schiff-network-sync:latest .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -215,7 +216,7 @@ E2E_TESTER_IMAGE ?= $(IMG_BASE)/das-schiff-e2e-tester:latest
 
 .PHONY: e2e-build-cra-frr
 e2e-build-cra-frr: ## Build the CRA-FRR image.
-	docker build --build-arg ldflags="$(LDFLAGS)" -f das-schiff-cra-frr.Dockerfile -t das-schiff-cra-frr:latest .
+	docker build --build-arg GO_VERSION="$(GO_VERSION)" --build-arg ldflags="$(LDFLAGS)" -f das-schiff-cra-frr.Dockerfile -t das-schiff-cra-frr:latest .
 
 .PHONY: e2e-build-node-image
 e2e-build-node-image: e2e-build-cra-frr ## Build kind node image with CRA-FRR baked in.

--- a/das-schiff-cra-frr.Dockerfile
+++ b/das-schiff-cra-frr.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.25.0
 FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
 

--- a/das-schiff-network-operator.Dockerfile
+++ b/das-schiff-network-operator.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.25.0
 FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
 

--- a/das-schiff-network-sync.Dockerfile
+++ b/das-schiff-network-sync.Dockerfile
@@ -1,5 +1,5 @@
 # Build the network-sync binary
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.25.0
 FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
 WORKDIR /workspace

--- a/das-schiff-nwop-agent-cra-frr.Dockerfile
+++ b/das-schiff-nwop-agent-cra-frr.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.25.0
 FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
 

--- a/das-schiff-nwop-agent-cra-vsr.Dockerfile
+++ b/das-schiff-nwop-agent-cra-vsr.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.25.0
 FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
 

--- a/das-schiff-nwop-agent-hbn-l2.Dockerfile
+++ b/das-schiff-nwop-agent-hbn-l2.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.25.0
 FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
 

--- a/das-schiff-nwop-agent-netplan.Dockerfile
+++ b/das-schiff-nwop-agent-netplan.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.25.0
 FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
 

--- a/das-schiff-platform-coil.Dockerfile
+++ b/das-schiff-platform-coil.Dockerfile
@@ -1,5 +1,5 @@
 # Build the platform-coil binary
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.25.0
 FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
 WORKDIR /workspace

--- a/das-schiff-platform-metallb.Dockerfile
+++ b/das-schiff-platform-metallb.Dockerfile
@@ -1,5 +1,5 @@
 # Build the platform-metallb binary
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.25.0
 FROM docker.io/library/golang:${GO_VERSION}-alpine AS builder
 
 WORKDIR /workspace

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "ip -6 route add default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1"
+        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 | grep -q \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
+        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 | grep -q \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 | grep -q \"inet6 fda5:25c1:193e::1/\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/images/tester/Dockerfile
+++ b/e2e/images/tester/Dockerfile
@@ -1,6 +1,6 @@
 # Test runner image for das-schiff-network-operator e2e tests.
 # Includes ginkgo CLI, kubectl, Go, and network diagnostic tools.
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.25.0
 FROM golang:${GO_VERSION} AS builder
 
 # Install ginkgo CLI

--- a/e2e/images/tester/Dockerfile
+++ b/e2e/images/tester/Dockerfile
@@ -1,6 +1,7 @@
 # Test runner image for das-schiff-network-operator e2e tests.
 # Includes ginkgo CLI, kubectl, Go, and network diagnostic tools.
-FROM golang:1.25 AS builder
+ARG GO_VERSION=1.25
+FROM golang:${GO_VERSION} AS builder
 
 # Install ginkgo CLI
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.27.2

--- a/e2e/setup/phases.go
+++ b/e2e/setup/phases.go
@@ -62,7 +62,7 @@ func phaseBuildAllImages(repoRoot string) error {
 	ldflags := getLDFlags(repoRoot)
 	goVersion, err := getGoVersion(repoRoot)
 	if err != nil {
-		return err
+		return fmt.Errorf("derive Go version from go.mod: %w", err)
 	}
 
 	// 1. Build cra-frr image

--- a/e2e/setup/phases.go
+++ b/e2e/setup/phases.go
@@ -130,6 +130,7 @@ func phaseBuildAllImages(repoRoot string) error {
 	}
 
 	if err := RunCmd("docker", "build",
+		"--build-arg", "GO_VERSION="+goVersion,
 		"--build-arg", "ldflags="+ldflags,
 		"-f", filepath.Join(repoRoot, "das-schiff-platform-coil.Dockerfile"),
 		"-t", imgBase+"/das-schiff-platform-coil:latest",
@@ -139,6 +140,7 @@ func phaseBuildAllImages(repoRoot string) error {
 	}
 
 	if err := RunCmd("docker", "build",
+		"--build-arg", "GO_VERSION="+goVersion,
 		"--build-arg", "ldflags="+ldflags,
 		"-f", filepath.Join(repoRoot, "das-schiff-platform-metallb.Dockerfile"),
 		"-t", imgBase+"/das-schiff-platform-metallb:latest",
@@ -148,6 +150,7 @@ func phaseBuildAllImages(repoRoot string) error {
 	}
 
 	if err := RunCmd("docker", "build",
+		"--build-arg", "GO_VERSION="+goVersion,
 		"--build-arg", "ldflags="+ldflags,
 		"-f", filepath.Join(repoRoot, "das-schiff-network-sync.Dockerfile"),
 		"-t", imgBase+"/das-schiff-network-sync:latest",

--- a/e2e/setup/phases.go
+++ b/e2e/setup/phases.go
@@ -201,7 +201,7 @@ func getGoVersion(repoRoot string) (string, error) {
 	}
 	for _, line := range strings.Split(string(data), "\n") {
 		fields := strings.Fields(line)
-		if len(fields) == 2 && fields[0] == "go" {
+		if len(fields) >= 2 && fields[0] == "go" {
 			return fields[1], nil
 		}
 	}

--- a/e2e/setup/phases.go
+++ b/e2e/setup/phases.go
@@ -60,10 +60,15 @@ func phaseBuildAllImages(repoRoot string) error {
 	testerImage := EnvOr("E2E_TESTER_IMAGE", imgBase+"/das-schiff-e2e-tester:latest")
 
 	ldflags := getLDFlags(repoRoot)
+	goVersion, err := getGoVersion(repoRoot)
+	if err != nil {
+		return err
+	}
 
 	// 1. Build cra-frr image
 	Logf("  Building das-schiff-cra-frr...")
 	if err := RunCmd("docker", "build",
+		"--build-arg", "GO_VERSION="+goVersion,
 		"--build-arg", "ldflags="+ldflags,
 		"-f", filepath.Join(repoRoot, "das-schiff-cra-frr.Dockerfile"),
 		"-t", "das-schiff-cra-frr:latest",
@@ -95,6 +100,7 @@ func phaseBuildAllImages(repoRoot string) error {
 	// 3. Build operator + agent + platform images
 	Logf("  Building operator + agent + platform images...")
 	if err := RunCmd("docker", "build",
+		"--build-arg", "GO_VERSION="+goVersion,
 		"--build-arg", "ldflags="+ldflags,
 		"-f", filepath.Join(repoRoot, "das-schiff-network-operator.Dockerfile"),
 		"-t", imgBase+"/das-schiff-network-operator:latest",
@@ -104,6 +110,7 @@ func phaseBuildAllImages(repoRoot string) error {
 	}
 
 	if err := RunCmd("docker", "build",
+		"--build-arg", "GO_VERSION="+goVersion,
 		"--build-arg", "ldflags="+ldflags,
 		"-f", filepath.Join(repoRoot, "das-schiff-nwop-agent-cra-frr.Dockerfile"),
 		"-t", imgBase+"/das-schiff-nwop-agent-cra-frr:latest",
@@ -113,6 +120,7 @@ func phaseBuildAllImages(repoRoot string) error {
 	}
 
 	if err := RunCmd("docker", "build",
+		"--build-arg", "GO_VERSION="+goVersion,
 		"--build-arg", "ldflags="+ldflags,
 		"-f", filepath.Join(repoRoot, "das-schiff-nwop-agent-netplan.Dockerfile"),
 		"-t", imgBase+"/das-schiff-nwop-agent-netplan:latest",
@@ -163,6 +171,7 @@ func phaseBuildAllImages(repoRoot string) error {
 	testerCtx := filepath.Join(repoRoot, "e2e", "images", "tester")
 	Logf("  Building tester image (%s)...", testerImage)
 	if err := RunCmd("docker", "build",
+		"--build-arg", "GO_VERSION="+goVersion,
 		"-t", testerImage,
 		"-f", filepath.Join(testerCtx, "Dockerfile"),
 		testerCtx,
@@ -183,6 +192,20 @@ func getLDFlags(repoRoot string) string {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
+}
+
+func getGoVersion(repoRoot string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(repoRoot, "go.mod"))
+	if err != nil {
+		return "", fmt.Errorf("reading go.mod: %w", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[0] == "go" {
+			return fields[1], nil
+		}
+	}
+	return "", fmt.Errorf("go.mod does not declare a Go version")
 }
 
 // Phase 1a: Create k8s node containers with proper Docker flags.

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "ip -6 route add default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1"
+        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
+        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 | grep -q \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 | grep -q \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 | grep -q \"inet6 fda5:25c1:193e::1/\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:


### PR DESCRIPTION
## Summary
- derive `GO_VERSION` from the root `go.mod` for Makefile Docker builds
- pass that version into the e2e setup program's Go-based Docker builds
- let the e2e tester image use a `GO_VERSION` build arg instead of a hard-coded Go base image
- align manual Docker defaults with the current `go.mod` version (`1.25.0`)

## CI failure addressed
- Keeps Docker build Go versions tied to the module Go version instead of stale Dockerfile defaults when the repository Go version changes.

## Validation
- `make -n docker-build`
- `make -n e2e-build-cra-frr`
- `(cd e2e/setup && go test ./...)`

## Not run
- Full `make e2e-up` / e2e lab run was not started locally.

CI harness fix: NAT64 route setup now waits for the NAT64 TUN source address before installing the default route, uses `/bin/sh`, and dumps IPv6 routing state if setup fails. This prevents kubeadm DNS timeouts during E2E setup while preserving the intended source address.