### PR TITLE
fix: address dsno CodeQL security findings

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -59,7 +59,14 @@ jobs:
           go-version-file: go.mod
 
       - name: Create Licenses Report
-        run: make licenses-report
+        run: |
+          for attempt in 1 2 3; do
+            if make licenses-report; then
+              exit 0
+            fi
+            sleep 1000 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 1000(attempt * 10))
+          done
+          make licenses-report
 
       - name: Read Go version
         id: go-version

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -64,7 +64,7 @@ jobs:
             if make licenses-report; then
               exit 0
             fi
-            sleep 1000 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 1000(attempt * 10))
+            sleep 10
           done
           make licenses-report
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -182,6 +182,7 @@ jobs:
 
       - name: system-level-dependencies
         run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
           sudo apt update
           sudo apt -y install linux-modules-extra-$(uname -r)
 

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -20,7 +20,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: run code generators
         run: make generate
       - name: golangci-lint
@@ -38,7 +41,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: Run Tests
         run: make test
       - name: Upload coverage report
@@ -59,7 +65,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: run code generators
         run: make generate
       - name: run manifest generators

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -86,8 +86,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-images.yaml
     with:
-      push: true
-      cache-write: true
+      push: false
+      cache-write: false
 
   build-images-fork:
     name: build container images (fork)

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -86,8 +86,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-images.yaml
     with:
-      push: false
-      cache-write: false
+      push: true
+      cache-write: true
 
   build-images-fork:
     name: build container images (fork)

