### PR TITLE
test: retry e2e pods after IPv6 DAD failure

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -59,7 +59,14 @@ jobs:
           go-version-file: go.mod
 
       - name: Create Licenses Report
-        run: make licenses-report
+        run: |
+          for attempt in 1 2 3; do
+            if make licenses-report; then
+              exit 0
+            fi
+            sleep 1000 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 1000(attempt * 10))
+          done
+          make licenses-report
 
       - name: Read Go version
         id: go-version

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -64,7 +64,7 @@ jobs:
             if make licenses-report; then
               exit 0
             fi
-            sleep 1000 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 1000(attempt * 10))
+            sleep 10
           done
           make licenses-report
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -182,6 +182,7 @@ jobs:
 
       - name: system-level-dependencies
         run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
           sudo apt update
           sudo apt -y install linux-modules-extra-$(uname -r)
 

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -20,7 +20,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: run code generators
         run: make generate
       - name: golangci-lint
@@ -38,7 +41,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: Run Tests
         run: make test
       - name: Upload coverage report
@@ -59,7 +65,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: run code generators
         run: make generate
       - name: run manifest generators

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -86,8 +86,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-images.yaml
     with:
-      push: true
-      cache-write: true
+      push: false
+      cache-write: false
 
   build-images-fork:
     name: build container images (fork)

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -86,8 +86,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-images.yaml
     with:
-      push: false
-      cache-write: false
+      push: true
+      cache-write: true
 
   build-images-fork:
     name: build container images (fork)

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "ip -6 route add default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1"
+        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 | grep -q \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
+        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "ip -6 route add default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1"
+        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
+        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 | grep -q \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2etests/framework/cluster.go
+++ b/e2etests/framework/cluster.go
@@ -38,6 +38,7 @@ type Framework struct {
 
 	// Track namespaces created during tests for cleanup.
 	testNamespaces []string
+	execInPodFn    func(context.Context, string, string, string, []string) (string, string, error)
 }
 
 // New creates a new Framework from the given config.

--- a/e2etests/framework/pod.go
+++ b/e2etests/framework/pod.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/netip"
 	"os/exec"
@@ -333,7 +334,7 @@ func (f *Framework) deletePodBestEffort(ctx context.Context, namespace, name str
 
 func (f *Framework) deleteCreatedTestPodAfterError(ctx context.Context, namespace, name string, cause error) error {
 	if err := f.DeletePod(ctx, namespace, name); err != nil {
-		return fmt.Errorf("%w; additionally failed to delete pod %s/%s after error: %w", cause, namespace, name, err)
+		return errors.Join(cause, fmt.Errorf("delete pod %s/%s after error: %w", namespace, name, err))
 	}
 	return cause
 }

--- a/e2etests/framework/pod.go
+++ b/e2etests/framework/pod.go
@@ -114,12 +114,22 @@ func (f *Framework) CreateTestPod(ctx context.Context, namespace, name, nodeName
 		}
 
 		if err := f.WaitForPodReady(ctx, namespace, name, f.Config.PodReadyTimeout); err != nil {
-			return fmt.Errorf("wait for pod %s/%s to become ready before IPv6 DAD check: %w", namespace, name, err)
+			return f.deleteCreatedTestPodAfterError(
+				ctx,
+				namespace,
+				name,
+				fmt.Errorf("wait for pod %s/%s to become ready before IPv6 DAD check: %w", namespace, name, err),
+			)
 		}
 
 		dadFailed, err := f.podHasIPv6DADFailure(ctx, namespace, name, testPodDADCheckTimeout)
 		if err != nil {
-			return fmt.Errorf("check IPv6 DAD state for pod %s/%s: %w", namespace, name, err)
+			return f.deleteCreatedTestPodAfterError(
+				ctx,
+				namespace,
+				name,
+				fmt.Errorf("check IPv6 DAD state for pod %s/%s: %w", namespace, name, err),
+			)
 		}
 		if !dadFailed {
 			return nil
@@ -319,6 +329,13 @@ func (f *Framework) deletePodBestEffort(ctx context.Context, namespace, name str
 		return apierrors.IsNotFound(err), nil
 	})
 	return nil
+}
+
+func (f *Framework) deleteCreatedTestPodAfterError(ctx context.Context, namespace, name string, cause error) error {
+	if err := f.DeletePod(ctx, namespace, name); err != nil {
+		return fmt.Errorf("%w; additionally failed to delete pod %s/%s after error: %v", cause, namespace, name, err)
+	}
+	return cause
 }
 
 // ExecInPod executes a command in a running pod and returns stdout, stderr.

