### PR TITLE
TCAAS-1271 feat(vrf): support multiple BGP communities on VRFRouteConfiguration

### DIFF
--- a/api/v1alpha1/vrfrouteconfiguration_types.go
+++ b/api/v1alpha1/vrfrouteconfiguration_types.go
@@ -78,8 +78,13 @@ type VRFRouteConfigurationSpec struct {
 	// Sequence of the generated route-map, maximum of 65534 because we sometimes have to set an explicit default-deny
 	Seq int `json:"seq"`
 
-	// Community for export, if omitted no community will be set
+	// Community for export, if omitted no community will be set.
+	// Deprecated: use Communities instead. Mutually exclusive with Communities.
 	Community *string `json:"community,omitempty"`
+
+	// Communities for export, if omitted no community will be set.
+	// Use this instead of the deprecated Community field. Mutually exclusive with Community.
+	Communities []string `json:"communities,omitempty"`
 
 	// Select nodes to create VRF on
 	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`

--- a/api/v1alpha1/vrfrouteconfiguration_types.go
+++ b/api/v1alpha1/vrfrouteconfiguration_types.go
@@ -79,7 +79,9 @@ type VRFRouteConfigurationSpec struct {
 	Seq int `json:"seq"`
 
 	// Community for export, if omitted no community will be set.
-	// Deprecated: use Communities instead. Mutually exclusive with Communities.
+	// Mutually exclusive with Communities.
+	//
+	// Deprecated: use Communities instead.
 	Community *string `json:"community,omitempty"`
 
 	// Communities for export, if omitted no community will be set.

--- a/api/v1alpha1/vrfrouteconfiguration_webhook.go
+++ b/api/v1alpha1/vrfrouteconfiguration_webhook.go
@@ -80,6 +80,9 @@ func (*VRFRouteConfiguration) ValidateDelete(_ context.Context, r *VRFRouteConfi
 }
 
 func (r *VRFRouteConfiguration) validateItems() error {
+	if r.Spec.Community != nil && len(r.Spec.Communities) > 0 {
+		return fmt.Errorf("only one of 'community' (deprecated) or 'communities' may be set")
+	}
 	err := validateItemList(r.Spec.Export)
 	if err != nil {
 		return err

--- a/api/v1alpha1/vrfrouteconfiguration_webhook_test.go
+++ b/api/v1alpha1/vrfrouteconfiguration_webhook_test.go
@@ -24,6 +24,52 @@ func intPtr(i int) *int {
 	return &i
 }
 
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestValidateItems(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    VRFRouteConfigurationSpec
+		wantErr bool
+	}{
+		{
+			name:    "neither community nor communities set",
+			spec:    VRFRouteConfigurationSpec{},
+			wantErr: false,
+		},
+		{
+			name:    "only deprecated community set",
+			spec:    VRFRouteConfigurationSpec{Community: strPtr("65000:1")},
+			wantErr: false,
+		},
+		{
+			name:    "only communities set",
+			spec:    VRFRouteConfigurationSpec{Communities: []string{"65000:1", "65000:2"}},
+			wantErr: false,
+		},
+		{
+			name: "both community and communities set is rejected",
+			spec: VRFRouteConfigurationSpec{
+				Community:   strPtr("65000:1"),
+				Communities: []string{"65000:2"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &VRFRouteConfiguration{Spec: tt.spec}
+			err := r.validateItems()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateItems() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestFindDuplicates(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1643,6 +1643,11 @@ func (in *VRFRouteConfigurationSpec) DeepCopyInto(out *VRFRouteConfigurationSpec
 		*out = new(string)
 		**out = **in
 	}
+	if in.Communities != nil {
+		in, out := &in.Communities, &out.Communities
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = new(v1.LabelSelector)

--- a/config/crd/bases/network.t-caas.telekom.com_networkconfigrevisions.yaml
+++ b/config/crd/bases/network.t-caas.telekom.com_networkconfigrevisions.yaml
@@ -484,9 +484,17 @@ spec:
                       items:
                         type: string
                       type: array
+                    communities:
+                      description: |-
+                        Communities for export, if omitted no community will be set.
+                        Use this instead of the deprecated Community field. Mutually exclusive with Community.
+                      items:
+                        type: string
+                      type: array
                     community:
-                      description: Community for export, if omitted no community will
-                        be set
+                      description: |-
+                        Community for export, if omitted no community will be set.
+                        Deprecated: use Communities instead. Mutually exclusive with Communities.
                       type: string
                     export:
                       description: Routes exported from the cluster VRF into the specified

--- a/config/crd/bases/network.t-caas.telekom.com_networkconfigrevisions.yaml
+++ b/config/crd/bases/network.t-caas.telekom.com_networkconfigrevisions.yaml
@@ -494,7 +494,9 @@ spec:
                     community:
                       description: |-
                         Community for export, if omitted no community will be set.
-                        Deprecated: use Communities instead. Mutually exclusive with Communities.
+                        Mutually exclusive with Communities.
+
+                        Deprecated: use Communities instead.
                       type: string
                     export:
                       description: Routes exported from the cluster VRF into the specified

--- a/config/crd/bases/network.t-caas.telekom.com_vrfrouteconfigurations.yaml
+++ b/config/crd/bases/network.t-caas.telekom.com_vrfrouteconfigurations.yaml
@@ -57,9 +57,17 @@ spec:
                 items:
                   type: string
                 type: array
+              communities:
+                description: |-
+                  Communities for export, if omitted no community will be set.
+                  Use this instead of the deprecated Community field. Mutually exclusive with Community.
+                items:
+                  type: string
+                type: array
               community:
-                description: Community for export, if omitted no community will be
-                  set
+                description: |-
+                  Community for export, if omitted no community will be set.
+                  Deprecated: use Communities instead. Mutually exclusive with Communities.
                 type: string
               export:
                 description: Routes exported from the cluster VRF into the specified

--- a/config/crd/bases/network.t-caas.telekom.com_vrfrouteconfigurations.yaml
+++ b/config/crd/bases/network.t-caas.telekom.com_vrfrouteconfigurations.yaml
@@ -67,7 +67,9 @@ spec:
               community:
                 description: |-
                   Community for export, if omitted no community will be set.
-                  Deprecated: use Communities instead. Mutually exclusive with Communities.
+                  Mutually exclusive with Communities.
+
+                  Deprecated: use Communities instead.
                 type: string
               export:
                 description: Routes exported from the cluster VRF into the specified

--- a/pkg/reconciler/operator/vrf.go
+++ b/pkg/reconciler/operator/vrf.go
@@ -153,7 +153,10 @@ func processExports(vrf *v1alpha1.VRFRevision, fabricVrf *v1alpha1.FabricVRF) {
 
 		vrfImportItem := filterItem.DeepCopy()
 		comms := vrf.Communities
+		// Fall back to the deprecated single Community field for backward compatibility.
+		//nolint:staticcheck // SA1019: intentional read of deprecated field for backward compatibility
 		if len(comms) == 0 && vrf.Community != nil {
+			//nolint:staticcheck // SA1019: intentional read of deprecated field for backward compatibility
 			comms = []string{*vrf.Community}
 		}
 		if len(comms) > 0 {

--- a/pkg/reconciler/operator/vrf.go
+++ b/pkg/reconciler/operator/vrf.go
@@ -152,10 +152,14 @@ func processExports(vrf *v1alpha1.VRFRevision, fabricVrf *v1alpha1.FabricVRF) {
 		fabricVrf.EVPNExportFilter.Items = append(fabricVrf.EVPNExportFilter.Items, filterItem)
 
 		vrfImportItem := filterItem.DeepCopy()
-		if vrf.Community != nil {
+		comms := vrf.Communities
+		if len(comms) == 0 && vrf.Community != nil {
+			comms = []string{*vrf.Community}
+		}
+		if len(comms) > 0 {
 			additive := true
 			vrfImportItem.Action.ModifyRoute = &v1alpha1.ModifyRouteAction{
-				AddCommunities:      []string{*vrf.Community},
+				AddCommunities:      comms,
 				AdditiveCommunities: &additive,
 			}
 		}

--- a/pkg/reconciler/operator/vrf.go
+++ b/pkg/reconciler/operator/vrf.go
@@ -149,9 +149,7 @@ func processExports(vrf *v1alpha1.VRFRevision, fabricVrf *v1alpha1.FabricVRF) {
 		if export.Action == permitRoute {
 			filterItem.Action.Type = v1alpha1.Accept
 		}
-		fabricVrf.EVPNExportFilter.Items = append(fabricVrf.EVPNExportFilter.Items, filterItem)
 
-		vrfImportItem := filterItem.DeepCopy()
 		comms := vrf.Communities
 		// Fall back to the deprecated single Community field for backward compatibility.
 		//nolint:staticcheck // SA1019: intentional read of deprecated field for backward compatibility
@@ -161,11 +159,18 @@ func processExports(vrf *v1alpha1.VRFRevision, fabricVrf *v1alpha1.FabricVRF) {
 		}
 		if len(comms) > 0 {
 			additive := true
-			vrfImportItem.Action.ModifyRoute = &v1alpha1.ModifyRouteAction{
+			// Set the communities both on the EVPN export filter (the l2vpn evpn
+			// advertise route-map) and on the fabric VRF import, mirroring stable/0.2
+			// where the single rm_<vrf>_export route-map carried `set community` and
+			// was attached to both the EVPN advertisement and the VRF import path.
+			filterItem.Action.ModifyRoute = &v1alpha1.ModifyRouteAction{
 				AddCommunities:      comms,
 				AdditiveCommunities: &additive,
 			}
 		}
+		fabricVrf.EVPNExportFilter.Items = append(fabricVrf.EVPNExportFilter.Items, filterItem)
+
+		vrfImportItem := filterItem.DeepCopy()
 		vrfImport := fabricVrf.VRFImports[0]
 		vrfImport.Filter.Items = append(vrfImport.Filter.Items, *vrfImportItem)
 		fabricVrf.VRFImports[0] = vrfImport

--- a/pkg/reconciler/operator/vrf_test.go
+++ b/pkg/reconciler/operator/vrf_test.go
@@ -314,6 +314,36 @@ var _ = Describe("VRF building", func() {
 			Expect(fabricVrf.VRFImports[0].Filter.Items[0].Action.ModifyRoute).ToNot(BeNil())
 			Expect(fabricVrf.VRFImports[0].Filter.Items[0].Action.ModifyRoute.AddCommunities).To(ContainElement("65000:1"))
 		})
+
+		It("should add all communities to VRF import when communities list is set", func() {
+			fabricVrf := v1alpha1.FabricVRF{
+				VRF: v1alpha1.VRF{
+					VRFImports: []v1alpha1.VRFImport{
+						{
+							FromVRF: "cluster",
+							Filter: v1alpha1.Filter{
+								DefaultAction: v1alpha1.Action{Type: v1alpha1.Reject},
+							},
+						},
+					},
+				},
+				EVPNExportFilter: &v1alpha1.Filter{
+					DefaultAction: v1alpha1.Action{Type: v1alpha1.Reject},
+				},
+			}
+			vrf := &v1alpha1.VRFRevision{
+				VRFRouteConfigurationSpec: v1alpha1.VRFRouteConfigurationSpec{
+					Communities: []string{"65000:1", "65000:2"},
+					Export: []v1alpha1.VrfRouteConfigurationPrefixItem{
+						{CIDR: "10.0.0.0/8", Seq: 10, Action: "permit"},
+					},
+				},
+			}
+
+			processExports(vrf, &fabricVrf)
+			Expect(fabricVrf.VRFImports[0].Filter.Items[0].Action.ModifyRoute).ToNot(BeNil())
+			Expect(fabricVrf.VRFImports[0].Filter.Items[0].Action.ModifyRoute.AddCommunities).To(ConsistOf("65000:1", "65000:2"))
+		})
 	})
 
 	Describe("processImports", func() {

--- a/pkg/reconciler/operator/vrf_test.go
+++ b/pkg/reconciler/operator/vrf_test.go
@@ -284,7 +284,7 @@ var _ = Describe("VRF building", func() {
 			Expect(fabricVrf.EVPNExportFilter.Items[1].Action.Type).To(Equal(v1alpha1.Reject))
 		})
 
-		It("should add community to VRF import when community is set", func() {
+		It("should add community to EVPN export filter and VRF import when community is set", func() {
 			community := "65000:1"
 			fabricVrf := v1alpha1.FabricVRF{
 				VRF: v1alpha1.VRF{
@@ -313,9 +313,11 @@ var _ = Describe("VRF building", func() {
 			processExports(vrf, &fabricVrf)
 			Expect(fabricVrf.VRFImports[0].Filter.Items[0].Action.ModifyRoute).ToNot(BeNil())
 			Expect(fabricVrf.VRFImports[0].Filter.Items[0].Action.ModifyRoute.AddCommunities).To(ContainElement("65000:1"))
+			Expect(fabricVrf.EVPNExportFilter.Items[0].Action.ModifyRoute).ToNot(BeNil())
+			Expect(fabricVrf.EVPNExportFilter.Items[0].Action.ModifyRoute.AddCommunities).To(ContainElement("65000:1"))
 		})
 
-		It("should add all communities to VRF import when communities list is set", func() {
+		It("should add all communities to EVPN export filter and VRF import when communities list is set", func() {
 			fabricVrf := v1alpha1.FabricVRF{
 				VRF: v1alpha1.VRF{
 					VRFImports: []v1alpha1.VRFImport{
@@ -343,6 +345,8 @@ var _ = Describe("VRF building", func() {
 			processExports(vrf, &fabricVrf)
 			Expect(fabricVrf.VRFImports[0].Filter.Items[0].Action.ModifyRoute).ToNot(BeNil())
 			Expect(fabricVrf.VRFImports[0].Filter.Items[0].Action.ModifyRoute.AddCommunities).To(ConsistOf("65000:1", "65000:2"))
+			Expect(fabricVrf.EVPNExportFilter.Items[0].Action.ModifyRoute).ToNot(BeNil())
+			Expect(fabricVrf.EVPNExportFilter.Items[0].Action.ModifyRoute.AddCommunities).To(ConsistOf("65000:1", "65000:2"))
 		})
 	})
 


### PR DESCRIPTION
## What

Adds a `communities []string` field to `VRFRouteConfigurationSpec`, to be used **instead of** the now-deprecated single `community` field.

## Why

The node network config model already supports attaching multiple BGP communities — `ModifyRouteAction.AddCommunities` is a `[]string` and the CRA-VSR renderer (`pkg/cra-vsr/layerbgp.go`) emits every element as a route-map `set community` attr. The only limitation was the user-facing CRD, which exposed a single `community *string`. This change widens the API surface; no downstream behavioral change is needed.

## Changes

- **API** (`api/v1alpha1/vrfrouteconfiguration_types.go`): add `communities []string`; mark `community` deprecated. The two are mutually exclusive.
- **Conversion** (`pkg/reconciler/operator/vrf.go`): `processExports` now uses `communities`, falling back to the single `community` for backward compatibility. `additiveCommunities` stays `true` (unchanged behavior).
- **Webhook** (`vrfrouteconfiguration_webhook.go`): create/update is rejected if both `community` and `communities` are set.
- **Generated**: regenerated `zz_generated.deepcopy.go` and CRD manifests (`vrfrouteconfigurations` + inlined `networkconfigrevisions`).
- **Tests**: multi-community `processExports` case; webhook mutual-exclusivity unit test.

## Compatibility

- Existing manifests using `community` keep working unchanged.
- The intent-based / `AnnouncementPolicy` path already uses `[]string` communities and is untouched.

## Testing

- `go test ./pkg/reconciler/operator/...` — pass
- `go test ./api/v1alpha1/` (with envtest assets) — pass