### PR TITLE
fix: keep dependabot on compatible Kubernetes minors

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -29,6 +29,17 @@ updates:
     prefix: ":seedling:"
   labels:
     - "ok-to-test"
+  ignore:
+    - dependency-name: "k8s.io/*"
+      # The code still imports Kubernetes APIs removed in newer minor lines.
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+      # Keep controller-runtime on the Kubernetes minor line used by the repo.
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
   groups:
     kubernetes-major:
       patterns:

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -59,7 +59,14 @@ jobs:
           go-version-file: go.mod
 
       - name: Create Licenses Report
-        run: make licenses-report
+        run: |
+          for attempt in 1 2 3; do
+            if make licenses-report; then
+              exit 0
+            fi
+            sleep 1000 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 1000(attempt * 10))
+          done
+          make licenses-report
 
       - name: Read Go version
         id: go-version

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -64,7 +64,7 @@ jobs:
             if make licenses-report; then
               exit 0
             fi
-            sleep 1000 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 1000(attempt * 10))
+            sleep 10
           done
           make licenses-report
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -182,6 +182,7 @@ jobs:
 
       - name: system-level-dependencies
         run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
           sudo apt update
           sudo apt -y install linux-modules-extra-$(uname -r)
 

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -20,7 +20,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: run code generators
         run: make generate
       - name: golangci-lint
@@ -38,7 +41,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: Run Tests
         run: make test
       - name: Upload coverage report
@@ -59,7 +65,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: run code generators
         run: make generate
       - name: run manifest generators

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -86,8 +86,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-images.yaml
     with:
-      push: true
-      cache-write: true
+      push: false
+      cache-write: false
 
   build-images-fork:
     name: build container images (fork)

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -86,8 +86,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-images.yaml
     with:
-      push: false
-      cache-write: false
+      push: true
+      cache-write: true
 
   build-images-fork:
     name: build container images (fork)


### PR DESCRIPTION
## Summary
- keep Dependabot Go module updates for `k8s.io/*` and `sigs.k8s.io/controller-runtime` to patch updates on the current compatible minor line
- prevents the Kubernetes updater from resolving v0.36 packages after removed APIs break dependency resolution

- removes the unused Azure CLI and Microsoft package APT sources from GitHub runners before apt updates in unit, generation, and E2E jobs; Ubuntu package sources remain intact
- retries transient license-report generation failures and retains the existing image publication behavior

## Evidence
- Dependabot run `27806530792` fails with `k8s.io/api@latest found (v0.36.2), but does not contain package k8s.io/api/autoscaling/v2beta1`, `v2beta2`, and `scheduling/v1alpha1`
- `git diff --check`
- YAML parsed and verified the ignore block is in the `gomod` updater section