--- a/cmd/agent-cra-vsr/main.go
+++ b/cmd/agent-cra-vsr/main.go
@@ -177,7 +177,7 @@ func createCraManager() (*cra.Manager, error) {
 
 	knownHostsPath := os.Getenv("CRA_KNOWN_HOSTS")
 	if knownHostsPath == "" {
-		return nil, fmt.Errorf("no CRA known hosts file provided")
+		return nil, fmt.Errorf("no CRA known hosts file provided via CRA_KNOWN_HOSTS")
 	}
 
 	craManager, err := cra.NewManager(urls, user, pwd, knownHostsPath, timeout)

--- a/cmd/agent-cra-vsr/main.go
+++ b/cmd/agent-cra-vsr/main.go
@@ -175,7 +175,12 @@ func createCraManager() (*cra.Manager, error) {
 		return nil, fmt.Errorf("no CRA password provided")
 	}
 
-	craManager, err := cra.NewManager(urls, user, pwd, timeout)
+	knownHostsPath := os.Getenv("CRA_KNOWN_HOSTS")
+	if knownHostsPath == "" {
+		return nil, fmt.Errorf("no CRA known hosts file provided")
+	}
+
+	craManager, err := cra.NewManager(urls, user, pwd, knownHostsPath, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("error creating CRA manager: %w", err)
 	}

--- a/cmd/agent-cra-vsr/main.go
+++ b/cmd/agent-cra-vsr/main.go
@@ -180,7 +180,7 @@ func createCraManager() (*cra.Manager, error) {
 		return nil, fmt.Errorf("no CRA known hosts file provided via CRA_KNOWN_HOSTS")
 	}
 
-	craManager, err := cra.NewManager(urls, user, pwd, knownHostsPath, timeout)
+	craManager, err := cra.NewManagerWithKnownHosts(urls, user, pwd, knownHostsPath, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("error creating CRA manager: %w", err)
 	}

--- a/cmd/agent-cra-vsr/main.go
+++ b/cmd/agent-cra-vsr/main.go
@@ -175,7 +175,7 @@ func createCraManager() (*cra.Manager, error) {
 		return nil, fmt.Errorf("no CRA password provided")
 	}
 
-	knownHostsPath := os.Getenv("CRA_KNOWN_HOSTS")
+	knownHostsPath := strings.TrimSpace(os.Getenv("CRA_KNOWN_HOSTS"))
 	if knownHostsPath == "" {
 		return nil, fmt.Errorf("no CRA known hosts file provided via CRA_KNOWN_HOSTS")
 	}

--- a/cmd/agent-cra-vsr/main_test.go
+++ b/cmd/agent-cra-vsr/main_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCreateCraManagerRejectsWhitespaceKnownHostsPath(t *testing.T) {
+	t.Setenv("CRA_URL", "169.254.33.1:830")
+	t.Setenv("CRA_TIMEOUT", "1s")
+	t.Setenv("CRA_USER", "test-user")
+	t.Setenv("CRA_PASSWORD", "test-password")
+	t.Setenv("CRA_KNOWN_HOSTS", "   ")
+
+	_, err := createCraManager()
+	if err == nil {
+		t.Fatal("createCraManager() returned nil error, want missing CRA_KNOWN_HOSTS error")
+	}
+	if !strings.Contains(err.Error(), "CRA_KNOWN_HOSTS") {
+		t.Fatalf("createCraManager() error = %q, want CRA_KNOWN_HOSTS context", err)
+	}
+}

--- a/cmd/frr-cra/main.go
+++ b/cmd/frr-cra/main.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -61,6 +62,10 @@ var (
 // sanitizeLog removes newlines and carriage returns from log messages
 // to prevent log injection attacks (CodeQL: Log entries created from user input).
 var logSanitizer = strings.NewReplacer("\n", "", "\r", "")
+
+func logSafef(format string, args ...any) {
+	log.Print(logSanitizer.Replace(fmt.Sprintf(format, args...)))
+}
 
 func deleteLayer2(cfg *nl.NetlinkConfiguration) error {
 	existing, err := nlManager.ListL2()
@@ -412,7 +417,7 @@ func createVRFs(cfg *nl.NetlinkConfiguration) ([]nl.VRFInformation, error) {
 			}
 		}
 		if !alreadyExists {
-			log.Print(logSanitizer.Replace(fmt.Sprintf("Creating VRF %s", cfg.VRFs[i].Name)))
+			logSafef("Creating VRF %s", cfg.VRFs[i].Name)
 			if err := nlManager.CreateL3(cfg.VRFs[i]); err != nil {
 				return created, fmt.Errorf("error creating L3 (VRF: %s): %w", cfg.VRFs[i].Name, err)
 			}
@@ -542,20 +547,20 @@ func applyConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := writeFRRConfig(craConfiguration.FRRConfiguration); err != nil {
-		log.Print(logSanitizer.Replace(fmt.Sprintf("Failed to write FRR config: %v", err)))
+		logSafef("Failed to write FRR config: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	if err := reconcileNetlink(&craConfiguration.NetlinkConfiguration); err != nil {
-		log.Print(logSanitizer.Replace(fmt.Sprintf("Failed to reconcile netlink: %v", err)))
+		logSafef("Failed to reconcile netlink: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	// Reconcile SBR policy routes as ip rules
 	if err := reconcilePolicyRoutes(craConfiguration.PolicyRoutes); err != nil {
-		log.Print(logSanitizer.Replace(fmt.Sprintf("Failed to reconcile policy routes: %v", err)))
+		logSafef("Failed to reconcile policy routes: %v", err)
 		http.Error(w, fmt.Sprintf("Failed to reconcile policy routes: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -591,7 +596,9 @@ func writeFRRConfig(frrConfig string) error {
 		return fmt.Errorf("failed to open FRR config file: %w", err)
 	}
 	if _, err = io.Copy(file, strings.NewReader(frrConfig)); err != nil {
-		_ = file.Close()
+		if closeErr := file.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
 		return fmt.Errorf("failed to write FRR config: %w", err)
 	}
 	if err := file.Close(); err != nil {

--- a/cmd/frr-cra/main.go
+++ b/cmd/frr-cra/main.go
@@ -452,9 +452,9 @@ func reconcileLayer3(cfg *nl.NetlinkConfiguration) ([]nl.VRFInformation, error) 
 	}
 
 	for i := range vrfsToDelete {
-		errors := nlManager.CleanupL3(vrfsToDelete[i])
-		if len(errors) > 0 {
-			return nil, fmt.Errorf("error cleaning up L3 (VRF: %s): %v", vrfsToDelete[i].Name, errors)
+		cleanupErrs := nlManager.CleanupL3(vrfsToDelete[i])
+		if len(cleanupErrs) > 0 {
+			return nil, fmt.Errorf("error cleaning up L3 (VRF: %s): %v", vrfsToDelete[i].Name, cleanupErrs)
 		}
 	}
 

--- a/config/agent-cra-vsr/agent.yaml
+++ b/config/agent-cra-vsr/agent.yaml
@@ -49,7 +49,7 @@ spec:
             - name: CRA_TIMEOUT
               value: 30s
             - name: CRA_KNOWN_HOSTS
-              value: /etc/cra/known_hosts
+              value: /etc/cra-host/known_hosts
             - name: OPERATOR_NETHEALTHCHECK_CONFIG
               value: /opt/healthcheck/config.yaml
             - name: HOST_IP
@@ -91,7 +91,7 @@ spec:
           volumeMounts:
             - mountPath: /etc/cra/config/base-config.yaml
               name: base-config
-            - mountPath: /etc/cra/known_hosts
+            - mountPath: /etc/cra-host
               name: cra-known-hosts
               readOnly: true
             - mountPath: /opt/healthcheck/
@@ -104,8 +104,8 @@ spec:
             type: File
           name: base-config
         - hostPath:
-            path: /etc/cra/known_hosts
-            type: File
+            path: /etc/cra
+            type: DirectoryOrCreate
           name: cra-known-hosts
         - configMap:
             name: healthcheck-config

--- a/config/agent-cra-vsr/agent.yaml
+++ b/config/agent-cra-vsr/agent.yaml
@@ -48,6 +48,8 @@ spec:
               value: admin
             - name: CRA_TIMEOUT
               value: 30s
+            - name: CRA_KNOWN_HOSTS
+              value: /etc/cra/known_hosts
             - name: OPERATOR_NETHEALTHCHECK_CONFIG
               value: /opt/healthcheck/config.yaml
             - name: HOST_IP
@@ -89,6 +91,9 @@ spec:
           volumeMounts:
             - mountPath: /etc/cra/config/base-config.yaml
               name: base-config
+            - mountPath: /etc/cra/known_hosts
+              name: cra-known-hosts
+              readOnly: true
             - mountPath: /opt/healthcheck/
               name: healthcheck-config
       terminationGracePeriodSeconds: 10
@@ -98,6 +103,10 @@ spec:
             path: /etc/cra/base-config.yaml
             type: File
           name: base-config
+        - hostPath:
+            path: /etc/cra/known_hosts
+            type: File
+          name: cra-known-hosts
         - configMap:
             name: healthcheck-config
           name: healthcheck-config

--- a/config/agent-cra-vsr/agent.yaml
+++ b/config/agent-cra-vsr/agent.yaml
@@ -91,7 +91,7 @@ spec:
           volumeMounts:
             - mountPath: /etc/cra/config/base-config.yaml
               name: base-config
-            - mountPath: /etc/cra-host
+            - mountPath: /etc/cra-host/known_hosts
               name: cra-known-hosts
               readOnly: true
             - mountPath: /opt/healthcheck/
@@ -104,8 +104,8 @@ spec:
             type: File
           name: base-config
         - hostPath:
-            path: /etc/cra
-            type: DirectoryOrCreate
+            path: /etc/cra/known_hosts
+            type: FileOrCreate
           name: cra-known-hosts
         - configMap:
             name: healthcheck-config

--- a/config/agent-cra-vsr/agent.yaml
+++ b/config/agent-cra-vsr/agent.yaml
@@ -105,7 +105,7 @@ spec:
           name: base-config
         - hostPath:
             path: /etc/cra/known_hosts
-            type: FileOrCreate
+            type: File
           name: cra-known-hosts
         - configMap:
             name: healthcheck-config

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "ip -6 route add default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1"
+        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 | grep -q \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/clab/topology.clab.yml
+++ b/e2e/clab/topology.clab.yml
@@ -91,7 +91,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
+        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/images/kind-node/Dockerfile
+++ b/e2e/images/kind-node/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update && \
       iproute2 \
       bridge-utils \
       bpftool \
-      openssh-client \
       tcpdump \
       netplan.io && \
     apt-get clean && \

--- a/e2e/images/kind-node/Dockerfile
+++ b/e2e/images/kind-node/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
       iproute2 \
       bridge-utils \
       bpftool \
+      openssh-client \
       tcpdump \
       netplan.io && \
     apt-get clean && \

--- a/e2e/setup/config.go
+++ b/e2e/setup/config.go
@@ -65,6 +65,9 @@ func generateNodeConfig(genDir, tplDir string, node Node, clusterVNI int, cluste
 	if err := os.WriteFile(filepath.Join(nodeDir, "cra/flavour"), []byte("frr\n"), 0o644); err != nil {
 		return err
 	}
+	if err := os.WriteFile(filepath.Join(nodeDir, "cra/known_hosts"), nil, 0o644); err != nil {
+		return err
+	}
 
 	data := templateData{
 		VtepIP:        node.VtepIP,

--- a/e2e/setup/phases.go
+++ b/e2e/setup/phases.go
@@ -319,7 +319,7 @@ func PhaseUnderlay(cluster *Cluster) error {
 
 	// Wait for BGP convergence
 	Logf("Waiting for BGP convergence...")
-	return WaitFor("BGP convergence", 120*time.Second, 5*time.Second, func() (bool, error) {
+	if err := WaitFor("BGP convergence", 120*time.Second, 5*time.Second, func() (bool, error) {
 		out, err := DockerExec("clab-nwop-leaf1", "vtysh", "-c", "show bgp summary json")
 		if err != nil {
 			return false, err
@@ -352,7 +352,34 @@ func PhaseUnderlay(cluster *Cluster) error {
 		}
 		Logf("  BGP: %d/4 peers established on leaf1", established)
 		return established >= 4, nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	return writeCRAKnownHosts(cluster)
+}
+
+func writeCRAKnownHosts(cluster *Cluster) error {
+	for _, node := range cluster.Nodes {
+		craPID, err := getCRAPID(node.Name)
+		if err != nil {
+			return fmt.Errorf("getting CRA PID on %s: %w", node.Name, err)
+		}
+
+		script := fmt.Sprintf(`nsenter -t %s -m -- sh -c 'for key in /etc/ssh/ssh_host_*_key.pub; do [ -f "$key" ] || continue; read -r key_type key_data _ < "$key"; printf "[169.254.33.1]:830 %%s %%s\n" "$key_type" "$key_data"; done'`, craPID)
+		knownHosts, err := DockerExecShell(node.Name, script)
+		if err != nil {
+			return fmt.Errorf("reading CRA host keys on %s: %w", node.Name, err)
+		}
+		knownHosts = strings.TrimSpace(knownHosts)
+		if knownHosts == "" {
+			return fmt.Errorf("no CRA host keys found on %s", node.Name)
+		}
+		if err := DockerExecInput(node.Name, knownHosts+"\n", "tee", "/etc/cra/known_hosts"); err != nil {
+			return fmt.Errorf("writing CRA known_hosts on %s: %w", node.Name, err)
+		}
+	}
+	return nil
 }
 
 // Phase 3: Configure NAT64/DNS64 and deploy kube-vip.

--- a/e2e/setup/phases.go
+++ b/e2e/setup/phases.go
@@ -360,19 +360,12 @@ func PhaseUnderlay(cluster *Cluster) error {
 }
 
 func writeCRAKnownHosts(cluster *Cluster) error {
+	// The FRR-based E2E CRA has no SSH/NETCONF server; this placeholder covers
+	// startup validation of the configured CRA URL without requiring live scan.
+	const e2eCRAKnownHosts = "[169.254.33.1]:830 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8g"
+
 	for _, node := range cluster.Nodes {
-		var knownHosts string
-		if err := WaitFor("CRA host key on "+node.Name, 30*time.Second, 2*time.Second, func() (bool, error) {
-			out, err := DockerExecShell(node.Name, "ssh-keyscan -T 5 -p 830 169.254.33.1 2>/dev/null")
-			if err != nil {
-				return false, nil
-			}
-			knownHosts = strings.TrimSpace(out)
-			return knownHosts != "", nil
-		}); err != nil {
-			return fmt.Errorf("reading CRA host key on %s: %w", node.Name, err)
-		}
-		if err := DockerExecInput(node.Name, knownHosts+"\n", "tee", "/etc/cra/known_hosts"); err != nil {
+		if err := DockerExecInput(node.Name, e2eCRAKnownHosts+"\n", "tee", "/etc/cra/known_hosts"); err != nil {
 			return fmt.Errorf("writing CRA known_hosts on %s: %w", node.Name, err)
 		}
 	}

--- a/e2e/setup/phases.go
+++ b/e2e/setup/phases.go
@@ -361,19 +361,16 @@ func PhaseUnderlay(cluster *Cluster) error {
 
 func writeCRAKnownHosts(cluster *Cluster) error {
 	for _, node := range cluster.Nodes {
-		craPID, err := getCRAPID(node.Name)
-		if err != nil {
-			return fmt.Errorf("getting CRA PID on %s: %w", node.Name, err)
-		}
-
-		script := fmt.Sprintf(`nsenter -t %s -m -- sh -c 'for key in /etc/ssh/ssh_host_*_key.pub; do [ -f "$key" ] || continue; read -r key_type key_data _ < "$key"; printf "[169.254.33.1]:830 %%s %%s\n" "$key_type" "$key_data"; done'`, craPID)
-		knownHosts, err := DockerExecShell(node.Name, script)
-		if err != nil {
-			return fmt.Errorf("reading CRA host keys on %s: %w", node.Name, err)
-		}
-		knownHosts = strings.TrimSpace(knownHosts)
-		if knownHosts == "" {
-			return fmt.Errorf("no CRA host keys found on %s", node.Name)
+		var knownHosts string
+		if err := WaitFor("CRA host key on "+node.Name, 30*time.Second, 2*time.Second, func() (bool, error) {
+			out, err := DockerExecShell(node.Name, "ssh-keyscan -T 5 -p 830 169.254.33.1 2>/dev/null")
+			if err != nil {
+				return false, nil
+			}
+			knownHosts = strings.TrimSpace(out)
+			return knownHosts != "", nil
+		}); err != nil {
+			return fmt.Errorf("reading CRA host key on %s: %w", node.Name, err)
 		}
 		if err := DockerExecInput(node.Name, knownHosts+"\n", "tee", "/etc/cra/known_hosts"); err != nil {
 			return fmt.Errorf("writing CRA known_hosts on %s: %w", node.Name, err)

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "ip -6 route add default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1"
+        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "bash -c 'for i in $(seq 1 30); do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; sleep 1; done; ip -6 addr show; exit 1'"
+        - "sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/e2e/setup/topology.clab.yml
+++ b/e2e/setup/topology.clab.yml
@@ -73,7 +73,7 @@ topology:
       exec:
         - ip addr add fddf:64ff:9b00:1::1/127 dev eth1
         - ip addr add fddf:64ff:9b00:2::1/127 dev eth2
-        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
+        - "/bin/sh -c 'i=0; while [ \"$i\" -lt 30 ]; do ip -6 addr show dev nat64 | grep -q \"inet6 fda5:25c1:193e::1\" && ip -6 route replace default src fda5:25c1:193e::1 nexthop via fddf:64ff:9b00:1:: dev eth1 weight 1 nexthop via fddf:64ff:9b00:2:: dev eth2 weight 1 && exit 0; i=$((i + 1)); sleep 1; done; ip -6 addr show; ip -6 route show; exit 1'"
 
     # ── Test runner ──
     tester:

--- a/pkg/cra-vsr/manager.go
+++ b/pkg/cra-vsr/manager.go
@@ -71,11 +71,17 @@ type Metrics struct {
 func NewManager(
 	urls []string,
 	user, password string,
+	knownHostsPath string,
 	timeout time.Duration,
 ) (*Manager, error) {
+	netconfClient, err := NewNetconf(urls, user, password, knownHostsPath, timeout)
+	if err != nil {
+		return nil, err
+	}
+
 	m := &Manager{
 		timeout: timeout,
-		nc:      NewNetconf(urls, user, password, timeout),
+		nc:      netconfClient,
 	}
 	ctx := context.Background()
 

--- a/pkg/cra-vsr/manager.go
+++ b/pkg/cra-vsr/manager.go
@@ -77,11 +77,17 @@ type Metrics struct {
 func NewManager(
 	urls []string,
 	user, password string,
+	knownHostsPath string,
 	timeout time.Duration,
 ) (*Manager, error) {
+	netconfClient, err := NewNetconf(urls, user, password, knownHostsPath, timeout)
+	if err != nil {
+		return nil, err
+	}
+
 	m := &Manager{
 		timeout: timeout,
-		nc:      NewNetconf(urls, user, password, timeout),
+		nc:      netconfClient,
 	}
 	ctx := context.Background()
 

--- a/pkg/cra-vsr/manager.go
+++ b/pkg/cra-vsr/manager.go
@@ -74,13 +74,43 @@ type Metrics struct {
 	BridgeFDB        ShowBridgeFDBOutput
 }
 
+// NewManager creates a CRA manager with the legacy host-key behavior.
+//
+// Deprecated: use NewManagerWithKnownHosts for host-key verification.
 func NewManager(
+	urls []string,
+	user, password string,
+	timeout time.Duration,
+) (*Manager, error) {
+	return buildManager(urls, user, password, "", timeout, false)
+}
+
+// NewManagerWithKnownHosts creates a CRA manager that verifies CRA host keys
+// against the supplied known_hosts file.
+func NewManagerWithKnownHosts(
 	urls []string,
 	user, password string,
 	knownHostsPath string,
 	timeout time.Duration,
 ) (*Manager, error) {
-	netconfClient, err := NewNetconf(urls, user, password, knownHostsPath, timeout)
+	return buildManager(urls, user, password, knownHostsPath, timeout, true)
+}
+
+func buildManager(
+	urls []string,
+	user, password, knownHostsPath string,
+	timeout time.Duration,
+	verifyKnownHosts bool,
+) (*Manager, error) {
+	var (
+		netconfClient *Netconf
+		err           error
+	)
+	if verifyKnownHosts {
+		netconfClient, err = NewNetconfWithKnownHosts(urls, user, password, knownHostsPath, timeout)
+	} else {
+		netconfClient = NewNetconf(urls, user, password, timeout)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cra-vsr/netconf.go
+++ b/pkg/cra-vsr/netconf.go
@@ -117,6 +117,8 @@ func NewNetconf(urls []string, user, pwd, knownHostsPath string, timeout time.Du
 }
 
 func validateKnownHostsEntries(knownHostsPath string, urls []string) error {
+	const knownHostsMarkerFieldCount = 3
+
 	required := map[string]struct{}{}
 	for _, rawURL := range urls {
 		url := strings.TrimSpace(rawURL)
@@ -144,7 +146,7 @@ func validateKnownHostsEntries(knownHostsPath string, urls []string) error {
 
 		hostField := fields[0]
 		if strings.HasPrefix(hostField, "@") {
-			if len(fields) < 3 {
+			if len(fields) < knownHostsMarkerFieldCount {
 				continue
 			}
 			hostField = fields[1]

--- a/pkg/cra-vsr/netconf.go
+++ b/pkg/cra-vsr/netconf.go
@@ -17,12 +17,15 @@ limitations under the License.
 package cra
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -91,6 +94,10 @@ type Netconf struct {
 }
 
 func NewNetconf(urls []string, user, pwd, knownHostsPath string, timeout time.Duration) (*Netconf, error) {
+	if err := validateKnownHostsEntries(knownHostsPath, urls); err != nil {
+		return nil, err
+	}
+
 	hostKeyCallback, err := knownhosts.New(knownHostsPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load known hosts file %q: %w", knownHostsPath, err)
@@ -107,6 +114,65 @@ func NewNetconf(urls []string, user, pwd, knownHostsPath string, timeout time.Du
 			HostKeyCallback: hostKeyCallback,
 		},
 	}, nil
+}
+
+func validateKnownHostsEntries(knownHostsPath string, urls []string) error {
+	required := map[string]struct{}{}
+	for _, rawURL := range urls {
+		url := strings.TrimSpace(rawURL)
+		if url == "" {
+			continue
+		}
+		required[knownhosts.Normalize(url)] = struct{}{}
+	}
+	if len(required) == 0 {
+		return fmt.Errorf("no CRA URLs provided")
+	}
+
+	knownHosts, err := os.ReadFile(knownHostsPath)
+	if err != nil {
+		return fmt.Errorf("failed to read known hosts file %q: %w", knownHostsPath, err)
+	}
+
+	found := map[string]struct{}{}
+	scanner := bufio.NewScanner(bytes.NewReader(knownHosts))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 || strings.HasPrefix(fields[0], "#") {
+			continue
+		}
+
+		hostField := fields[0]
+		if strings.HasPrefix(hostField, "@") {
+			if len(fields) < 3 {
+				continue
+			}
+			hostField = fields[1]
+		}
+
+		for _, host := range strings.Split(hostField, ",") {
+			normalized := knownhosts.Normalize(host)
+			if _, ok := required[normalized]; ok {
+				found[normalized] = struct{}{}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to scan known hosts file %q: %w", knownHostsPath, err)
+	}
+
+	missing := []string{}
+	for url := range required {
+		if _, ok := found[url]; !ok {
+			missing = append(missing, url)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("known hosts file %q does not contain CRA URL entries: %s", knownHostsPath, strings.Join(missing, ", "))
+	}
+
+	return nil
 }
 
 func (nc *Netconf) Open(ctx context.Context) error {

--- a/pkg/cra-vsr/netconf.go
+++ b/pkg/cra-vsr/netconf.go
@@ -94,7 +94,8 @@ type Netconf struct {
 }
 
 func NewNetconf(urls []string, user, pwd, knownHostsPath string, timeout time.Duration) (*Netconf, error) {
-	if err := validateKnownHostsEntries(knownHostsPath, urls); err != nil {
+	normalizedURLs := normalizeCRAURLs(urls)
+	if err := validateKnownHostsEntries(knownHostsPath, normalizedURLs); err != nil {
 		return nil, err
 	}
 
@@ -104,7 +105,7 @@ func NewNetconf(urls []string, user, pwd, knownHostsPath string, timeout time.Du
 	}
 
 	return &Netconf{
-		urls:    urls,
+		urls:    normalizedURLs,
 		timeout: timeout,
 		sshConfig: &ssh.ClientConfig{
 			User: user,
@@ -116,15 +117,23 @@ func NewNetconf(urls []string, user, pwd, knownHostsPath string, timeout time.Du
 	}, nil
 }
 
-func validateKnownHostsEntries(knownHostsPath string, urls []string) error {
-	const knownHostsMarkerFieldCount = 3
-
-	required := map[string]struct{}{}
+func normalizeCRAURLs(urls []string) []string {
+	normalized := make([]string, 0, len(urls))
 	for _, rawURL := range urls {
 		url := strings.TrimSpace(rawURL)
 		if url == "" {
 			continue
 		}
+		normalized = append(normalized, url)
+	}
+	return normalized
+}
+
+func validateKnownHostsEntries(knownHostsPath string, urls []string) error {
+	const knownHostsMarkerFieldCount = 3
+
+	required := map[string]struct{}{}
+	for _, url := range normalizeCRAURLs(urls) {
 		required[knownhosts.Normalize(url)] = struct{}{}
 	}
 	if len(required) == 0 {

--- a/pkg/cra-vsr/netconf.go
+++ b/pkg/cra-vsr/netconf.go
@@ -148,6 +148,10 @@ func validateKnownHostsEntries(knownHostsPath string, urls []string) error {
 
 	missing := []string{}
 	for _, url := range normalizedURLs {
+		if _, _, err := net.SplitHostPort(url); err != nil {
+			return fmt.Errorf("CRA URL %q must be in host:port form: %w", url, err)
+		}
+
 		hasEntry, err := knownHostsHasEntry(hostKeyCallback, url, validationKey)
 		if err != nil {
 			return fmt.Errorf("validate known hosts entry for CRA URL %q in file %q: %w", url, knownHostsPath, err)

--- a/pkg/cra-vsr/netconf.go
+++ b/pkg/cra-vsr/netconf.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 	"nemith.io/netconf"
 	"nemith.io/netconf/rpc"
 	ncssh "nemith.io/netconf/transport/ssh"
@@ -89,7 +90,12 @@ type Netconf struct {
 	urls      []string
 }
 
-func NewNetconf(urls []string, user, pwd string, timeout time.Duration) *Netconf {
+func NewNetconf(urls []string, user, pwd, knownHostsPath string, timeout time.Duration) (*Netconf, error) {
+	hostKeyCallback, err := knownhosts.New(knownHostsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load known hosts file %q: %w", knownHostsPath, err)
+	}
+
 	return &Netconf{
 		urls:    urls,
 		timeout: timeout,
@@ -98,13 +104,9 @@ func NewNetconf(urls []string, user, pwd string, timeout time.Duration) *Netconf
 			Auth: []ssh.AuthMethod{
 				ssh.Password(pwd),
 			},
-			// InsecureIgnoreHostKey is acceptable here because the NETCONF target is a
-			// locally managed network device reachable only within the cluster's trust
-			// boundary. Host-key verification would require pre-distributing known-hosts
-			// for each device and is not operationally feasible in this environment.
-			HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+			HostKeyCallback: hostKeyCallback,
 		},
-	}
+	}, nil
 }
 
 func (nc *Netconf) Open(ctx context.Context) error {

--- a/pkg/cra-vsr/netconf.go
+++ b/pkg/cra-vsr/netconf.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
-	"crypto/rand"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -96,6 +95,7 @@ type Netconf struct {
 
 func NewNetconf(urls []string, user, pwd, knownHostsPath string, timeout time.Duration) (*Netconf, error) {
 	normalizedURLs := normalizeCRAURLs(urls)
+	knownHostsPath = strings.TrimSpace(knownHostsPath)
 	if err := validateKnownHostsEntries(knownHostsPath, normalizedURLs); err != nil {
 		return nil, err
 	}
@@ -131,6 +131,11 @@ func normalizeCRAURLs(urls []string) []string {
 }
 
 func validateKnownHostsEntries(knownHostsPath string, urls []string) error {
+	knownHostsPath = strings.TrimSpace(knownHostsPath)
+	if knownHostsPath == "" {
+		return fmt.Errorf("known hosts file path is required")
+	}
+
 	normalizedURLs := normalizeCRAURLs(urls)
 	if len(normalizedURLs) == 0 {
 		return fmt.Errorf("no CRA URLs provided")
@@ -169,9 +174,9 @@ func validateKnownHostsEntries(knownHostsPath string, urls []string) error {
 }
 
 func newKnownHostsValidationKey() (ssh.PublicKey, error) {
-	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		return nil, fmt.Errorf("generate validation SSH key: %w", err)
+	publicKey := make(ed25519.PublicKey, ed25519.PublicKeySize)
+	for i := range publicKey {
+		publicKey[i] = byte(i + 1)
 	}
 	sshKey, err := ssh.NewPublicKey(publicKey)
 	if err != nil {

--- a/pkg/cra-vsr/netconf.go
+++ b/pkg/cra-vsr/netconf.go
@@ -177,8 +177,13 @@ func newKnownHostsValidationKey() (ssh.PublicKey, error) {
 }
 
 func knownHostsHasEntry(hostKeyCallback ssh.HostKeyCallback, address string, validationKey ssh.PublicKey) (bool, error) {
+	const (
+		validationCallbackLoopback = "127.0.0.1"
+		validationCallbackPort     = 22
+	)
+
 	callbackAddress := knownHostsCallbackAddress(address)
-	err := hostKeyCallback(callbackAddress, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 22}, validationKey)
+	err := hostKeyCallback(callbackAddress, &net.TCPAddr{IP: net.ParseIP(validationCallbackLoopback), Port: validationCallbackPort}, validationKey)
 	if err == nil {
 		return true, nil
 	}

--- a/pkg/cra-vsr/netconf.go
+++ b/pkg/cra-vsr/netconf.go
@@ -17,14 +17,15 @@ limitations under the License.
 package cra
 
 import (
-	"bufio"
 	"bytes"
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
-	"os"
+	"net"
 	"sort"
 	"strings"
 	"time"
@@ -130,52 +131,29 @@ func normalizeCRAURLs(urls []string) []string {
 }
 
 func validateKnownHostsEntries(knownHostsPath string, urls []string) error {
-	const knownHostsMarkerFieldCount = 3
-
-	required := map[string]struct{}{}
-	for _, url := range normalizeCRAURLs(urls) {
-		required[knownhosts.Normalize(url)] = struct{}{}
-	}
-	if len(required) == 0 {
+	normalizedURLs := normalizeCRAURLs(urls)
+	if len(normalizedURLs) == 0 {
 		return fmt.Errorf("no CRA URLs provided")
 	}
 
-	knownHosts, err := os.ReadFile(knownHostsPath)
+	hostKeyCallback, err := knownhosts.New(knownHostsPath)
 	if err != nil {
-		return fmt.Errorf("failed to read known hosts file %q: %w", knownHostsPath, err)
+		return fmt.Errorf("failed to load known hosts file %q: %w", knownHostsPath, err)
 	}
 
-	found := map[string]struct{}{}
-	scanner := bufio.NewScanner(bytes.NewReader(knownHosts))
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-		if len(fields) < 2 || strings.HasPrefix(fields[0], "#") {
-			continue
-		}
-
-		hostField := fields[0]
-		if strings.HasPrefix(hostField, "@") {
-			if len(fields) < knownHostsMarkerFieldCount {
-				continue
-			}
-			hostField = fields[1]
-		}
-
-		for _, host := range strings.Split(hostField, ",") {
-			normalized := knownhosts.Normalize(host)
-			if _, ok := required[normalized]; ok {
-				found[normalized] = struct{}{}
-			}
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("failed to scan known hosts file %q: %w", knownHostsPath, err)
+	validationKey, err := newKnownHostsValidationKey()
+	if err != nil {
+		return err
 	}
 
 	missing := []string{}
-	for url := range required {
-		if _, ok := found[url]; !ok {
-			missing = append(missing, url)
+	for _, url := range normalizedURLs {
+		hasEntry, err := knownHostsHasEntry(hostKeyCallback, url, validationKey)
+		if err != nil {
+			return fmt.Errorf("validate known hosts entry for CRA URL %q in file %q: %w", url, knownHostsPath, err)
+		}
+		if !hasEntry {
+			missing = append(missing, knownhosts.Normalize(url))
 		}
 	}
 	if len(missing) > 0 {
@@ -184,6 +162,46 @@ func validateKnownHostsEntries(knownHostsPath string, urls []string) error {
 	}
 
 	return nil
+}
+
+func newKnownHostsValidationKey() (ssh.PublicKey, error) {
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate validation SSH key: %w", err)
+	}
+	sshKey, err := ssh.NewPublicKey(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("create validation SSH key: %w", err)
+	}
+	return sshKey, nil
+}
+
+func knownHostsHasEntry(hostKeyCallback ssh.HostKeyCallback, address string, validationKey ssh.PublicKey) (bool, error) {
+	callbackAddress := knownHostsCallbackAddress(address)
+	err := hostKeyCallback(callbackAddress, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 22}, validationKey)
+	if err == nil {
+		return true, nil
+	}
+
+	var keyErr *knownhosts.KeyError
+	if errors.As(err, &keyErr) {
+		return len(keyErr.Want) > 0, nil
+	}
+
+	return false, err
+}
+
+func knownHostsCallbackAddress(address string) string {
+	if _, _, err := net.SplitHostPort(address); err == nil {
+		return address
+	}
+
+	normalized := knownhosts.Normalize(address)
+	if _, _, err := net.SplitHostPort(normalized); err == nil {
+		return normalized
+	}
+
+	return net.JoinHostPort(strings.Trim(normalized, "[]"), "22")
 }
 
 func (nc *Netconf) Open(ctx context.Context) error {

--- a/pkg/cra-vsr/netconf.go
+++ b/pkg/cra-vsr/netconf.go
@@ -93,15 +93,28 @@ type Netconf struct {
 	urls      []string
 }
 
-func NewNetconf(urls []string, user, pwd, knownHostsPath string, timeout time.Duration) (*Netconf, error) {
+// NewNetconf creates a NETCONF client with the legacy host-key behavior.
+//
+// Deprecated: use NewNetconfWithKnownHosts for host-key verification.
+func NewNetconf(urls []string, user, pwd string, timeout time.Duration) *Netconf {
+	return buildNetconf(urls, user, pwd, timeout, ssh.InsecureIgnoreHostKey()) //nolint:gosec // preserve legacy API behavior
+}
+
+// NewNetconfWithKnownHosts creates a NETCONF client that verifies CRA host keys
+// against the supplied known_hosts file.
+func NewNetconfWithKnownHosts(urls []string, user, pwd, knownHostsPath string, timeout time.Duration) (*Netconf, error) {
 	normalizedURLs := normalizeCRAURLs(urls)
 	hostKeyCallback, err := validateKnownHostsEntries(knownHostsPath, normalizedURLs)
 	if err != nil {
 		return nil, err
 	}
 
+	return buildNetconf(normalizedURLs, user, pwd, timeout, hostKeyCallback), nil
+}
+
+func buildNetconf(urls []string, user, pwd string, timeout time.Duration, hostKeyCallback ssh.HostKeyCallback) *Netconf {
 	return &Netconf{
-		urls:    normalizedURLs,
+		urls:    normalizeCRAURLs(urls),
 		timeout: timeout,
 		sshConfig: &ssh.ClientConfig{
 			User: user,
@@ -110,7 +123,7 @@ func NewNetconf(urls []string, user, pwd, knownHostsPath string, timeout time.Du
 			},
 			HostKeyCallback: hostKeyCallback,
 		},
-	}, nil
+	}
 }
 
 func normalizeCRAURLs(urls []string) []string {

--- a/pkg/cra-vsr/netconf.go
+++ b/pkg/cra-vsr/netconf.go
@@ -95,14 +95,9 @@ type Netconf struct {
 
 func NewNetconf(urls []string, user, pwd, knownHostsPath string, timeout time.Duration) (*Netconf, error) {
 	normalizedURLs := normalizeCRAURLs(urls)
-	knownHostsPath = strings.TrimSpace(knownHostsPath)
-	if err := validateKnownHostsEntries(knownHostsPath, normalizedURLs); err != nil {
-		return nil, err
-	}
-
-	hostKeyCallback, err := knownhosts.New(knownHostsPath)
+	hostKeyCallback, err := validateKnownHostsEntries(knownHostsPath, normalizedURLs)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load known hosts file %q: %w", knownHostsPath, err)
+		return nil, err
 	}
 
 	return &Netconf{
@@ -130,36 +125,36 @@ func normalizeCRAURLs(urls []string) []string {
 	return normalized
 }
 
-func validateKnownHostsEntries(knownHostsPath string, urls []string) error {
+func validateKnownHostsEntries(knownHostsPath string, urls []string) (ssh.HostKeyCallback, error) {
 	knownHostsPath = strings.TrimSpace(knownHostsPath)
 	if knownHostsPath == "" {
-		return fmt.Errorf("known hosts file path is required")
+		return nil, fmt.Errorf("known hosts file path is required")
 	}
 
 	normalizedURLs := normalizeCRAURLs(urls)
 	if len(normalizedURLs) == 0 {
-		return fmt.Errorf("no CRA URLs provided")
+		return nil, fmt.Errorf("no CRA URLs provided")
 	}
 
 	hostKeyCallback, err := knownhosts.New(knownHostsPath)
 	if err != nil {
-		return fmt.Errorf("failed to load known hosts file %q: %w", knownHostsPath, err)
+		return nil, fmt.Errorf("failed to load known hosts file %q: %w", knownHostsPath, err)
 	}
 
 	validationKey, err := newKnownHostsValidationKey()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	missing := []string{}
 	for _, url := range normalizedURLs {
 		if _, _, err := net.SplitHostPort(url); err != nil {
-			return fmt.Errorf("CRA URL %q must be in host:port form: %w", url, err)
+			return nil, fmt.Errorf("CRA URL %q must be in host:port form: %w", url, err)
 		}
 
 		hasEntry, err := knownHostsHasEntry(hostKeyCallback, url, validationKey)
 		if err != nil {
-			return fmt.Errorf("validate known hosts entry for CRA URL %q in file %q: %w", url, knownHostsPath, err)
+			return nil, fmt.Errorf("validate known hosts entry for CRA URL %q in file %q: %w", url, knownHostsPath, err)
 		}
 		if !hasEntry {
 			missing = append(missing, knownhosts.Normalize(url))
@@ -167,10 +162,10 @@ func validateKnownHostsEntries(knownHostsPath string, urls []string) error {
 	}
 	if len(missing) > 0 {
 		sort.Strings(missing)
-		return fmt.Errorf("known hosts file %q does not contain CRA URL entries: %s", knownHostsPath, strings.Join(missing, ", "))
+		return nil, fmt.Errorf("known hosts file %q does not contain CRA URL entries: %s", knownHostsPath, strings.Join(missing, ", "))
 	}
 
-	return nil
+	return hostKeyCallback, nil
 }
 
 func newKnownHostsValidationKey() (ssh.PublicKey, error) {

--- a/pkg/cra-vsr/netconf_test.go
+++ b/pkg/cra-vsr/netconf_test.go
@@ -104,6 +104,22 @@ func TestValidateKnownHostsEntries(t *testing.T) {
 	}
 }
 
+func TestNewNetconf_NormalizesCRAURLs(t *testing.T) {
+	hostKey := newTestPublicKey(t)
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	if err := os.WriteFile(path, []byte(knownhosts.Line([]string{"[169.254.33.1]:830"}, hostKey)), 0o600); err != nil {
+		t.Fatalf("write known_hosts: %v", err)
+	}
+
+	nc, err := NewNetconf([]string{" 169.254.33.1:830 ", ""}, "user", "password", path, 0)
+	if err != nil {
+		t.Fatalf("NewNetconf returned error: %v", err)
+	}
+	if len(nc.urls) != 1 || nc.urls[0] != "169.254.33.1:830" {
+		t.Fatalf("urls = %#v, want normalized CRA URL", nc.urls)
+	}
+}
+
 func newTestPublicKey(t *testing.T) ssh.PublicKey {
 	t.Helper()
 

--- a/pkg/cra-vsr/netconf_test.go
+++ b/pkg/cra-vsr/netconf_test.go
@@ -137,6 +137,16 @@ func TestNewNetconf_NormalizesCRAURLs(t *testing.T) {
 	}
 }
 
+func TestNewNetconf_RejectsMissingKnownHostsPath(t *testing.T) {
+	_, err := NewNetconf([]string{"169.254.33.1:830"}, "user", "password", " ", 0)
+	if err == nil {
+		t.Fatal("NewNetconf returned nil error, want missing known hosts path error")
+	}
+	if !strings.Contains(err.Error(), "known hosts file path is required") {
+		t.Fatalf("NewNetconf error = %q, want known hosts path context", err)
+	}
+}
+
 func newTestPublicKey(t *testing.T) ssh.PublicKey {
 	t.Helper()
 

--- a/pkg/cra-vsr/netconf_test.go
+++ b/pkg/cra-vsr/netconf_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cra
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+func TestValidateKnownHostsEntries(t *testing.T) {
+	hostKey := newTestPublicKey(t)
+
+	tests := []struct {
+		name       string
+		lines      []string
+		urls       []string
+		wantErrSub string
+	}{
+		{
+			name:  "single CRA endpoint",
+			lines: []string{knownhosts.Line([]string{"[169.254.33.1]:830"}, hostKey)},
+			urls:  []string{"169.254.33.1:830"},
+		},
+		{
+			name: "multiple CRA endpoints",
+			lines: []string{
+				knownhosts.Line([]string{"[169.254.33.1]:830"}, hostKey),
+				knownhosts.Line([]string{"[169.254.33.2]:830"}, hostKey),
+			},
+			urls: []string{"169.254.33.1:830", "169.254.33.2:830"},
+		},
+		{
+			name:  "marker line",
+			lines: []string{"@cert-authority " + knownhosts.Line([]string{"[169.254.33.1]:830"}, hostKey)},
+			urls:  []string{"169.254.33.1:830"},
+		},
+		{
+			name:       "missing host",
+			lines:      []string{knownhosts.Line([]string{"[169.254.33.2]:830"}, hostKey)},
+			urls:       []string{"169.254.33.1:830"},
+			wantErrSub: "does not contain CRA URL entries: [169.254.33.1]:830",
+		},
+		{
+			name:       "wrong port",
+			lines:      []string{knownhosts.Line([]string{"169.254.33.1"}, hostKey)},
+			urls:       []string{"169.254.33.1:830"},
+			wantErrSub: "does not contain CRA URL entries: [169.254.33.1]:830",
+		},
+		{
+			name:       "empty file",
+			urls:       []string{"169.254.33.1:830"},
+			wantErrSub: "does not contain CRA URL entries: [169.254.33.1]:830",
+		},
+		{
+			name:       "empty URLs",
+			lines:      []string{knownhosts.Line([]string{"[169.254.33.1]:830"}, hostKey)},
+			urls:       []string{"", " "},
+			wantErrSub: "no CRA URLs provided",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "known_hosts")
+			if err := os.WriteFile(path, []byte(strings.Join(tt.lines, "\n")), 0o600); err != nil {
+				t.Fatalf("write known_hosts: %v", err)
+			}
+
+			err := validateKnownHostsEntries(path, tt.urls)
+			if tt.wantErrSub == "" {
+				if err != nil {
+					t.Fatalf("validateKnownHostsEntries returned error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.wantErrSub)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrSub) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErrSub)
+			}
+		})
+	}
+}
+
+func newTestPublicKey(t *testing.T) ssh.PublicKey {
+	t.Helper()
+
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate test SSH key: %v", err)
+	}
+	sshKey, err := ssh.NewPublicKey(publicKey)
+	if err != nil {
+		t.Fatalf("convert test SSH key: %v", err)
+	}
+
+	return sshKey
+}

--- a/pkg/cra-vsr/netconf_test.go
+++ b/pkg/cra-vsr/netconf_test.go
@@ -79,6 +79,12 @@ func TestValidateKnownHostsEntries(t *testing.T) {
 			wantErrSub: "does not contain CRA URL entries: [169.254.33.1]:830",
 		},
 		{
+			name:       "missing port",
+			lines:      []string{knownhosts.Line([]string{"169.254.33.1"}, hostKey)},
+			urls:       []string{"169.254.33.1"},
+			wantErrSub: `CRA URL "169.254.33.1" must be in host:port form`,
+		},
+		{
 			name:       "empty file",
 			urls:       []string{"169.254.33.1:830"},
 			wantErrSub: "does not contain CRA URL entries: [169.254.33.1]:830",

--- a/pkg/cra-vsr/netconf_test.go
+++ b/pkg/cra-vsr/netconf_test.go
@@ -19,6 +19,7 @@ package cra
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,6 +55,16 @@ func TestValidateKnownHostsEntries(t *testing.T) {
 			name:  "marker line",
 			lines: []string{"@cert-authority " + knownhosts.Line([]string{"[169.254.33.1]:830"}, hostKey)},
 			urls:  []string{"169.254.33.1:830"},
+		},
+		{
+			name:  "hashed host",
+			lines: []string{knownHostsLineForPattern(knownhosts.HashHostname("[169.254.33.1]:830"), hostKey)},
+			urls:  []string{"169.254.33.1:830"},
+		},
+		{
+			name:  "wildcard host",
+			lines: []string{knownHostsLineForPattern("[*.example.com]:830", hostKey)},
+			urls:  []string{"cra.example.com:830"},
 		},
 		{
 			name:       "missing host",
@@ -133,4 +144,8 @@ func newTestPublicKey(t *testing.T) ssh.PublicKey {
 	}
 
 	return sshKey
+}
+
+func knownHostsLineForPattern(pattern string, key ssh.PublicKey) string {
+	return pattern + " " + key.Type() + " " + base64.StdEncoding.EncodeToString(key.Marshal())
 }

--- a/pkg/cra-vsr/netconf_test.go
+++ b/pkg/cra-vsr/netconf_test.go
@@ -104,7 +104,7 @@ func TestValidateKnownHostsEntries(t *testing.T) {
 				t.Fatalf("write known_hosts: %v", err)
 			}
 
-			err := validateKnownHostsEntries(path, tt.urls)
+			_, err := validateKnownHostsEntries(path, tt.urls)
 			if tt.wantErrSub == "" {
 				if err != nil {
 					t.Fatalf("validateKnownHostsEntries returned error: %v", err)

--- a/pkg/cra-vsr/netconf_test.go
+++ b/pkg/cra-vsr/netconf_test.go
@@ -24,9 +24,15 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+var (
+	_ func([]string, string, string, time.Duration) *Netconf          = NewNetconf
+	_ func([]string, string, string, time.Duration) (*Manager, error) = NewManager
 )
 
 func TestValidateKnownHostsEntries(t *testing.T) {
@@ -128,22 +134,51 @@ func TestNewNetconf_NormalizesCRAURLs(t *testing.T) {
 		t.Fatalf("write known_hosts: %v", err)
 	}
 
-	nc, err := NewNetconf([]string{" 169.254.33.1:830 ", ""}, "user", "password", path, 0)
+	nc, err := NewNetconfWithKnownHosts([]string{" 169.254.33.1:830 ", ""}, "user", "password", path, 0)
 	if err != nil {
-		t.Fatalf("NewNetconf returned error: %v", err)
+		t.Fatalf("NewNetconfWithKnownHosts returned error: %v", err)
 	}
 	if len(nc.urls) != 1 || nc.urls[0] != "169.254.33.1:830" {
 		t.Fatalf("urls = %#v, want normalized CRA URL", nc.urls)
 	}
 }
 
-func TestNewNetconf_RejectsMissingKnownHostsPath(t *testing.T) {
-	_, err := NewNetconf([]string{"169.254.33.1:830"}, "user", "password", " ", 0)
+func TestNewNetconfWithKnownHosts_RejectsMissingKnownHostsPath(t *testing.T) {
+	_, err := NewNetconfWithKnownHosts([]string{"169.254.33.1:830"}, "user", "password", " ", 0)
 	if err == nil {
-		t.Fatal("NewNetconf returned nil error, want missing known hosts path error")
+		t.Fatal("NewNetconfWithKnownHosts returned nil error, want missing known hosts path error")
 	}
 	if !strings.Contains(err.Error(), "known hosts file path is required") {
-		t.Fatalf("NewNetconf error = %q, want known hosts path context", err)
+		t.Fatalf("NewNetconfWithKnownHosts error = %q, want known hosts path context", err)
+	}
+}
+
+func TestNewNetconf_PreservesLegacyConstructor(t *testing.T) {
+	nc := NewNetconf([]string{" 169.254.33.1:830 ", ""}, "user", "password", 0)
+	if nc == nil {
+		t.Fatal("NewNetconf returned nil")
+	}
+	if len(nc.urls) != 1 || nc.urls[0] != "169.254.33.1:830" {
+		t.Fatalf("urls = %#v, want normalized CRA URL", nc.urls)
+	}
+	if nc.sshConfig == nil || nc.sshConfig.HostKeyCallback == nil {
+		t.Fatal("NewNetconf did not configure a host-key callback")
+	}
+}
+
+func TestNewManagerWithKnownHosts_ValidatesBeforeDeviceAccess(t *testing.T) {
+	_, err := NewManagerWithKnownHosts(
+		[]string{"169.254.33.1:830"},
+		"user",
+		"password",
+		" ",
+		time.Second,
+	)
+	if err == nil {
+		t.Fatal("NewManagerWithKnownHosts returned nil error, want known hosts validation error")
+	}
+	if !strings.Contains(err.Error(), "known hosts file path is required") {
+		t.Fatalf("NewManagerWithKnownHosts error = %q, want known hosts path context", err)
 	}
 }
 

--- a/pkg/nl/create.go
+++ b/pkg/nl/create.go
@@ -1,13 +1,13 @@
 package nl
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -131,7 +131,9 @@ func (*Manager) setEUIAutogeneration(intfName string, generateEUI bool) error {
 		value = "0"
 	}
 	if _, err := fmt.Fprintf(file, "%s\n", value); err != nil {
-		file.Close()
+		if closeErr := file.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
 		return fmt.Errorf("error writing to file: %w", err)
 	}
 	if err := file.Close(); err != nil {

--- a/pkg/nl/create.go
+++ b/pkg/nl/create.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
 )
 
 const (

--- a/pkg/nl/layer2.go
+++ b/pkg/nl/layer2.go
@@ -24,14 +24,27 @@ const (
 
 var procSysNetPath = "/proc/sys/net"
 
+// ValidateInterfaceName verifies that name is safe to use as a Linux interface name.
+func ValidateInterfaceName(name string) error {
+	switch {
+	case name == "", name == ".", name == "..":
+		return fmt.Errorf("invalid interface name: %q", name)
+	case len(name) >= unix.IFNAMSIZ:
+		return fmt.Errorf("interface name %q exceeds Linux limit", name)
+	case strings.ContainsAny(name, "/\\\x00"):
+		return fmt.Errorf("interface name %q contains path separators or NUL bytes", name)
+	default:
+		return nil
+	}
+}
+
 // sanitizeIntfName validates that an interface name is a single path component
 // with no directory traversal. Returns the sanitized name or an error.
 func sanitizeIntfName(name string) (string, error) {
-	s := filepath.Base(name)
-	if s == "." || s == ".." || strings.ContainsAny(s, "/\\") {
-		return "", fmt.Errorf("invalid interface name: %q", name)
+	if err := ValidateInterfaceName(name); err != nil {
+		return "", err
 	}
-	return s, nil
+	return filepath.Base(name), nil
 }
 
 var segmentationFeatureCandidates = [][]string{

--- a/pkg/nl/layer2.go
+++ b/pkg/nl/layer2.go
@@ -24,14 +24,27 @@ const (
 
 var procSysNetPath = "/proc/sys/net"
 
+// ValidateInterfaceName verifies that name is safe to use as a Linux interface name.
+func ValidateInterfaceName(name string) error {
+	switch {
+	case name == "", name == ".", name == "..":
+		return fmt.Errorf("invalid interface name: %q", name)
+	case len(name) >= unix.IFNAMSIZ:
+		return fmt.Errorf("interface name %q exceeds Linux limit", name)
+	case strings.ContainsAny(name, "/\\\x00"):
+		return fmt.Errorf("interface name %q contains path separators or NUL bytes", name)
+	default:
+		return nil
+	}
+}
+
 // sanitizeIntfName validates that an interface name is a single path component
 // with no directory traversal. Returns the sanitized name or an error.
 func sanitizeIntfName(name string) (string, error) {
-	s := filepath.Base(name)
-	if s == "." || s == ".." || strings.ContainsAny(s, "/\\") {
-		return "", fmt.Errorf("invalid interface name: %q", name)
+	if err := ValidateInterfaceName(name); err != nil {
+		return "", err
 	}
-	return s, nil
+	return filepath.Base(name), nil
 }
 
 // segmentationFeatureCandidates lists the offload features to toggle, keyed by

--- a/pkg/nl/nl_test.go
+++ b/pkg/nl/nl_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -1330,6 +1331,62 @@ var _ = Describe("CreateL3()", func() {
 		err := nm.CreateL3(vrfInfo)
 		Expect(err).To(HaveOccurred())
 		procSysNetPath = oldProcSysNetPath
+	})
+})
+
+var _ = Describe("setEUIAutogeneration()", func() {
+	It("fails before file IO for invalid interface names", func() {
+		oldProcSysNetPath := procSysNetPath
+		testProcSysNetPath, err := os.MkdirTemp("", "proc-sys-net-")
+		Expect(err).ToNot(HaveOccurred())
+		procSysNetPath = testProcSysNetPath
+		defer func() {
+			procSysNetPath = oldProcSysNetPath
+			Expect(os.RemoveAll(testProcSysNetPath)).To(Succeed())
+		}()
+
+		nm := &Manager{}
+		for _, tc := range []struct {
+			name string
+			want string
+		}{
+			{name: "", want: "invalid interface name"},
+			{name: ".", want: "invalid interface name"},
+			{name: "..", want: "invalid interface name"},
+			{name: "eth/0", want: "contains path separators or NUL bytes"},
+			{name: "eth\x000", want: "contains path separators or NUL bytes"},
+			{name: strings.Repeat("a", unix.IFNAMSIZ), want: "exceeds Linux limit"},
+		} {
+			err := nm.setEUIAutogeneration(tc.name, false)
+			Expect(err).To(MatchError(ContainSubstring(tc.want)))
+			Expect(err).NotTo(MatchError(ContainSubstring("error opening file")))
+		}
+	})
+
+	It("writes addr_gen_mode for valid interface names", func() {
+		oldProcSysNetPath := procSysNetPath
+		testProcSysNetPath, err := os.MkdirTemp("", "proc-sys-net-")
+		Expect(err).ToNot(HaveOccurred())
+		procSysNetPath = testProcSysNetPath
+		defer func() {
+			procSysNetPath = oldProcSysNetPath
+			Expect(os.RemoveAll(testProcSysNetPath)).To(Succeed())
+		}()
+
+		nm := &Manager{}
+		intfName := "vxlan100"
+		addrGenModePathIPv6 := filepath.Join(procSysNetPath, "ipv6", "conf", intfName, addrGenMode)
+		createInterfaceFile(addrGenModePathIPv6)
+
+		Expect(nm.setEUIAutogeneration(intfName, true)).To(Succeed())
+		value, err := os.ReadFile(addrGenModePathIPv6)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(value)).To(Equal("0\n"))
+
+		Expect(nm.setEUIAutogeneration(intfName, false)).To(Succeed())
+		value, err = os.ReadFile(addrGenModePathIPv6)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(value)).To(Equal("1\n"))
 	})
 })
 

--- a/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go
+++ b/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go
@@ -502,7 +502,7 @@ func (reconciler *NodeNetplanConfigReconciler) Reconcile(ctx context.Context) er
 }
 
 func setEUIAutogeneration(intfName string, generateEUI bool) error {
-	if err := validateInterfaceName(intfName); err != nil {
+	if err := nl.ValidateInterfaceName(intfName); err != nil {
 		return err
 	}
 	fileName := filepath.Join(procSysNetIPv6ConfPath, intfName, "addr_gen_mode")
@@ -524,19 +524,6 @@ func setEUIAutogeneration(intfName string, generateEUI bool) error {
 		return fmt.Errorf("error closing file: %w", err)
 	}
 	return nil
-}
-
-func validateInterfaceName(intfName string) error {
-	switch {
-	case intfName == "", intfName == ".", intfName == "..":
-		return fmt.Errorf("invalid interface name %q", intfName)
-	case len(intfName) >= unix.IFNAMSIZ:
-		return fmt.Errorf("interface name %q exceeds Linux limit", intfName)
-	case strings.ContainsAny(intfName, "/\x00"):
-		return fmt.Errorf("interface name %q contains path separators or NUL bytes", intfName)
-	default:
-		return nil
-	}
 }
 
 func parseVlan(device netplan.Device) (*netplanVlan, error) {

--- a/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go
+++ b/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go
@@ -503,7 +503,7 @@ func (reconciler *NodeNetplanConfigReconciler) Reconcile(ctx context.Context) er
 
 func setEUIAutogeneration(intfName string, generateEUI bool) error {
 	if err := nl.ValidateInterfaceName(intfName); err != nil {
-		return err
+		return fmt.Errorf("validate interface name %q: %w", intfName, err)
 	}
 	fileName := filepath.Join(procSysNetIPv6ConfPath, intfName, "addr_gen_mode")
 	file, err := os.OpenFile(fileName, os.O_WRONLY, 0)

--- a/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go
+++ b/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go
@@ -2,6 +2,7 @@ package agent_hbn_l2 //nolint:revive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -40,8 +41,9 @@ const (
 )
 
 var (
-	dummyAliasPrefix = fmt.Sprintf("%s::%s::", aliasPrefix, dummyNamePrefix)
-	vlanAliasPrefix  = fmt.Sprintf("%s::%s::", aliasPrefix, vlanNamePrefix)
+	dummyAliasPrefix       = fmt.Sprintf("%s::%s::", aliasPrefix, dummyNamePrefix)
+	vlanAliasPrefix        = fmt.Sprintf("%s::%s::", aliasPrefix, vlanNamePrefix)
+	procSysNetIPv6ConfPath = "/proc/sys/net/ipv6/conf"
 )
 
 type addresses struct {
@@ -500,11 +502,10 @@ func (reconciler *NodeNetplanConfigReconciler) Reconcile(ctx context.Context) er
 }
 
 func setEUIAutogeneration(intfName string, generateEUI bool) error {
-	safe := filepath.Base(intfName)
-	if safe == "." || safe == ".." || strings.ContainsAny(safe, "/\\") {
-		return fmt.Errorf("invalid interface name: %q", intfName)
+	if err := validateInterfaceName(intfName); err != nil {
+		return err
 	}
-	fileName := fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/addr_gen_mode", safe)
+	fileName := filepath.Join(procSysNetIPv6ConfPath, intfName, "addr_gen_mode")
 	file, err := os.OpenFile(fileName, os.O_WRONLY, 0)
 	if err != nil {
 		return fmt.Errorf("error opening file: %w", err)
@@ -514,13 +515,28 @@ func setEUIAutogeneration(intfName string, generateEUI bool) error {
 		value = "0"
 	}
 	if _, err := fmt.Fprintf(file, "%s\n", value); err != nil {
-		file.Close()
+		if closeErr := file.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
 		return fmt.Errorf("error writing to file: %w", err)
 	}
 	if err := file.Close(); err != nil {
 		return fmt.Errorf("error closing file: %w", err)
 	}
 	return nil
+}
+
+func validateInterfaceName(intfName string) error {
+	switch {
+	case intfName == "", intfName == ".", intfName == "..":
+		return fmt.Errorf("invalid interface name %q", intfName)
+	case len(intfName) >= unix.IFNAMSIZ:
+		return fmt.Errorf("interface name %q exceeds Linux limit", intfName)
+	case strings.ContainsAny(intfName, "/\x00"):
+		return fmt.Errorf("interface name %q contains path separators", intfName)
+	default:
+		return nil
+	}
 }
 
 func parseVlan(device netplan.Device) (*netplanVlan, error) {

--- a/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go
+++ b/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go
@@ -533,7 +533,7 @@ func validateInterfaceName(intfName string) error {
 	case len(intfName) >= unix.IFNAMSIZ:
 		return fmt.Errorf("interface name %q exceeds Linux limit", intfName)
 	case strings.ContainsAny(intfName, "/\x00"):
-		return fmt.Errorf("interface name %q contains path separators", intfName)
+		return fmt.Errorf("interface name %q contains path separators or NUL bytes", intfName)
 	default:
 		return nil
 	}


### PR DESCRIPTION
## Summary
- require NETCONF host-key verification via CRA_KNOWN_HOSTS and mount the known_hosts file into the VSR agent
- fail fast with a clear error when the CRA known_hosts path is blank
- use a deterministic validation key for known_hosts entry checks instead of generating one from crypto/rand at startup
- harden frr-cra log output and writable file close handling
- validate interface names before /proc/sys path construction and handle writable close errors
- avoid explicit sequence allocation that CodeQL can flag for overflow

## Validation
- `go test ./pkg/helpers/merge ./pkg/cra-vsr`
- `go test ./pkg/cra-vsr`
- `docker run --rm -v "$PWD":/src -w /src golang:1.25.5 go test ./pkg/nl ./pkg/reconciler/agent-hbn-l2 ./cmd/agent-cra-vsr`
- `docker run --rm -v "$PWD":/src -w /src golang:1.25.5 bash -c 'apt-get update >/tmp/apt.log && apt-get install -y clang llvm libbpf-dev linux-libc-dev gcc >/tmp/apt-install.log && export BPF2GO_CFLAGS="-I/usr/include/x86_64-linux-gnu" && cd pkg/bpf && /usr/local/go/bin/go generate && cd /src && /usr/local/go/bin/go test ./cmd/frr-cra'`
- `docker run --rm -v "$PWD":/src -w /src golang:1.25.5 bash -lc 'export PATH=/usr/local/go/bin:$PATH && apt-get update >/tmp/apt.log && apt-get install -y clang llvm libbpf-dev linux-libc-dev gcc >/tmp/apt-install.log && export BPF2GO_CFLAGS="-I/usr/include/x86_64-linux-gnu" && mkdir -p /tmp/dsno-tools/bin && make generate CONTROLLER_GEN=/tmp/dsno-tools/bin/controller-gen PROJECT_DIR=/tmp/dsno-tools && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 run --timeout=10m'`
- `git diff --check`

## Rollout note
The VSR agent now fails closed unless `/etc/cra/known_hosts` contains the trusted NETCONF host key, for example a `[169.254.33.1]:830 ...` entry. Provision that file on every target node before rolling this out; a missing or stale host key is expected to block agent startup instead of silently accepting an unverified NETCONF peer.

CI harness fix: NAT64 route setup now explicitly waits until the `nat64` interface has the `fda5:25c1:193e::1` source address before installing the default route, uses `/bin/sh`, and dumps IPv6 address/routing state if setup fails. This prevents kubeadm DNS timeouts during E2E setup while preserving the intended source address.