--- a/e2etests/framework/pod.go
+++ b/e2etests/framework/pod.go
@@ -333,7 +333,7 @@ func (f *Framework) deletePodBestEffort(ctx context.Context, namespace, name str
 
 func (f *Framework) deleteCreatedTestPodAfterError(ctx context.Context, namespace, name string, cause error) error {
 	if err := f.DeletePod(ctx, namespace, name); err != nil {
-		return fmt.Errorf("%w; additionally failed to delete pod %s/%s after error: %v", cause, namespace, name, err)
+		return fmt.Errorf("%w; additionally failed to delete pod %s/%s after error: %w", cause, namespace, name, err)
 	}
 	return cause
 }

--- a/e2etests/framework/pod.go
+++ b/e2etests/framework/pod.go
@@ -238,7 +238,7 @@ func (f *Framework) podHasIPv6DADFailure(ctx context.Context, namespace, name st
 			return false, nil
 		}
 
-		stdout, stderr, err := f.execInPod(ctx, namespace, name, "", []string{"ip", "-6", "addr", "show"})
+		stdout, stderr, err := f.executePodCommand(ctx, namespace, name, "", []string{"ip", "-6", "addr", "show"})
 		if err != nil {
 			return false, fmt.Errorf("inspect IPv6 addresses in pod %s/%s failed (stderr=%s): %w", namespace, name, stderr, err)
 		}
@@ -254,7 +254,7 @@ func (f *Framework) podHasIPv6DADFailure(ctx context.Context, namespace, name st
 	return dadFailed, err
 }
 
-func (f *Framework) execInPod(ctx context.Context, namespace, podName, containerName string, command []string) (string, string, error) {
+func (f *Framework) executePodCommand(ctx context.Context, namespace, podName, containerName string, command []string) (stdout, stderr string, err error) {
 	if f.execInPodFn != nil {
 		return f.execInPodFn(ctx, namespace, podName, containerName, command)
 	}

--- a/e2etests/framework/pod.go
+++ b/e2etests/framework/pod.go
@@ -238,7 +238,7 @@ func (f *Framework) podHasIPv6DADFailure(ctx context.Context, namespace, name st
 			return false, nil
 		}
 
-		stdout, stderr, err := f.ExecInPod(ctx, namespace, name, "", []string{"ip", "-6", "addr", "show"})
+		stdout, stderr, err := f.execInPod(ctx, namespace, name, "", []string{"ip", "-6", "addr", "show"})
 		if err != nil {
 			return false, fmt.Errorf("inspect IPv6 addresses in pod %s/%s failed (stderr=%s): %w", namespace, name, stderr, err)
 		}
@@ -252,6 +252,13 @@ func (f *Framework) podHasIPv6DADFailure(ctx context.Context, namespace, name st
 		return true, nil
 	})
 	return dadFailed, err
+}
+
+func (f *Framework) execInPod(ctx context.Context, namespace, podName, containerName string, command []string) (string, string, error) {
+	if f.execInPodFn != nil {
+		return f.execInPodFn(ctx, namespace, podName, containerName, command)
+	}
+	return f.ExecInPod(ctx, namespace, podName, containerName, command)
 }
 
 func podIsReady(pod *corev1.Pod) bool {

--- a/e2etests/framework/pod_test.go
+++ b/e2etests/framework/pod_test.go
@@ -1,6 +1,17 @@
 package framework
 
-import "testing"
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/telekom/das-schiff-network-operator/e2etests/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
 
 func TestHasStaticIPv6MultusNetwork(t *testing.T) {
 	tests := []struct {
@@ -62,5 +73,47 @@ func TestHasStaticIPv6MultusNetwork(t *testing.T) {
 				t.Fatalf("hasStaticIPv6MultusNetwork() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCreateTestPodDeletesStaticIPv6PodWhenReadinessFails(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+
+	kubeClient := kubefake.NewSimpleClientset()
+	f := &Framework{
+		Config: &config.Config{
+			PodReadyTimeout: time.Nanosecond,
+		},
+		KubeClient: kubeClient,
+		Client:     clientfake.NewClientBuilder().WithScheme(scheme).Build(),
+	}
+
+	err := f.CreateTestPod(
+		context.Background(),
+		"default",
+		"static-ipv6",
+		"worker-1",
+		map[string]string{
+			"k8s.v1.cni.cncf.io/networks": `[{"name":"macvlan-vlan501","ips":["fda5:25c1:193c::1/64"]}]`,
+		},
+	)
+	if err == nil {
+		t.Fatal("CreateTestPod() error = nil, want readiness failure")
+	}
+	if !strings.Contains(err.Error(), "become ready before IPv6 DAD check") {
+		t.Fatalf("CreateTestPod() error = %q, want readiness context", err)
+	}
+
+	podDeletes := 0
+	for _, action := range kubeClient.Actions() {
+		if action.GetVerb() == "delete" && action.GetResource().Resource == "pods" {
+			podDeletes++
+		}
+	}
+	if podDeletes < 2 {
+		t.Fatalf("pod delete actions = %d, want at least 2 initial+cleanup deletes", podDeletes)
 	}
 }

--- a/e2etests/framework/pod_test.go
+++ b/e2etests/framework/pod_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/telekom/das-schiff-network-operator/e2etests/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/telekom/das-schiff-network-operator/e2etests/config"
 )
 
 func TestHasStaticIPv6MultusNetwork(t *testing.T) {

--- a/e2etests/framework/pod_test.go
+++ b/e2etests/framework/pod_test.go
@@ -82,7 +82,7 @@ func TestCreateTestPodDeletesStaticIPv6PodWhenReadinessFails(t *testing.T) {
 		t.Fatalf("add corev1 to scheme: %v", err)
 	}
 
-	kubeClient := kubefake.NewSimpleClientset()
+	kubeClient := kubefake.NewClientset()
 	f := &Framework{
 		Config: &config.Config{
 			PodReadyTimeout: time.Nanosecond,

--- a/e2etests/framework/pod_test.go
+++ b/e2etests/framework/pod_test.go
@@ -7,8 +7,11 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/telekom/das-schiff-network-operator/e2etests/config"
@@ -89,7 +92,10 @@ func TestCreateTestPodDeletesStaticIPv6PodWhenReadinessFails(t *testing.T) {
 			PodReadyTimeout: time.Nanosecond,
 		},
 		KubeClient: kubeClient,
-		Client:     clientfake.NewClientBuilder().WithScheme(scheme).Build(),
+		Client: &mirroringCreateClient{
+			Client:     clientfake.NewClientBuilder().WithScheme(scheme).Build(),
+			kubeClient: kubeClient,
+		},
 	}
 
 	err := f.CreateTestPod(
@@ -108,13 +114,44 @@ func TestCreateTestPodDeletesStaticIPv6PodWhenReadinessFails(t *testing.T) {
 		t.Fatalf("CreateTestPod() error = %q, want readiness context", err)
 	}
 
+	podCreates := 0
 	podDeletes := 0
 	for _, action := range kubeClient.Actions() {
-		if action.GetVerb() == "delete" && action.GetResource().Resource == "pods" {
+		if action.GetResource().Resource != "pods" {
+			continue
+		}
+		switch action.GetVerb() {
+		case "create":
+			podCreates++
+		case "delete":
 			podDeletes++
 		}
+	}
+	if podCreates != 1 {
+		t.Fatalf("pod create actions = %d, want 1", podCreates)
 	}
 	if podDeletes < 2 {
 		t.Fatalf("pod delete actions = %d, want at least 2 initial+cleanup deletes", podDeletes)
 	}
+	if _, err := kubeClient.CoreV1().Pods("default").Get(context.Background(), "static-ipv6", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("pod still exists after cleanup: %v", err)
+	}
+}
+
+type mirroringCreateClient struct {
+	client.Client
+	kubeClient *kubefake.Clientset
+}
+
+func (c *mirroringCreateClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if err := c.Client.Create(ctx, obj, opts...); err != nil {
+		return err
+	}
+
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+	_, err := c.kubeClient.CoreV1().Pods(pod.Namespace).Create(ctx, pod.DeepCopy(), metav1.CreateOptions{})
+	return err
 }

--- a/e2etests/framework/pod_test.go
+++ b/e2etests/framework/pod_test.go
@@ -115,23 +115,29 @@ func TestCreateTestPodDeletesStaticIPv6PodWhenReadinessFails(t *testing.T) {
 	}
 
 	podCreates := 0
-	podDeletes := 0
-	for _, action := range kubeClient.Actions() {
+	createActionIdx := -1
+	deletesAfterCreate := 0
+	for idx, action := range kubeClient.Actions() {
 		if action.GetResource().Resource != "pods" {
 			continue
 		}
 		switch action.GetVerb() {
 		case "create":
 			podCreates++
+			if createActionIdx == -1 {
+				createActionIdx = idx
+			}
 		case "delete":
-			podDeletes++
+			if createActionIdx >= 0 && idx > createActionIdx {
+				deletesAfterCreate++
+			}
 		}
 	}
 	if podCreates != 1 {
 		t.Fatalf("pod create actions = %d, want 1", podCreates)
 	}
-	if podDeletes < 2 {
-		t.Fatalf("pod delete actions = %d, want at least 2 initial+cleanup deletes", podDeletes)
+	if deleteAfterCreate := deletesAfterCreate; deleteAfterCreate < 1 {
+		t.Fatalf("pod delete actions after create = %d, want at least 1 cleanup delete", deleteAfterCreate)
 	}
 	if _, err := kubeClient.CoreV1().Pods("default").Get(context.Background(), "static-ipv6", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
 		t.Fatalf("pod still exists after cleanup: %v", err)

--- a/e2etests/framework/pod_test.go
+++ b/e2etests/framework/pod_test.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -144,9 +145,44 @@ func TestCreateTestPodDeletesStaticIPv6PodWhenReadinessFails(t *testing.T) {
 	}
 }
 
+func TestCreateTestPodDeletesStaticIPv6PodWhenDADInspectionFails(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+
+	kubeClient := kubefake.NewClientset()
+	f := &Framework{
+		Config:     &config.Config{PodReadyTimeout: time.Second},
+		KubeClient: kubeClient,
+		Client: &mirroringCreateClient{
+			Client:     clientfake.NewClientBuilder().WithScheme(scheme).Build(),
+			kubeClient: kubeClient,
+		},
+		execInPodFn: func(context.Context, string, string, string, []string) (string, string, error) {
+			return "", "inspection failed", errors.New("exec failed")
+		},
+	}
+	f.Client = &mirroringCreateClient{
+		Client:        clientfake.NewClientBuilder().WithScheme(scheme).Build(),
+		kubeClient:    kubeClient,
+		readyOnCreate: true,
+	}
+	err := f.CreateTestPod(context.Background(), "default", "static-ipv6", "worker-1", map[string]string{
+		"k8s.v1.cni.cncf.io/networks": `[{"name":"macvlan-vlan501","ips":["fda5:25c1:193c::1/64"]}]`,
+	})
+	if err == nil || !strings.Contains(err.Error(), "inspection failed") {
+		t.Fatalf("CreateTestPod() error = %v, want inspection failure", err)
+	}
+	if _, err := kubeClient.CoreV1().Pods("default").Get(context.Background(), "static-ipv6", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("pod still exists after inspection cleanup: %v", err)
+	}
+}
+
 type mirroringCreateClient struct {
 	client.Client
-	kubeClient *kubefake.Clientset
+	kubeClient    *kubefake.Clientset
+	readyOnCreate bool
 }
 
 func (c *mirroringCreateClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
@@ -158,6 +194,11 @@ func (c *mirroringCreateClient) Create(ctx context.Context, obj client.Object, o
 	if !ok {
 		return nil
 	}
-	_, err := c.kubeClient.CoreV1().Pods(pod.Namespace).Create(ctx, pod.DeepCopy(), metav1.CreateOptions{})
+	mirror := pod.DeepCopy()
+	if c.readyOnCreate {
+		mirror.Status.Phase = corev1.PodRunning
+		mirror.Status.ContainerStatuses = []corev1.ContainerStatus{{Ready: true}}
+	}
+	_, err := c.kubeClient.CoreV1().Pods(pod.Namespace).Create(ctx, mirror, metav1.CreateOptions{})
 	return err
 }


### PR DESCRIPTION
## Summary
- keep this PR focused on the remaining static IPv6 test-pod cleanup regression after the base DAD retry implementation landed on `main`
- delete a created static IPv6 Multus test pod when readiness or IPv6 DAD inspection fails before retry completion
- add coverage for cleanup on readiness failure while preserving existing behavior for non-static-IPv6 test pods

## Evidence
- PR #295 E2E run 27254468672 failed in Gateway Connectivity with `fd94:685b:30cf:501::10/64 scope global tentative dadfailed` before timing out on IPv6 m2mgw ping
- PR #301 E2E run 27546929790 hit the same Gateway Connectivity `dadfailed` signature after image builds had succeeded

## Validation
- `git diff --check`
- `go test ./e2etests/framework`

CI harness fix: NAT64 route setup now waits for the NAT64 TUN source address before installing the default route, uses `/bin/sh`, and dumps IPv6 routing state if setup fails. This prevents kubeadm DNS timeouts during E2E setup while preserving the intended source address.