### PR TITLE
fix(sync): preserve Helm ownership metadata

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -59,7 +59,14 @@ jobs:
           go-version-file: go.mod
 
       - name: Create Licenses Report
-        run: make licenses-report
+        run: |
+          for attempt in 1 2 3; do
+            if make licenses-report; then
+              exit 0
+            fi
+            sleep 1000 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 1000(attempt * 10))
+          done
+          make licenses-report
 
       - name: Read Go version
         id: go-version

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -64,7 +64,7 @@ jobs:
             if make licenses-report; then
               exit 0
             fi
-            sleep 1000 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 65534 1000(attempt * 10))
+            sleep 10
           done
           make licenses-report
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -182,6 +182,7 @@ jobs:
 
       - name: system-level-dependencies
         run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
           sudo apt update
           sudo apt -y install linux-modules-extra-$(uname -r)
 

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -20,7 +20,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: run code generators
         run: make generate
       - name: golangci-lint
@@ -38,7 +41,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: Run Tests
         run: make test
       - name: Upload coverage report
@@ -59,7 +65,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.* /etc/apt/sources.list.d/microsoft-prod.* /etc/apt/sources.list.d/packages-microsoft-prod.*
+          sudo apt-get update
+          sudo apt-get install -y llvm clang libbpf-dev gcc-multilib linux-headers-$(uname -r)
       - name: run code generators
         run: make generate
       - name: run manifest generators

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -86,8 +86,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-images.yaml
     with:
-      push: true
-      cache-write: true
+      push: false
+      cache-write: false
 
   build-images-fork:
     name: build container images (fork)

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -86,8 +86,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build-images.yaml
     with:
-      push: false
-      cache-write: false
+      push: true
+      cache-write: true
 
   build-images-fork:
     name: build container images (fork)

--- a/controllers/intent/predicates.go
+++ b/controllers/intent/predicates.go
@@ -47,7 +47,7 @@ func intentCRDPredicate() predicate.Predicate {
 			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
 				return true
 			}
-			if !reflect.DeepEqual(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels()) {
+			if !metadataEqualIgnoringKeys(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels(), nil) {
 				return true
 			}
 			return !metadataEqualIgnoringKeys(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations(), ownershipAnnotationKeys)

--- a/controllers/intent/predicates.go
+++ b/controllers/intent/predicates.go
@@ -29,18 +29,62 @@ import (
 
 // intentCRDPredicate accepts only events that should trigger an intent
 // re-evaluation: creates, deletes, generic, and any update where either
-// the spec generation, labels, or annotations have changed.
+// the spec generation, labels, or non-ownership annotations have changed.
 //
 // This filters out status-only updates the controller writes back to its
 // own intent CRDs (e.g. Collector.status.nodeAddresses, BGPPeering
 // conditions), preventing self-trigger loops while still reacting to
-// label/annotation changes that affect selectors.
+// all label changes because selectors can bind on any label key.
 func intentCRDPredicate() predicate.Predicate {
-	return predicate.Or(
-		predicate.GenerationChangedPredicate{},
-		predicate.LabelChangedPredicate{},
-		predicate.AnnotationChangedPredicate{},
-	)
+	return predicate.Funcs{
+		CreateFunc:  func(event.CreateEvent) bool { return true },
+		DeleteFunc:  func(event.DeleteEvent) bool { return true },
+		GenericFunc: func(event.GenericEvent) bool { return true },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return true
+			}
+			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+				return true
+			}
+			if !reflect.DeepEqual(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels()) {
+				return true
+			}
+			return !metadataEqualIgnoringKeys(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations(), ownershipAnnotationKeys)
+		},
+	}
+}
+
+const (
+	helmReleaseNameAnnotation      = "meta.helm.sh/release-name"
+	helmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
+)
+
+var ownershipAnnotationKeys = map[string]struct{}{
+	helmReleaseNameAnnotation:      {},
+	helmReleaseNamespaceAnnotation: {},
+}
+
+func metadataEqualIgnoringKeys(oldMetadata, newMetadata map[string]string, ignoredKeys map[string]struct{}) bool {
+	return reflect.DeepEqual(filterMetadata(oldMetadata, ignoredKeys), filterMetadata(newMetadata, ignoredKeys))
+}
+
+func filterMetadata(metadata map[string]string, ignoredKeys map[string]struct{}) map[string]string {
+	if len(metadata) == 0 {
+		return nil
+	}
+
+	filtered := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		if _, ok := ignoredKeys[key]; ok {
+			continue
+		}
+		filtered[key] = value
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
 }
 
 // nodePredicate filters Node events down to changes that can plausibly

--- a/controllers/intent/predicates.go
+++ b/controllers/intent/predicates.go
@@ -18,6 +18,7 @@ package intent
 
 import (
 	"reflect"
+	"sort"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -89,9 +90,9 @@ func filterMetadata(metadata map[string]string, ignoredKeys map[string]struct{})
 
 // nodePredicate filters Node events down to changes that can plausibly
 // affect intent reconciliation: creates, deletes, label changes, taint
-// changes, and Ready-condition transitions. Frequent heartbeat-only
-// status updates (kubelet reports, allocatable/capacity churn) are
-// ignored, which prevents the intent controller from being re-triggered
+// changes, InternalIP changes, and Ready-condition transitions. Frequent
+// heartbeat-only status updates (kubelet reports, allocatable/capacity churn)
+// are ignored, which prevents the intent controller from being re-triggered
 // many times per minute by every Node in the cluster.
 func nodePredicate() predicate.Predicate {
 	return predicate.Funcs{
@@ -112,9 +113,31 @@ func nodePredicate() predicate.Predicate {
 			if !reflect.DeepEqual(oldNode.Spec.Taints, newNode.Spec.Taints) {
 				return true
 			}
+			if internalIPAddressesChanged(oldNode, newNode) {
+				return true
+			}
 			return readyConditionChanged(oldNode, newNode)
 		},
 	}
+}
+
+func internalIPAddressesChanged(oldNode, newNode *corev1.Node) bool {
+	return !reflect.DeepEqual(internalIPAddresses(oldNode), internalIPAddresses(newNode))
+}
+
+func internalIPAddresses(node *corev1.Node) []string {
+	addresses := make([]string, 0)
+	for i := range node.Status.Addresses {
+		address := node.Status.Addresses[i]
+		if address.Type == corev1.NodeInternalIP && address.Address != "" {
+			addresses = append(addresses, address.Address)
+		}
+	}
+	sort.Strings(addresses)
+	if len(addresses) == 0 {
+		return nil
+	}
+	return addresses
 }
 
 // readyConditionChanged reports whether the NodeReady condition's Status

--- a/controllers/intent/predicates_test.go
+++ b/controllers/intent/predicates_test.go
@@ -60,6 +60,15 @@ func TestIntentCRDPredicate_StatusOnlyUpdateIgnored(t *testing.T) {
 	}
 }
 
+func TestIntentCRDPredicate_EmptyLabelsMatchNilLabels(t *testing.T) {
+	p := intentCRDPredicate()
+	old := makeVRF("v1", 5, nil, nil)
+	updated := makeVRF("v1", 5, map[string]string{}, nil)
+	if p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated}) {
+		t.Fatalf("expected nil and empty label maps to be treated as equal")
+	}
+}
+
 func TestIntentCRDPredicate_GenerationBumpAccepted(t *testing.T) {
 	p := intentCRDPredicate()
 	old := makeVRF("v1", 5, nil, nil)

--- a/controllers/intent/predicates_test.go
+++ b/controllers/intent/predicates_test.go
@@ -27,6 +27,19 @@ import (
 	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
 )
 
+const (
+	intentTestManagedByLabel         = "app.kubernetes.io/managed-by"
+	intentTestFluxHelmNameLabel      = "helm.toolkit.fluxcd.io/name"
+	intentTestFluxHelmNamespaceLabel = "helm.toolkit.fluxcd.io/namespace"
+	intentTestHelmManager            = "Helm"
+	intentTestScopeLabel             = "networking.telekom.com/scope"
+	intentTestSourceNamespace        = "t-caas-controllers"
+	intentTestOldRelease             = "old-release"
+	intentTestNewRelease             = "new-release"
+	intentTestNetworkingRelease      = "networking"
+	intentTestSANScope               = "san"
+)
+
 func makeVRF(name string, gen int64, labels, annotations map[string]string) *nc.VRF {
 	return &nc.VRF{
 		ObjectMeta: metav1.ObjectMeta{
@@ -71,6 +84,102 @@ func TestIntentCRDPredicate_AnnotationChangeAccepted(t *testing.T) {
 	updated := makeVRF("v1", 5, nil, map[string]string{"k": "v2"})
 	if !p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated}) {
 		t.Fatalf("expected annotation change to be accepted")
+	}
+}
+
+func TestIntentCRDPredicate_HelmOwnershipAnnotationIgnored(t *testing.T) {
+	p := intentCRDPredicate()
+	old := makeVRF("v1", 5, map[string]string{intentTestManagedByLabel: intentTestHelmManager}, nil)
+	updated := makeVRF("v1", 5,
+		map[string]string{
+			intentTestManagedByLabel: intentTestHelmManager,
+		},
+		map[string]string{
+			helmReleaseNameAnnotation:      intentTestNetworkingRelease,
+			helmReleaseNamespaceAnnotation: intentTestSourceNamespace,
+		},
+	)
+	if p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated}) {
+		t.Fatalf("expected Helm ownership annotation-only update to be filtered out")
+	}
+}
+
+func TestIntentCRDPredicate_HelmOwnershipAnnotationChangeIgnored(t *testing.T) {
+	p := intentCRDPredicate()
+	old := makeVRF("v1", 5,
+		map[string]string{intentTestScopeLabel: intentTestSANScope},
+		map[string]string{
+			helmReleaseNameAnnotation:      intentTestOldRelease,
+			helmReleaseNamespaceAnnotation: "old-namespace",
+		},
+	)
+	updated := makeVRF("v1", 5,
+		map[string]string{intentTestScopeLabel: intentTestSANScope},
+		map[string]string{
+			helmReleaseNameAnnotation:      intentTestNewRelease,
+			helmReleaseNamespaceAnnotation: "new-namespace",
+		},
+	)
+	if p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated}) {
+		t.Fatalf("expected Helm ownership annotation value changes to be filtered out")
+	}
+}
+
+func TestIntentCRDPredicate_HelmOwnershipAnnotationRemovalIgnored(t *testing.T) {
+	p := intentCRDPredicate()
+	old := makeVRF("v1", 5,
+		map[string]string{intentTestScopeLabel: intentTestSANScope},
+		map[string]string{
+			helmReleaseNameAnnotation:      intentTestNetworkingRelease,
+			helmReleaseNamespaceAnnotation: intentTestSourceNamespace,
+		},
+	)
+	updated := makeVRF("v1", 5, map[string]string{intentTestScopeLabel: intentTestSANScope}, nil)
+	if p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated}) {
+		t.Fatalf("expected Helm ownership annotation removal to be filtered out")
+	}
+}
+
+func TestIntentCRDPredicate_HelmFluxOwnershipLabelChangeAccepted(t *testing.T) {
+	p := intentCRDPredicate()
+	old := makeVRF("v1", 5, nil, nil)
+	updated := makeVRF("v1", 5,
+		map[string]string{
+			intentTestManagedByLabel:         intentTestHelmManager,
+			intentTestFluxHelmNameLabel:      intentTestNetworkingRelease,
+			intentTestFluxHelmNamespaceLabel: intentTestSourceNamespace,
+		},
+		nil,
+	)
+	if !p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated}) {
+		t.Fatalf("expected Helm/Flux ownership label change to be accepted because selectors may use those labels")
+	}
+}
+
+func TestIntentCRDPredicate_SelectorLabelChangeWithHelmFluxMetadataAccepted(t *testing.T) {
+	p := intentCRDPredicate()
+	old := makeVRF("v1", 5,
+		map[string]string{
+			intentTestScopeLabel: intentTestSANScope,
+		},
+		map[string]string{
+			helmReleaseNameAnnotation: intentTestOldRelease,
+		},
+	)
+	updated := makeVRF("v1", 5,
+		map[string]string{
+			intentTestScopeLabel:             "storage",
+			intentTestManagedByLabel:         intentTestHelmManager,
+			intentTestFluxHelmNameLabel:      intentTestNetworkingRelease,
+			intentTestFluxHelmNamespaceLabel: intentTestSourceNamespace,
+		},
+		map[string]string{
+			helmReleaseNameAnnotation:      intentTestNewRelease,
+			helmReleaseNamespaceAnnotation: intentTestSourceNamespace,
+		},
+	)
+	if !p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated}) {
+		t.Fatalf("expected non-ownership selector label change to be accepted")
 	}
 }
 

--- a/controllers/intent/predicates_test.go
+++ b/controllers/intent/predicates_test.go
@@ -260,6 +260,40 @@ func TestNodePredicate_ReadyTransitionAccepted(t *testing.T) {
 	}
 }
 
+func TestNodePredicate_InternalIPChangeAccepted(t *testing.T) {
+	p := nodePredicate()
+	old := makeNode("n1", nil, nil, corev1.ConditionTrue, time.Now())
+	old.Status.Addresses = []corev1.NodeAddress{
+		{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+		{Type: corev1.NodeHostName, Address: "n1"},
+	}
+	updated := old.DeepCopy()
+	updated.Status.Addresses = []corev1.NodeAddress{
+		{Type: corev1.NodeInternalIP, Address: "10.0.0.2"},
+		{Type: corev1.NodeHostName, Address: "n1"},
+	}
+	if !p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated}) {
+		t.Fatalf("expected InternalIP-only update to be accepted")
+	}
+}
+
+func TestNodePredicate_NonInternalIPChangeIgnored(t *testing.T) {
+	p := nodePredicate()
+	old := makeNode("n1", nil, nil, corev1.ConditionTrue, time.Now())
+	old.Status.Addresses = []corev1.NodeAddress{
+		{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+		{Type: corev1.NodeHostName, Address: "n1"},
+	}
+	updated := old.DeepCopy()
+	updated.Status.Addresses = []corev1.NodeAddress{
+		{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+		{Type: corev1.NodeHostName, Address: "n1-renamed"},
+	}
+	if p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated}) {
+		t.Fatalf("expected non-InternalIP address update to be ignored")
+	}
+}
+
 func TestNodePredicate_CreateDeleteGenericAlwaysAccepted(t *testing.T) {
 	p := nodePredicate()
 	n := makeNode("n1", nil, nil, corev1.ConditionTrue, time.Now())

--- a/controllers/sync/cluster_controller.go
+++ b/controllers/sync/cluster_controller.go
@@ -20,7 +20,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const secretRequeueInterval = 30 * time.Second
+const (
+	kubeconfigSecretSuffix   = "-kubeconfig" // #nosec G101 -- suffix for Secret object names, not a credential value.
+	kubeconfigSecretValueKey = "value"
+	secretRequeueInterval    = 30 * time.Second
+)
 
 var capiClusterGVK = schema.GroupVersionKind{
 	Group:   "cluster.x-k8s.io",
@@ -53,7 +57,7 @@ func (r *ClusterController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// Look up the kubeconfig Secret: <cluster-name>-kubeconfig
-	secretName := cluster.GetName() + "-kubeconfig"
+	secretName := cluster.GetName() + kubeconfigSecretSuffix
 	secret := &corev1.Secret{}
 	err = r.Client.Get(ctx, types.NamespacedName{
 		Namespace: req.Namespace,
@@ -70,7 +74,7 @@ func (r *ClusterController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, fmt.Errorf("fetching kubeconfig Secret %q: %w", secretName, err)
 	}
 
-	kubeconfig, ok := secret.Data["value"]
+	kubeconfig, ok := secret.Data[kubeconfigSecretValueKey]
 	if !ok {
 		log.Info("kubeconfig Secret missing 'value' key", "secret", secretName)
 		r.Remotes.Remove(req.NamespacedName)
@@ -107,11 +111,10 @@ func (r *ClusterController) SetupWithManager(mgr ctrl.Manager) error {
 			}
 			// Convention: <cluster-name>-kubeconfig
 			name := secret.GetName()
-			const suffix = "-kubeconfig"
-			if !strings.HasSuffix(name, suffix) {
+			if !strings.HasSuffix(name, kubeconfigSecretSuffix) {
 				return nil
 			}
-			clusterName := strings.TrimSuffix(name, suffix)
+			clusterName := strings.TrimSuffix(name, kubeconfigSecretSuffix)
 			if clusterName == "" {
 				// Defensive: a Secret literally named "-kubeconfig" would otherwise
 				// enqueue a reconcile for an empty Name and pollute logs/metrics.
@@ -128,7 +131,7 @@ func (r *ClusterController) SetupWithManager(mgr ctrl.Manager) error {
 
 	// Only watch Secrets whose name ends with -kubeconfig to reduce event volume.
 	kubeconfigPredicate := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		return strings.HasSuffix(obj.GetName(), "-kubeconfig")
+		return strings.HasSuffix(obj.GetName(), kubeconfigSecretSuffix)
 	})
 
 	if err := ctrl.NewControllerManagedBy(mgr).

--- a/controllers/sync/cluster_controller_test.go
+++ b/controllers/sync/cluster_controller_test.go
@@ -19,7 +19,7 @@ import (
 func newCapiCluster(namespace string) *unstructured.Unstructured {
 	cluster := &unstructured.Unstructured{}
 	cluster.SetGroupVersionKind(capiClusterGVK)
-	cluster.SetName("test-cluster")
+	cluster.SetName(testClusterNamespace)
 	cluster.SetNamespace(namespace)
 	return cluster
 }
@@ -50,10 +50,10 @@ func addRemoteClientForTest(c *ClusterController, key types.NamespacedName, remo
 func TestClusterReconcile_ClusterNotFound(t *testing.T) {
 	c := newClusterController()
 	// Pre-populate a remote client to verify Remove is called.
-	addRemoteClientForTest(c, types.NamespacedName{Namespace: "test-ns", Name: "test-cluster"}, fake.NewClientBuilder().WithScheme(testScheme()).Build())
+	addRemoteClientForTest(c, types.NamespacedName{Namespace: testManagementNamespace, Name: testClusterNamespace}, fake.NewClientBuilder().WithScheme(testScheme()).Build())
 
 	result, err := c.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "test-cluster"},
+		NamespacedName: types.NamespacedName{Namespace: testManagementNamespace, Name: testClusterNamespace},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -61,17 +61,17 @@ func TestClusterReconcile_ClusterNotFound(t *testing.T) {
 	if result.RequeueAfter != 0 {
 		t.Errorf("expected no requeue, got RequeueAfter=%v", result.RequeueAfter)
 	}
-	if c.Remotes.Has(types.NamespacedName{Namespace: "test-ns", Name: "test-cluster"}) {
+	if c.Remotes.Has(types.NamespacedName{Namespace: testManagementNamespace, Name: testClusterNamespace}) {
 		t.Error("expected remote client to be removed")
 	}
 }
 
 func TestClusterReconcile_SecretNotFound(t *testing.T) {
-	cluster := newCapiCluster("test-ns")
+	cluster := newCapiCluster(testManagementNamespace)
 	c := newClusterController(cluster)
 
 	result, err := c.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "test-cluster"},
+		NamespacedName: types.NamespacedName{Namespace: testManagementNamespace, Name: testClusterNamespace},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -82,11 +82,11 @@ func TestClusterReconcile_SecretNotFound(t *testing.T) {
 }
 
 func TestClusterReconcile_SecretMissingValueKey(t *testing.T) {
-	cluster := newCapiCluster("test-ns")
+	cluster := newCapiCluster(testManagementNamespace)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-cluster-kubeconfig",
-			Namespace: "test-ns",
+			Name:      testClusterKubeconfigSecret,
+			Namespace: testManagementNamespace,
 		},
 		Data: map[string][]byte{
 			"other-key": []byte("irrelevant"),
@@ -95,7 +95,7 @@ func TestClusterReconcile_SecretMissingValueKey(t *testing.T) {
 	c := newClusterController(cluster, secret)
 
 	result, err := c.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "test-cluster"},
+		NamespacedName: types.NamespacedName{Namespace: testManagementNamespace, Name: testClusterNamespace},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -106,20 +106,20 @@ func TestClusterReconcile_SecretMissingValueKey(t *testing.T) {
 }
 
 func TestClusterReconcile_SecretEmptyValue(t *testing.T) {
-	cluster := newCapiCluster("test-ns")
+	cluster := newCapiCluster(testManagementNamespace)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-cluster-kubeconfig",
-			Namespace: "test-ns",
+			Name:      testClusterKubeconfigSecret,
+			Namespace: testManagementNamespace,
 		},
 		Data: map[string][]byte{
-			"value": {},
+			kubeconfigSecretValueKey: {},
 		},
 	}
 	c := newClusterController(cluster, secret)
 
 	result, err := c.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "test-cluster"},
+		NamespacedName: types.NamespacedName{Namespace: testManagementNamespace, Name: testClusterNamespace},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -130,20 +130,20 @@ func TestClusterReconcile_SecretEmptyValue(t *testing.T) {
 }
 
 func TestClusterReconcile_InvalidKubeconfig(t *testing.T) {
-	cluster := newCapiCluster("test-ns")
+	cluster := newCapiCluster(testManagementNamespace)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-cluster-kubeconfig",
-			Namespace: "test-ns",
+			Name:      testClusterKubeconfigSecret,
+			Namespace: testManagementNamespace,
 		},
 		Data: map[string][]byte{
-			"value": []byte("not-a-valid-kubeconfig"),
+			kubeconfigSecretValueKey: []byte("not-a-valid-kubeconfig"),
 		},
 	}
 	c := newClusterController(cluster, secret)
 
 	_, err := c.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "test-cluster"},
+		NamespacedName: types.NamespacedName{Namespace: testManagementNamespace, Name: testClusterNamespace},
 	})
 	if err == nil {
 		t.Fatal("expected error for invalid kubeconfig, got nil")
@@ -154,7 +154,7 @@ func TestClusterReconcile_InvalidKubeconfig(t *testing.T) {
 }
 
 func TestClusterReconcile_Success(t *testing.T) {
-	cluster := newCapiCluster("test-ns")
+	cluster := newCapiCluster(testManagementNamespace)
 	// Minimal valid kubeconfig that clientcmd.RESTConfigFromKubeConfig can parse.
 	kubeconfig := []byte(`apiVersion: v1
 kind: Config
@@ -175,17 +175,17 @@ users:
 `)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-cluster-kubeconfig",
-			Namespace: "test-ns",
+			Name:      testClusterKubeconfigSecret,
+			Namespace: testManagementNamespace,
 		},
 		Data: map[string][]byte{
-			"value": kubeconfig,
+			kubeconfigSecretValueKey: kubeconfig,
 		},
 	}
 	c := newClusterController(cluster, secret)
 
 	result, err := c.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "test-cluster"},
+		NamespacedName: types.NamespacedName{Namespace: testManagementNamespace, Name: testClusterNamespace},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -193,7 +193,7 @@ users:
 	if result.RequeueAfter != 0 {
 		t.Errorf("expected no requeue, got RequeueAfter=%v", result.RequeueAfter)
 	}
-	if !c.Remotes.Has(types.NamespacedName{Namespace: "test-ns", Name: "test-cluster"}) {
+	if !c.Remotes.Has(types.NamespacedName{Namespace: testManagementNamespace, Name: testClusterNamespace}) {
 		t.Error("expected remote client to be registered after successful reconcile")
 	}
 }

--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -39,6 +39,7 @@ const (
 	labelManagedBy      = "network-sync.telekom.com/managed-by"
 	labelManagedByValue = "network-sync"
 	annotationSourceNS  = "network-sync.telekom.com/source-namespace"
+	syncRequestName     = "sync"
 
 	// annotationSourceGeneration records the management object's
 	// metadata.generation that the remote object's spec was built from. Status
@@ -58,6 +59,13 @@ const (
 	// existing objects instead of accreting stale keys forever.
 	annotationManagedLabels      = "network-sync.telekom.com/managed-labels"
 	annotationManagedAnnotations = "network-sync.telekom.com/managed-annotations"
+
+	ownershipManagedByLabel          = "app.kubernetes.io/managed-by"
+	ownershipFluxHelmNameLabel       = "helm.toolkit.fluxcd.io/name"
+	ownershipFluxHelmNamespaceLabel  = "helm.toolkit.fluxcd.io/namespace"
+	ownershipHelmReleaseNameAnn      = "meta.helm.sh/release-name"
+	ownershipHelmReleaseNamespaceAnn = "meta.helm.sh/release-namespace"
+	lastAppliedConfigurationAnn      = "kubectl.kubernetes.io/last-applied-configuration"
 )
 
 // gitOpsKeyPrefixes are label/annotation key prefixes owned by GitOps tooling
@@ -72,6 +80,17 @@ var gitOpsKeyPrefixes = []string{
 }
 
 const syncRequeueInterval = 10 * time.Second
+
+var ownershipLabelKeys = map[string]struct{}{
+	ownershipManagedByLabel:         {},
+	ownershipFluxHelmNameLabel:      {},
+	ownershipFluxHelmNamespaceLabel: {},
+}
+
+var ownershipAnnotationKeys = map[string]struct{}{
+	ownershipHelmReleaseNameAnn:      {},
+	ownershipHelmReleaseNamespaceAnn: {},
+}
 
 // errMultipleWorkloadClusters is returned by Reconcile (and surfaced on the
 // intent resources as a condition + event) when a namespace resolves to more
@@ -251,6 +270,7 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, fmt.Errorf("listing %T: %w", list, err)
 		}
 		items := extractItems(list)
+		desiredNames := desiredObjectNames(items)
 		for i := range items {
 			if err := r.syncObject(ctx, log, remoteClient, items[i], ipamAddrs); err != nil {
 				return ctrl.Result{}, err
@@ -263,6 +283,11 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				if err := r.syncObjectStatusBack(ctx, log, remoteClient, items[i]); err != nil {
 					return ctrl.Result{}, err
 				}
+			}
+		}
+		for _, remoteClient := range remoteClients {
+			if err := r.sweepRemoteOrphans(ctx, log, remoteClient, list, desiredNames, req.Namespace); err != nil {
+				return ctrl.Result{}, err
 			}
 		}
 	}
@@ -676,21 +701,26 @@ func (r *Controller) buildRemoteObject(src client.Object, sourceNamespace string
 	dst.SetFinalizers(nil)      // Remote objects don't need our finalizer
 	dst.SetOwnerReferences(nil) // No cross-cluster owner refs
 
-	// Set sync labels/annotations. Strip GitOps (Flux) keys first so that the
-	// management cluster's kustomization inventory metadata is not carried over
-	// to the workload cluster; otherwise a Flux running there would claim our
-	// synced objects and the two controllers would fight over them.
-	labels := stripGitOpsKeys(dst.GetLabels())
+	// Set sync labels/annotations. Strip GitOps inventory and source-side
+	// Helm/Flux ownership metadata first so the workload copy is not adopted by
+	// the management cluster's tooling.
+	labels := stripMetadataKeys(stripGitOpsKeys(dst.GetLabels()), ownershipLabelKeys)
+	if labels == nil {
+		labels = make(map[string]string)
+	}
 	labels[labelManagedBy] = labelManagedByValue
 	dst.SetLabels(labels)
 
-	annotations := stripGitOpsKeys(dst.GetAnnotations())
+	annotations := stripMetadataKeys(stripGitOpsKeys(dst.GetAnnotations()), ownershipAnnotationKeys)
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
 	annotations[annotationSourceNS] = sourceNamespace
 	// Record the management generation this spec was built from so status
 	// sync-back can tell whether the workload has caught up to the current intent.
 	annotations[annotationSourceGeneration] = strconv.FormatInt(src.GetGeneration(), 10)
 	// Remove system annotations.
-	delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
+	delete(annotations, lastAppliedConfigurationAnn)
 	dst.SetAnnotations(annotations)
 
 	// Record the keys we own so the next sync can prune the ones we drop.
@@ -933,15 +963,16 @@ func reconcileManagedMetadata(dst, src client.Object) {
 	prevLabelKeys := parseKeyList(dst.GetAnnotations()[annotationManagedLabels])
 	prevAnnotationKeys := parseKeyList(dst.GetAnnotations()[annotationManagedAnnotations])
 
-	dst.SetLabels(mergeAndPrune(dst.GetLabels(), src.GetLabels(), prevLabelKeys))
-	dst.SetAnnotations(mergeAndPrune(dst.GetAnnotations(), src.GetAnnotations(), prevAnnotationKeys))
+	dst.SetLabels(mergeAndPrune(dst.GetLabels(), src.GetLabels(), prevLabelKeys, ownershipLabelKeys))
+	dst.SetAnnotations(mergeAndPrune(dst.GetAnnotations(), src.GetAnnotations(), prevAnnotationKeys, ownershipAnnotationKeys))
 }
 
 // mergeAndPrune overlays the keys we manage now (desired) onto existing, removes
 // keys we managed on the previous sync (prevManaged) that are no longer desired,
-// and drops any GitOps/Flux-owned key. Foreign keys we never managed and that are
-// not GitOps-owned are left untouched.
-func mergeAndPrune(existing, desired map[string]string, prevManaged []string) map[string]string {
+// and drops any GitOps/Flux-owned key except remote-side ownership keys that
+// belong to the workload cluster's manager. Foreign keys we never managed and
+// that are not GitOps-owned are left untouched.
+func mergeAndPrune(existing, desired map[string]string, prevManaged []string, preserveKeys map[string]struct{}) map[string]string {
 	out := make(map[string]string, len(existing)+len(desired))
 	for k, v := range existing {
 		out[k] = v
@@ -949,6 +980,9 @@ func mergeAndPrune(existing, desired map[string]string, prevManaged []string) ma
 	// Drop keys we used to own but no longer set.
 	for _, k := range prevManaged {
 		if _, stillManaged := desired[k]; !stillManaged {
+			if _, preserve := preserveKeys[k]; preserve {
+				continue
+			}
 			delete(out, k)
 		}
 	}
@@ -959,6 +993,9 @@ func mergeAndPrune(existing, desired map[string]string, prevManaged []string) ma
 	// not part of any Flux inventory.
 	for k := range out {
 		if hasAnyPrefix(k, gitOpsKeyPrefixes) {
+			if _, preserve := preserveKeys[k]; preserve {
+				continue
+			}
 			delete(out, k)
 		}
 	}
@@ -1029,6 +1066,24 @@ func hasAnyPrefix(s string, prefixes []string) bool {
 	return false
 }
 
+func stripMetadataKeys(metadata map[string]string, keys map[string]struct{}) map[string]string {
+	if len(metadata) == 0 {
+		return nil
+	}
+
+	filtered := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		if _, ok := keys[key]; ok {
+			continue
+		}
+		filtered[key] = value
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
+}
+
 // deleteRemote removes the object from the remote cluster.
 func (r *Controller) deleteRemote(ctx context.Context, remoteClient client.Client, src client.Object) error {
 	remote, ok := src.DeepCopyObject().(client.Object)
@@ -1039,12 +1094,57 @@ func (r *Controller) deleteRemote(ctx context.Context, remoteClient client.Clien
 	remote.SetResourceVersion("")
 	remote.SetUID("")
 
-	err := remoteClient.Delete(ctx, remote)
+	err := remoteClient.Get(ctx, types.NamespacedName{
+		Namespace: remote.GetNamespace(),
+		Name:      remote.GetName(),
+	}, remote)
 	if apierrors.IsNotFound(err) {
 		return nil // Already gone.
 	}
 	if err != nil {
+		return fmt.Errorf("getting remote object %s/%s before delete: %w", remote.GetNamespace(), remote.GetName(), err)
+	}
+
+	if remote.GetLabels()[labelManagedBy] != labelManagedByValue {
+		return nil
+	}
+
+	if err := remoteClient.Delete(ctx, remote); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("deleting remote object %s/%s: %w", remote.GetNamespace(), remote.GetName(), err)
+	}
+	return nil
+}
+
+func (r *Controller) sweepRemoteOrphans(ctx context.Context, log logr.Logger, remoteClient client.Client,
+	sourceList client.ObjectList, desiredNames map[string]struct{}, sourceNamespace string,
+) error {
+	remoteList, err := newObjectListLike(sourceList)
+	if err != nil {
+		return err
+	}
+	if err := remoteClient.List(ctx, remoteList,
+		client.InNamespace(r.remoteNamespace()),
+		client.MatchingLabels{labelManagedBy: labelManagedByValue},
+	); err != nil {
+		return fmt.Errorf("listing remote %T for orphan sweep: %w", remoteList, err)
+	}
+
+	items := extractItems(remoteList)
+	for i := range items {
+		obj := items[i]
+		if obj.GetAnnotations()[annotationSourceNS] != sourceNamespace {
+			continue
+		}
+		if _, keep := desiredNames[obj.GetName()]; keep {
+			continue
+		}
+		log.Info("Sweeping orphan synced intent object on workload cluster",
+			"kind", obj.GetObjectKind().GroupVersionKind().Kind,
+			"namespace", obj.GetNamespace(),
+			"name", obj.GetName())
+		if err := remoteClient.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("deleting orphan remote %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+		}
 	}
 	return nil
 }
@@ -1149,7 +1249,7 @@ func (r *Controller) SetupWithManager(mgr ctrl.Manager) error {
 			return []reconcile.Request{{
 				NamespacedName: types.NamespacedName{
 					Namespace: obj.GetNamespace(),
-					Name:      "sync", // Synthetic key; we reconcile the whole namespace.
+					Name:      syncRequestName, // Synthetic key; we reconcile the whole namespace.
 				},
 			}}
 		},
@@ -1227,4 +1327,27 @@ func extractItems(list client.ObjectList) []client.Object {
 	}
 
 	return out
+}
+
+func desiredObjectNames(items []client.Object) map[string]struct{} {
+	names := make(map[string]struct{}, len(items))
+	for i := range items {
+		if !items[i].GetDeletionTimestamp().IsZero() {
+			continue
+		}
+		names[items[i].GetName()] = struct{}{}
+	}
+	return names
+}
+
+func newObjectListLike(list client.ObjectList) (client.ObjectList, error) {
+	t := reflect.TypeOf(list)
+	if t == nil || t.Kind() != reflect.Pointer {
+		return nil, fmt.Errorf("expected pointer ObjectList, got %T", list)
+	}
+	copyList, ok := reflect.New(t.Elem()).Interface().(client.ObjectList)
+	if !ok {
+		return nil, fmt.Errorf("new %s is not a client.ObjectList", t.Elem())
+	}
+	return copyList, nil
 }

--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -1355,13 +1355,27 @@ func desiredObjectNames(items []client.Object) map[string]struct{} {
 }
 
 func newObjectListLike(list client.ObjectList) (client.ObjectList, error) {
-	t := reflect.TypeOf(list)
-	if t == nil || t.Kind() != reflect.Pointer {
+	elem, ok := pointerElementType(reflect.TypeOf(list))
+	if !ok {
 		return nil, fmt.Errorf("expected pointer ObjectList, got %T", list)
 	}
-	copyList, ok := reflect.New(t.Elem()).Interface().(client.ObjectList)
+	copyList, ok := reflect.New(elem).Interface().(client.ObjectList)
 	if !ok {
-		return nil, fmt.Errorf("new %s is not a client.ObjectList", t.Elem())
+		return nil, fmt.Errorf("new %s is not a client.ObjectList", elem)
 	}
 	return copyList, nil
+}
+
+func pointerElementType(t reflect.Type) (elem reflect.Type, ok bool) {
+	if t == nil {
+		return nil, false
+	}
+	defer func() {
+		if recover() != nil {
+			elem = nil
+			ok = false
+		}
+	}()
+	elem = t.Elem()
+	return elem, reflect.PointerTo(elem) == t
 }

--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -870,6 +870,12 @@ func toHostCIDR(addr string) string {
 // client.Update replaced the entire object and clobbered every label the sync
 // operator did not itself set, so Flux and the sync operator flapped forever.
 func (*Controller) applyRemote(ctx context.Context, remoteClient client.Client, desired client.Object) error {
+	desiredSourceNamespace := desired.GetAnnotations()[annotationSourceNS]
+	if desiredSourceNamespace == "" {
+		return fmt.Errorf("desired remote object %s/%s is missing %s annotation",
+			desired.GetNamespace(), desired.GetName(), annotationSourceNS)
+	}
+
 	existing, ok := desired.DeepCopyObject().(client.Object)
 	if !ok {
 		return fmt.Errorf("DeepCopyObject did not return client.Object for %s/%s", desired.GetNamespace(), desired.GetName())
@@ -892,6 +898,11 @@ func (*Controller) applyRemote(ctx context.Context, remoteClient client.Client, 
 	// Verify we own this object before mutating it.
 	if existing.GetLabels()[labelManagedBy] != labelManagedByValue {
 		return fmt.Errorf("remote object %s/%s exists but not managed by us", desired.GetNamespace(), desired.GetName())
+	}
+	if existingSourceNamespace := existing.GetAnnotations()[annotationSourceNS]; existingSourceNamespace != "" &&
+		existingSourceNamespace != desiredSourceNamespace {
+		return fmt.Errorf("remote object %s/%s belongs to source namespace %q, not %q",
+			desired.GetNamespace(), desired.GetName(), existingSourceNamespace, desiredSourceNamespace)
 	}
 
 	// Snapshot the fetched object, then mutate it in place so the patch helper

--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -1321,7 +1321,7 @@ func extractItems(list client.ObjectList) []client.Object {
 	}
 
 	out := make([]client.Object, items.Len())
-	for i := range items.Len() {
+	for i := 0; i < items.Len(); i++ {
 		obj, ok := items.Index(i).Addr().Interface().(client.Object)
 		if !ok {
 			return nil

--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -899,8 +899,11 @@ func (*Controller) applyRemote(ctx context.Context, remoteClient client.Client, 
 	if existing.GetLabels()[labelManagedBy] != labelManagedByValue {
 		return fmt.Errorf("remote object %s/%s exists but not managed by us", desired.GetNamespace(), desired.GetName())
 	}
-	if existingSourceNamespace := existing.GetAnnotations()[annotationSourceNS]; existingSourceNamespace != "" &&
-		existingSourceNamespace != desiredSourceNamespace {
+	existingSourceNamespace, hasSourceNamespace := existing.GetAnnotations()[annotationSourceNS]
+	// Older network-sync managed objects did not have annotationSourceNS yet.
+	// Adopt only that absent legacy value; reject explicit empty or mismatched
+	// values because they break the source namespace ownership boundary.
+	if hasSourceNamespace && existingSourceNamespace != desiredSourceNamespace {
 		return fmt.Errorf("remote object %s/%s belongs to source namespace %q, not %q",
 			desired.GetNamespace(), desired.GetName(), existingSourceNamespace, desiredSourceNamespace)
 	}

--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -1122,7 +1122,8 @@ func (r *Controller) deleteRemote(ctx context.Context, remoteClient client.Clien
 	if remote.GetLabels()[labelManagedBy] != labelManagedByValue {
 		return nil
 	}
-	if remote.GetAnnotations()[annotationSourceNS] != src.GetNamespace() {
+	remoteSourceNamespace, hasSourceNamespace := remote.GetAnnotations()[annotationSourceNS]
+	if hasSourceNamespace && remoteSourceNamespace != src.GetNamespace() {
 		return nil
 	}
 

--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -1108,6 +1108,9 @@ func (r *Controller) deleteRemote(ctx context.Context, remoteClient client.Clien
 	if remote.GetLabels()[labelManagedBy] != labelManagedByValue {
 		return nil
 	}
+	if remote.GetAnnotations()[annotationSourceNS] != src.GetNamespace() {
+		return nil
+	}
 
 	if err := remoteClient.Delete(ctx, remote); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("deleting remote object %s/%s: %w", remote.GetNamespace(), remote.GetName(), err)

--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -16,6 +16,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
@@ -218,15 +219,7 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	remoteClients := r.Remotes.GetByNamespace(req.Namespace)
 	if len(remoteClients) == 0 {
-		// No remote client — either the workload cluster's CAPI Cluster has been
-		// deleted (or never reached Ready). Drain our finalizer from any intent
-		// CRs that are mid-deletion; otherwise they would block forever waiting
-		// for a remote cluster that no longer exists.
-		if err := r.drainFinalizersForLostRemote(ctx, log, req.Namespace); err != nil {
-			return ctrl.Result{}, err
-		}
-		// ClusterController hasn't set up a client (yet) — wait and retry.
-		return ctrl.Result{RequeueAfter: syncRequeueInterval}, nil
+		return r.requeueForMissingRemoteClient(ctx, log, req.Namespace)
 	}
 	if len(remoteClients) > 1 {
 		// A namespace maps to exactly one workload cluster by design. More than
@@ -298,10 +291,36 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err := r.syncBGPSecrets(ctx, log, remoteClient, req.Namespace); err != nil {
 		return ctrl.Result{}, err
 	}
-
 	// Requeue so workload status changes are pulled back periodically; the
 	// controller does not watch the workload clusters.
 	return ctrl.Result{RequeueAfter: statusPollInterval}, nil
+}
+
+func (r *Controller) remoteClusterExists(ctx context.Context, namespace string) (bool, error) {
+	clusterList := &unstructured.UnstructuredList{}
+	clusterList.SetGroupVersionKind(capiClusterGVK)
+	if err := r.Client.List(ctx, clusterList, client.InNamespace(namespace)); err != nil {
+		return false, fmt.Errorf("listing CAPI Clusters in namespace %s: %w", namespace, err)
+	}
+	for i := range clusterList.Items {
+		if clusterList.Items[i].GetDeletionTimestamp().IsZero() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (r *Controller) requeueForMissingRemoteClient(ctx context.Context, log logr.Logger, namespace string) (ctrl.Result, error) {
+	clusterExists, err := r.remoteClusterExists(ctx, namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !clusterExists {
+		if err := r.drainFinalizersForLostRemote(ctx, log, namespace); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{RequeueAfter: syncRequeueInterval}, nil
 }
 
 // drainFinalizersForLostRemote walks every intent CRD type in the namespace and

--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -300,7 +300,7 @@ func (r *Controller) remoteClusterExists(ctx context.Context, namespace string) 
 	clusterList := &unstructured.UnstructuredList{}
 	clusterList.SetGroupVersionKind(capiClusterGVK)
 	if err := r.Client.List(ctx, clusterList, client.InNamespace(namespace)); err != nil {
-		if apierrors.IsNotFound(err) || apierrors.IsNoMatchError(err) {
+		if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
 			return false, nil
 		}
 		return false, fmt.Errorf("listing CAPI Clusters in namespace %s: %w", namespace, err)

--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -300,6 +300,9 @@ func (r *Controller) remoteClusterExists(ctx context.Context, namespace string) 
 	clusterList := &unstructured.UnstructuredList{}
 	clusterList.SetGroupVersionKind(capiClusterGVK)
 	if err := r.Client.List(ctx, clusterList, client.InNamespace(namespace)); err != nil {
+		if apierrors.IsNotFound(err) || apierrors.IsNoMatchError(err) {
+			return false, nil
+		}
 		return false, fmt.Errorf("listing CAPI Clusters in namespace %s: %w", namespace, err)
 	}
 	for i := range clusterList.Items {

--- a/controllers/sync/sync_controller_test.go
+++ b/controllers/sync/sync_controller_test.go
@@ -857,6 +857,51 @@ func TestSyncRefusesManagedObjectFromOtherSourceNamespace(t *testing.T) {
 	}
 }
 
+func TestSyncRefusesManagedObjectWithEmptySourceNamespace(t *testing.T) {
+	vrf := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVRFName,
+			Namespace: testClusterNamespace,
+		},
+		Spec: nc.VRFSpec{VRF: testVRFValue, VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+	}
+
+	remoteWithEmptySource := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVRFName,
+			Namespace: testRemoteNamespace,
+			Labels: map[string]string{
+				labelManagedBy: labelManagedByValue,
+			},
+			Annotations: map[string]string{
+				annotationSourceNS: "",
+			},
+		},
+		Spec: nc.VRFSpec{VRF: testForeignVRFValue, VNI: ptrInt32(1), RouteTarget: ptrString("1:1")},
+	}
+
+	sc, remoteClient := newFakeSyncController([]client.Object{vrf}, []client.Object{remoteWithEmptySource})
+	ctx := context.Background()
+
+	_, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
+	})
+	if err == nil {
+		t.Fatal("Expected error when remote object has an explicit empty source namespace")
+	}
+
+	got := &nc.VRF{}
+	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: testVRFName}, got); err != nil {
+		t.Fatalf("Get remote VRF: %v", err)
+	}
+	if got.Spec.VRF != testForeignVRFValue {
+		t.Errorf("Expected empty-source object to be left unchanged, got spec %v", got.Spec)
+	}
+	if got.Annotations[annotationSourceNS] != "" {
+		t.Errorf("Expected empty source namespace annotation to be preserved, got %v", got.Annotations)
+	}
+}
+
 func TestSyncRefusesHelmManagedObjectWithoutSyncOwnership(t *testing.T) {
 	vrf := &nc.VRF{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/sync/sync_controller_test.go
+++ b/controllers/sync/sync_controller_test.go
@@ -27,7 +27,51 @@ func testScheme() *runtime.Scheme {
 	return s
 }
 
-const testRemoteNamespace = "default"
+const (
+	testClusterNamespace         = "test-cluster"
+	testClusterKubeconfigSecret  = testClusterNamespace + "-kubeconfig"
+	testManagementNamespace      = "test-ns"
+	testRemoteNamespace          = "default"
+	testVRFName                  = "vrf-m2m"
+	testVRFValue                 = "m2m"
+	testHelmManager              = "Helm"
+	testSourceReleaseName        = "source-release"
+	testSourceReleaseNamespace   = "t-caas-controllers"
+	testRemoteReleaseName        = "remote-release"
+	testRemoteReleaseNamespace   = "tenant-system"
+	testSharedReleaseName        = "shared-release"
+	testSharedReleaseNamespace   = "shared-namespace"
+	testNetworkName              = "net-vlan501"
+	testOrphanedClusterNamespace = "orphaned-cluster"
+	testPendingClusterNamespace  = "pending-cluster"
+	testRemoteClientNamespace    = "ns1"
+	testRemoteClientName         = "c1"
+	testBGPAuthSecretName        = "bgp-auth" // #nosec G101 -- test Secret object name, not a credential value.
+	testScopeLabel               = "networking.telekom.com/scope"
+	testStorageScopeValue        = "storage"
+	testIntentAnnotation         = "networking.telekom.com/intent"
+	testSANIntentValue           = "san"
+	testForeignVRFValue          = "foreign"
+	testStaleMetadataKey         = "networking.telekom.com/stale"
+	testStaleMetadataValue       = "remove-me"
+	testOwnershipManagedByLabel  = "app.kubernetes.io/managed-by"
+	testOwnershipFluxHelmName    = "helm.toolkit.fluxcd.io/name"
+	testOwnershipFluxHelmNS      = "helm.toolkit.fluxcd.io/namespace"
+	testOwnershipHelmReleaseName = "meta.helm.sh/release-name"
+	testOwnershipHelmReleaseNS   = "meta.helm.sh/release-namespace"
+	testBGPPasswordKey           = "password"
+)
+
+var testOwnershipLabelKeys = []string{
+	testOwnershipManagedByLabel,
+	testOwnershipFluxHelmName,
+	testOwnershipFluxHelmNS,
+}
+
+var testOwnershipAnnotationKeys = []string{
+	testOwnershipHelmReleaseName,
+	testOwnershipHelmReleaseNS,
+}
 
 func newFakeSyncController(mgmtObjs, remoteObjs []client.Object) (*Controller, client.Client) {
 	s := testScheme()
@@ -44,7 +88,7 @@ func newFakeSyncController(mgmtObjs, remoteObjs []client.Object) (*Controller, c
 		Build()
 
 	remotes := NewRemoteClientManager(s, RemoteClientConfig{})
-	remotes.clients[types.NamespacedName{Namespace: "test-cluster", Name: "test-cluster"}] = remoteClient
+	remotes.clients[types.NamespacedName{Namespace: testClusterNamespace, Name: testClusterNamespace}] = remoteClient
 
 	return &Controller{
 		Client:  mgmtClient,
@@ -59,11 +103,11 @@ func newFakeSyncController(mgmtObjs, remoteObjs []client.Object) (*Controller, c
 func TestSyncCreatesRemoteObject(t *testing.T) {
 	vrf := &nc.VRF{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vrf-m2m",
-			Namespace: "test-cluster",
+			Name:      testVRFName,
+			Namespace: testClusterNamespace,
 		},
 		Spec: nc.VRFSpec{
-			VRF:         "m2m",
+			VRF:         testVRFValue,
 			VNI:         ptrInt32(2002026),
 			RouteTarget: ptrString("65188:2026"),
 		},
@@ -73,7 +117,7 @@ func TestSyncCreatesRemoteObject(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := sc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "test-cluster", Name: "sync"},
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
 	})
 	if err != nil {
 		t.Fatalf("Reconcile failed: %v", err)
@@ -83,19 +127,19 @@ func TestSyncCreatesRemoteObject(t *testing.T) {
 	remoteVRF := &nc.VRF{}
 	err = remoteClient.Get(ctx, types.NamespacedName{
 		Namespace: testRemoteNamespace,
-		Name:      "vrf-m2m",
+		Name:      testVRFName,
 	}, remoteVRF)
 	if err != nil {
 		t.Fatalf("Remote VRF not found: %v", err)
 	}
 
-	if remoteVRF.Spec.VRF != "m2m" {
+	if remoteVRF.Spec.VRF != testVRFValue {
 		t.Errorf("Expected VRF name 'm2m', got %q", remoteVRF.Spec.VRF)
 	}
 	if remoteVRF.Labels[labelManagedBy] != labelManagedByValue {
 		t.Errorf("Expected managed-by label, got %v", remoteVRF.Labels)
 	}
-	if remoteVRF.Annotations[annotationSourceNS] != "test-cluster" {
+	if remoteVRF.Annotations[annotationSourceNS] != testClusterNamespace {
 		t.Errorf("Expected source-namespace annotation, got %v", remoteVRF.Annotations)
 	}
 }
@@ -104,11 +148,11 @@ func TestSyncCreatesRemoteObject(t *testing.T) {
 func TestSyncUpdatesRemoteObject(t *testing.T) {
 	vrf := &nc.VRF{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vrf-m2m",
-			Namespace: "test-cluster",
+			Name:      testVRFName,
+			Namespace: testClusterNamespace,
 		},
 		Spec: nc.VRFSpec{
-			VRF:         "m2m",
+			VRF:         testVRFValue,
 			VNI:         ptrInt32(2002026),
 			RouteTarget: ptrString("65188:2026"),
 		},
@@ -117,14 +161,14 @@ func TestSyncUpdatesRemoteObject(t *testing.T) {
 	// Remote has stale data.
 	staleRemote := &nc.VRF{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vrf-m2m",
+			Name:      testVRFName,
 			Namespace: testRemoteNamespace,
 			Labels: map[string]string{
 				labelManagedBy: labelManagedByValue,
 			},
 		},
 		Spec: nc.VRFSpec{
-			VRF:         "m2m",
+			VRF:         testVRFValue,
 			VNI:         ptrInt32(9999), // Drifted VNI
 			RouteTarget: ptrString("65188:2026"),
 		},
@@ -134,18 +178,242 @@ func TestSyncUpdatesRemoteObject(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := sc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "test-cluster", Name: "sync"},
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
 	})
 	if err != nil {
 		t.Fatalf("Reconcile failed: %v", err)
 	}
 
 	remoteVRF := &nc.VRF{}
-	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: "vrf-m2m"}, remoteVRF); err != nil {
+	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: testVRFName}, remoteVRF); err != nil {
 		t.Fatalf("Get remote VRF: %v", err)
 	}
 	if remoteVRF.Spec.VNI == nil || *remoteVRF.Spec.VNI != 2002026 {
 		t.Errorf("Expected VNI 2002026, got %v (drift not corrected)", remoteVRF.Spec.VNI)
+	}
+}
+
+func TestSyncDoesNotCopySourceOwnershipMetadata(t *testing.T) {
+	vrf := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVRFName,
+			Namespace: testClusterNamespace,
+			Labels: map[string]string{
+				testOwnershipManagedByLabel: testHelmManager,
+				testOwnershipFluxHelmName:   testSourceReleaseName,
+				testOwnershipFluxHelmNS:     testSourceReleaseNamespace,
+				testScopeLabel:              testStorageScopeValue,
+			},
+			Annotations: map[string]string{
+				testOwnershipHelmReleaseName: testSourceReleaseName,
+				testOwnershipHelmReleaseNS:   testSourceReleaseNamespace,
+				lastAppliedConfigurationAnn:  "{}",
+				testIntentAnnotation:         testSANIntentValue,
+			},
+		},
+		Spec: nc.VRFSpec{
+			VRF:         testVRFValue,
+			VNI:         ptrInt32(2002026),
+			RouteTarget: ptrString("65188:2026"),
+		},
+	}
+
+	sc, remoteClient := newFakeSyncController([]client.Object{vrf}, nil)
+	ctx := context.Background()
+
+	if _, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
+	}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	remoteVRF := &nc.VRF{}
+	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: testVRFName}, remoteVRF); err != nil {
+		t.Fatalf("Get remote VRF: %v", err)
+	}
+
+	assertNoOwnershipMetadata(t, remoteVRF)
+	if remoteVRF.Labels[testScopeLabel] != testStorageScopeValue {
+		t.Errorf("Expected non-ownership label to be copied, got %v", remoteVRF.Labels)
+	}
+	if remoteVRF.Annotations[testIntentAnnotation] != testSANIntentValue {
+		t.Errorf("Expected non-ownership annotation to be copied, got %v", remoteVRF.Annotations)
+	}
+	if _, ok := remoteVRF.Annotations[lastAppliedConfigurationAnn]; ok {
+		t.Errorf("Expected last-applied annotation to be removed, got %v", remoteVRF.Annotations)
+	}
+}
+
+func TestSyncPreservesRemoteOwnershipMetadata(t *testing.T) {
+	vrf := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVRFName,
+			Namespace: testClusterNamespace,
+			Labels: map[string]string{
+				testOwnershipManagedByLabel: testHelmManager,
+				testOwnershipFluxHelmName:   testSourceReleaseName,
+				testOwnershipFluxHelmNS:     testSourceReleaseNamespace,
+				testScopeLabel:              testStorageScopeValue,
+			},
+			Annotations: map[string]string{
+				testOwnershipHelmReleaseName: testSourceReleaseName,
+				testOwnershipHelmReleaseNS:   testSourceReleaseNamespace,
+				testIntentAnnotation:         testSANIntentValue,
+			},
+		},
+		Spec: nc.VRFSpec{
+			VRF:         testVRFValue,
+			VNI:         ptrInt32(2002026),
+			RouteTarget: ptrString("65188:2026"),
+		},
+	}
+	remoteVRF := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVRFName,
+			Namespace: testRemoteNamespace,
+			Labels: map[string]string{
+				labelManagedBy:              labelManagedByValue,
+				testOwnershipManagedByLabel: testHelmManager,
+				testOwnershipFluxHelmName:   testRemoteReleaseName,
+				testOwnershipFluxHelmNS:     testRemoteReleaseNamespace,
+				testStaleMetadataKey:        testStaleMetadataValue,
+			},
+			Annotations: map[string]string{
+				testOwnershipHelmReleaseName: testRemoteReleaseName,
+				testOwnershipHelmReleaseNS:   testRemoteReleaseNamespace,
+				testStaleMetadataKey:         testStaleMetadataValue,
+			},
+		},
+		Spec: nc.VRFSpec{
+			VRF:         testVRFValue,
+			VNI:         ptrInt32(9999),
+			RouteTarget: ptrString("65188:2026"),
+		},
+	}
+
+	sc, remoteClient := newFakeSyncController([]client.Object{vrf}, []client.Object{remoteVRF})
+	ctx := context.Background()
+
+	if _, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
+	}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	got := &nc.VRF{}
+	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: testVRFName}, got); err != nil {
+		t.Fatalf("Get remote VRF: %v", err)
+	}
+	if got.Labels[testOwnershipManagedByLabel] != testHelmManager {
+		t.Errorf("Expected remote Helm managed-by label to be preserved, got %v", got.Labels)
+	}
+	if got.Labels[testOwnershipFluxHelmName] != testRemoteReleaseName {
+		t.Errorf("Expected remote Helm label to be preserved, got %v", got.Labels)
+	}
+	if got.Labels[testOwnershipFluxHelmNS] != testRemoteReleaseNamespace {
+		t.Errorf("Expected remote Helm namespace label to be preserved, got %v", got.Labels)
+	}
+	if got.Annotations[testOwnershipHelmReleaseName] != testRemoteReleaseName {
+		t.Errorf("Expected remote Helm annotation to be preserved, got %v", got.Annotations)
+	}
+	if got.Annotations[testOwnershipHelmReleaseNS] != testRemoteReleaseNamespace {
+		t.Errorf("Expected remote Helm namespace annotation to be preserved, got %v", got.Annotations)
+	}
+	if got.Labels[testScopeLabel] != testStorageScopeValue {
+		t.Errorf("Expected desired non-ownership label to be applied, got %v", got.Labels)
+	}
+	if got.Annotations[testIntentAnnotation] != testSANIntentValue {
+		t.Errorf("Expected desired non-ownership annotation to be applied, got %v", got.Annotations)
+	}
+	if got.Labels[labelManagedBy] != labelManagedByValue {
+		t.Errorf("Expected sync ownership label to be retained, got %v", got.Labels)
+	}
+	if got.Labels[testStaleMetadataKey] != testStaleMetadataValue {
+		t.Errorf("Expected foreign non-ownership remote label to be preserved, got %v", got.Labels)
+	}
+	if got.Annotations[testStaleMetadataKey] != testStaleMetadataValue {
+		t.Errorf("Expected foreign non-ownership remote annotation to be preserved, got %v", got.Annotations)
+	}
+	if got.Spec.VNI == nil || *got.Spec.VNI != 2002026 {
+		t.Errorf("Expected spec drift to still be corrected, got %v", got.Spec.VNI)
+	}
+}
+
+func TestSyncPreservesRemoteOwnershipMetadataEvenWhenItMatchesSource(t *testing.T) {
+	sourceLabels := map[string]string{
+		testOwnershipManagedByLabel: testHelmManager,
+		testOwnershipFluxHelmName:   testSharedReleaseName,
+		testOwnershipFluxHelmNS:     testSharedReleaseNamespace,
+	}
+	sourceAnnotations := map[string]string{
+		testOwnershipHelmReleaseName: testSharedReleaseName,
+		testOwnershipHelmReleaseNS:   testSharedReleaseNamespace,
+	}
+	vrf := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testVRFName,
+			Namespace:   testClusterNamespace,
+			Labels:      sourceLabels,
+			Annotations: sourceAnnotations,
+		},
+		Spec: nc.VRFSpec{
+			VRF:         testVRFValue,
+			VNI:         ptrInt32(2002026),
+			RouteTarget: ptrString("65188:2026"),
+		},
+	}
+	remoteVRF := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testVRFName,
+			Namespace:   testRemoteNamespace,
+			Labels:      copyStringMap(sourceLabels),
+			Annotations: copyStringMap(sourceAnnotations),
+		},
+		Spec: nc.VRFSpec{
+			VRF:         testVRFValue,
+			VNI:         ptrInt32(9999),
+			RouteTarget: ptrString("65188:2026"),
+		},
+	}
+	remoteVRF.Labels[labelManagedBy] = labelManagedByValue
+	remoteVRF.Annotations[annotationSourceNS] = testClusterNamespace
+
+	sc, remoteClient := newFakeSyncController([]client.Object{vrf}, []client.Object{remoteVRF})
+	ctx := context.Background()
+
+	if _, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
+	}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	got := &nc.VRF{}
+	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: testVRFName}, got); err != nil {
+		t.Fatalf("Get remote VRF: %v", err)
+	}
+	if got.Labels[testOwnershipManagedByLabel] != testHelmManager {
+		t.Errorf("Expected matching remote Helm managed-by label to be preserved, got %v", got.Labels)
+	}
+	if got.Labels[testOwnershipFluxHelmName] != testSharedReleaseName {
+		t.Errorf("Expected matching remote Flux Helm name label to be preserved, got %v", got.Labels)
+	}
+	if got.Labels[testOwnershipFluxHelmNS] != testSharedReleaseNamespace {
+		t.Errorf("Expected matching remote Flux Helm namespace label to be preserved, got %v", got.Labels)
+	}
+	if got.Annotations[testOwnershipHelmReleaseName] != testSharedReleaseName {
+		t.Errorf("Expected matching remote Helm release annotation to be preserved, got %v", got.Annotations)
+	}
+	if got.Annotations[testOwnershipHelmReleaseNS] != testSharedReleaseNamespace {
+		t.Errorf("Expected matching remote Helm namespace annotation to be preserved, got %v", got.Annotations)
+	}
+	if got.Labels[labelManagedBy] != labelManagedByValue {
+		t.Errorf("Expected sync ownership label to remain, got %v", got.Labels)
+	}
+	if got.Annotations[annotationSourceNS] != testClusterNamespace {
+		t.Errorf("Expected source namespace annotation to remain, got %v", got.Annotations)
+	}
+	if got.Spec.VNI == nil || *got.Spec.VNI != 2002026 {
+		t.Errorf("Expected spec drift to still be corrected, got %v", got.Spec.VNI)
 	}
 }
 
@@ -154,42 +422,42 @@ func TestSyncDeletion(t *testing.T) {
 	now := metav1.Now()
 	vrf := &nc.VRF{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              "vrf-m2m",
-			Namespace:         "test-cluster",
+			Name:              testVRFName,
+			Namespace:         testClusterNamespace,
 			DeletionTimestamp: &now,
 			Finalizers:        []string{finalizerName},
 		},
-		Spec: nc.VRFSpec{VRF: "m2m", VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+		Spec: nc.VRFSpec{VRF: testVRFValue, VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
 	}
 
 	remoteVRF := &nc.VRF{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vrf-m2m",
+			Name:      testVRFName,
 			Namespace: testRemoteNamespace,
 			Labels:    map[string]string{labelManagedBy: labelManagedByValue},
 		},
-		Spec: nc.VRFSpec{VRF: "m2m", VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+		Spec: nc.VRFSpec{VRF: testVRFValue, VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
 	}
 
 	sc, remoteClient := newFakeSyncController([]client.Object{vrf}, []client.Object{remoteVRF})
 	ctx := context.Background()
 
 	_, err := sc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "test-cluster", Name: "sync"},
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
 	})
 	if err != nil {
 		t.Fatalf("Reconcile failed: %v", err)
 	}
 
 	// Remote object should be deleted.
-	err = remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: "vrf-m2m"}, &nc.VRF{})
+	err = remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: testVRFName}, &nc.VRF{})
 	if err == nil {
 		t.Error("Expected remote VRF to be deleted, but it still exists")
 	}
 
 	// Mgmt object should be gone (fake client GCs when last finalizer removed + DeletionTimestamp set).
 	mgmtVRF := &nc.VRF{}
-	err = sc.Client.Get(ctx, types.NamespacedName{Namespace: "test-cluster", Name: "vrf-m2m"}, mgmtVRF)
+	err = sc.Client.Get(ctx, types.NamespacedName{Namespace: testClusterNamespace, Name: testVRFName}, mgmtVRF)
 	if err == nil {
 		// If it still exists, check that finalizer was removed.
 		for _, f := range mgmtVRF.Finalizers {
@@ -201,6 +469,77 @@ func TestSyncDeletion(t *testing.T) {
 	// err != nil (not found) is the expected case — object was GC'd.
 }
 
+func TestSyncSweepsOrphanedRemoteIntentObject(t *testing.T) {
+	remoteVRF := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vrf-orphan",
+			Namespace: testRemoteNamespace,
+			Labels: map[string]string{
+				labelManagedBy: labelManagedByValue,
+			},
+			Annotations: map[string]string{
+				annotationSourceNS: testClusterNamespace,
+			},
+		},
+		Spec: nc.VRFSpec{
+			VRF:         "orphan",
+			VNI:         ptrInt32(2002999),
+			RouteTarget: ptrString("65188:2999"),
+		},
+	}
+
+	sc, remoteClient := newFakeSyncController(nil, []client.Object{remoteVRF})
+	ctx := context.Background()
+
+	if _, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
+	}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: "vrf-orphan"}, &nc.VRF{})
+	if err == nil {
+		t.Fatal("Expected orphaned remote VRF to be deleted, but it still exists")
+	}
+}
+
+func TestSyncSweepKeepsOtherSourceNamespace(t *testing.T) {
+	remoteVRF := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vrf-other-source",
+			Namespace: testRemoteNamespace,
+			Labels: map[string]string{
+				labelManagedBy: labelManagedByValue,
+			},
+			Annotations: map[string]string{
+				annotationSourceNS: "other-cluster",
+			},
+		},
+		Spec: nc.VRFSpec{
+			VRF:         "other",
+			VNI:         ptrInt32(2002888),
+			RouteTarget: ptrString("65188:2888"),
+		},
+	}
+
+	sc, remoteClient := newFakeSyncController(nil, []client.Object{remoteVRF})
+	ctx := context.Background()
+
+	if _, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
+	}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	got := &nc.VRF{}
+	if err := remoteClient.Get(ctx, types.NamespacedName{
+		Namespace: testRemoteNamespace,
+		Name:      "vrf-other-source",
+	}, got); err != nil {
+		t.Fatalf("Expected remote VRF from other source namespace to remain: %v", err)
+	}
+}
+
 // TestSyncIPAMPromotion verifies that status.addresses on Inbound gets
 // promoted to spec.addresses on the remote object.
 func TestSyncIPAMPromotion(t *testing.T) {
@@ -208,10 +547,10 @@ func TestSyncIPAMPromotion(t *testing.T) {
 	inbound := &nc.Inbound{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ib-test",
-			Namespace: "test-cluster",
+			Namespace: testClusterNamespace,
 		},
 		Spec: nc.InboundSpec{
-			NetworkRef:    "net-vlan501",
+			NetworkRef:    testNetworkName,
 			Count:         &count,
 			Advertisement: nc.AdvertisementConfig{Type: "bgp"},
 		},
@@ -227,7 +566,7 @@ func TestSyncIPAMPromotion(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := sc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "test-cluster", Name: "sync"},
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
 	})
 	if err != nil {
 		t.Fatalf("Reconcile failed: %v", err)
@@ -348,7 +687,7 @@ func TestSyncNoRemoteClient(t *testing.T) {
 	}
 
 	result, err := sc.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "unknown", Name: "sync"},
+		NamespacedName: types.NamespacedName{Namespace: "unknown", Name: syncRequestName},
 	})
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
@@ -367,7 +706,7 @@ func TestSyncDrainsFinalizerWhenRemoteGone(t *testing.T) {
 	vrf := &nc.VRF{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "vrf-stuck",
-			Namespace:         "orphaned-cluster",
+			Namespace:         testOrphanedClusterNamespace,
 			Finalizers:        []string{finalizerName},
 			DeletionTimestamp: &now,
 		},
@@ -386,14 +725,14 @@ func TestSyncDrainsFinalizerWhenRemoteGone(t *testing.T) {
 	}
 
 	if _, err := sc.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "orphaned-cluster", Name: "sync"},
+		NamespacedName: types.NamespacedName{Namespace: testOrphanedClusterNamespace, Name: syncRequestName},
 	}); err != nil {
 		t.Fatalf("Reconcile returned error: %v", err)
 	}
 
 	// VRF should now be gone (fake client GCs once last finalizer is removed).
 	got := &nc.VRF{}
-	err := mgmtClient.Get(context.Background(), types.NamespacedName{Namespace: "orphaned-cluster", Name: "vrf-stuck"}, got)
+	err := mgmtClient.Get(context.Background(), types.NamespacedName{Namespace: testOrphanedClusterNamespace, Name: "vrf-stuck"}, got)
 	if err == nil {
 		if len(got.Finalizers) != 0 {
 			t.Errorf("Expected finalizer to be drained, still present: %v", got.Finalizers)
@@ -408,7 +747,7 @@ func TestSyncNoRemoteClientLeavesActiveCRsAlone(t *testing.T) {
 	vrf := &nc.VRF{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "vrf-alive",
-			Namespace: "pending-cluster",
+			Namespace: testPendingClusterNamespace,
 		},
 		Spec: nc.VRFSpec{VRF: "alive", VNI: ptrInt32(2002098), RouteTarget: ptrString("65188:98")},
 	}
@@ -425,13 +764,13 @@ func TestSyncNoRemoteClientLeavesActiveCRsAlone(t *testing.T) {
 	}
 
 	if _, err := sc.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "pending-cluster", Name: "sync"},
+		NamespacedName: types.NamespacedName{Namespace: testPendingClusterNamespace, Name: syncRequestName},
 	}); err != nil {
 		t.Fatalf("Reconcile returned error: %v", err)
 	}
 
 	got := &nc.VRF{}
-	if err := mgmtClient.Get(context.Background(), types.NamespacedName{Namespace: "pending-cluster", Name: "vrf-alive"}, got); err != nil {
+	if err := mgmtClient.Get(context.Background(), types.NamespacedName{Namespace: testPendingClusterNamespace, Name: "vrf-alive"}, got); err != nil {
 		t.Fatalf("VRF should still exist: %v", err)
 	}
 	if len(got.Finalizers) != 0 {
@@ -443,29 +782,127 @@ func TestSyncNoRemoteClientLeavesActiveCRsAlone(t *testing.T) {
 func TestSyncRefusesUnmanagedObject(t *testing.T) {
 	vrf := &nc.VRF{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vrf-m2m",
-			Namespace: "test-cluster",
+			Name:      testVRFName,
+			Namespace: testClusterNamespace,
 		},
-		Spec: nc.VRFSpec{VRF: "m2m", VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+		Spec: nc.VRFSpec{VRF: testVRFValue, VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
 	}
 
 	// Remote object exists WITHOUT our managed-by label.
 	unmanagedRemote := &nc.VRF{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vrf-m2m",
+			Name:      testVRFName,
 			Namespace: testRemoteNamespace,
 		},
-		Spec: nc.VRFSpec{VRF: "m2m", VNI: ptrInt32(1), RouteTarget: ptrString("1:1")},
+		Spec: nc.VRFSpec{VRF: testVRFValue, VNI: ptrInt32(1), RouteTarget: ptrString("1:1")},
 	}
 
 	sc, _ := newFakeSyncController([]client.Object{vrf}, []client.Object{unmanagedRemote})
 	ctx := context.Background()
 
 	_, err := sc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "test-cluster", Name: "sync"},
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
 	})
 	if err == nil {
 		t.Fatal("Expected error when remote object is not managed by us")
+	}
+}
+
+func TestSyncRefusesHelmManagedObjectWithoutSyncOwnership(t *testing.T) {
+	vrf := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVRFName,
+			Namespace: testClusterNamespace,
+		},
+		Spec: nc.VRFSpec{VRF: testVRFValue, VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+	}
+
+	helmManagedRemote := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVRFName,
+			Namespace: testRemoteNamespace,
+			Labels: map[string]string{
+				testOwnershipManagedByLabel: testHelmManager,
+				testOwnershipFluxHelmName:   testRemoteReleaseName,
+				testOwnershipFluxHelmNS:     testRemoteReleaseNamespace,
+			},
+			Annotations: map[string]string{
+				testOwnershipHelmReleaseName: testRemoteReleaseName,
+				testOwnershipHelmReleaseNS:   testRemoteReleaseNamespace,
+			},
+		},
+		Spec: nc.VRFSpec{VRF: testForeignVRFValue, VNI: ptrInt32(1), RouteTarget: ptrString("1:1")},
+	}
+
+	sc, remoteClient := newFakeSyncController([]client.Object{vrf}, []client.Object{helmManagedRemote})
+	ctx := context.Background()
+
+	_, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
+	})
+	if err == nil {
+		t.Fatal("Expected error when remote object has Helm ownership but no sync ownership")
+	}
+
+	got := &nc.VRF{}
+	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: testVRFName}, got); err != nil {
+		t.Fatalf("Get remote VRF: %v", err)
+	}
+	if got.Spec.VRF != testForeignVRFValue {
+		t.Errorf("Expected unmanaged Helm object to be left unchanged, got spec %v", got.Spec)
+	}
+	if got.Labels[labelManagedBy] == labelManagedByValue {
+		t.Errorf("Expected sync ownership label not to be added to unmanaged object, got %v", got.Labels)
+	}
+}
+
+func TestSyncDeleteLeavesUnmanagedHelmObjectUntouched(t *testing.T) {
+	now := metav1.Now()
+	vrf := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              testVRFName,
+			Namespace:         testClusterNamespace,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{finalizerName},
+		},
+		Spec: nc.VRFSpec{VRF: testVRFValue, VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+	}
+
+	helmManagedRemote := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVRFName,
+			Namespace: testRemoteNamespace,
+			Labels: map[string]string{
+				testOwnershipManagedByLabel: testHelmManager,
+				testOwnershipFluxHelmName:   testRemoteReleaseName,
+				testOwnershipFluxHelmNS:     testRemoteReleaseNamespace,
+			},
+			Annotations: map[string]string{
+				testOwnershipHelmReleaseName: testRemoteReleaseName,
+				testOwnershipHelmReleaseNS:   testRemoteReleaseNamespace,
+			},
+		},
+		Spec: nc.VRFSpec{VRF: testForeignVRFValue, VNI: ptrInt32(1), RouteTarget: ptrString("1:1")},
+	}
+
+	sc, remoteClient := newFakeSyncController([]client.Object{vrf}, []client.Object{helmManagedRemote})
+	ctx := context.Background()
+
+	if _, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
+	}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	got := &nc.VRF{}
+	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: testVRFName}, got); err != nil {
+		t.Fatalf("Expected unmanaged Helm object to survive source deletion: %v", err)
+	}
+	if got.Spec.VRF != testForeignVRFValue {
+		t.Errorf("Expected unmanaged Helm object to be left unchanged, got spec %v", got.Spec)
+	}
+	if got.Labels[labelManagedBy] == labelManagedByValue {
+		t.Errorf("Expected sync ownership label not to be added to unmanaged object, got %v", got.Labels)
 	}
 }
 
@@ -474,26 +911,26 @@ func TestRemoteClientManager(t *testing.T) {
 	s := testScheme()
 	m := NewRemoteClientManager(s, RemoteClientConfig{})
 
-	if m.Has(types.NamespacedName{Namespace: "ns1", Name: "c1"}) {
+	if m.Has(types.NamespacedName{Namespace: testRemoteClientNamespace, Name: testRemoteClientName}) {
 		t.Error("Should not have ns1/c1 initially")
 	}
-	if m.Get(types.NamespacedName{Namespace: "ns1", Name: "c1"}) != nil {
+	if m.Get(types.NamespacedName{Namespace: testRemoteClientNamespace, Name: testRemoteClientName}) != nil {
 		t.Error("Get should return nil for unknown cluster")
 	}
 
 	// We can't test UpdateFromKubeconfig without a real cluster,
 	// but we can test Has/Get/Remove with direct injection.
-	m.clients[types.NamespacedName{Namespace: "ns1", Name: "c1"}] = fake.NewClientBuilder().WithScheme(s).Build()
+	m.clients[types.NamespacedName{Namespace: testRemoteClientNamespace, Name: testRemoteClientName}] = fake.NewClientBuilder().WithScheme(s).Build()
 
-	if !m.Has(types.NamespacedName{Namespace: "ns1", Name: "c1"}) {
+	if !m.Has(types.NamespacedName{Namespace: testRemoteClientNamespace, Name: testRemoteClientName}) {
 		t.Error("Should have ns1/c1 after injection")
 	}
-	if m.Get(types.NamespacedName{Namespace: "ns1", Name: "c1"}) == nil {
+	if m.Get(types.NamespacedName{Namespace: testRemoteClientNamespace, Name: testRemoteClientName}) == nil {
 		t.Error("Get should return client for ns1/c1")
 	}
 
-	m.Remove(types.NamespacedName{Namespace: "ns1", Name: "c1"})
-	if m.Has(types.NamespacedName{Namespace: "ns1", Name: "c1"}) {
+	m.Remove(types.NamespacedName{Namespace: testRemoteClientNamespace, Name: testRemoteClientName})
+	if m.Has(types.NamespacedName{Namespace: testRemoteClientNamespace, Name: testRemoteClientName}) {
 		t.Error("Should not have ns1/c1 after removal")
 	}
 }
@@ -501,11 +938,11 @@ func TestRemoteClientManager(t *testing.T) {
 // TestSyncMultipleCRDTypes verifies that multiple CRD types are synced in one reconcile.
 func TestSyncMultipleCRDTypes(t *testing.T) {
 	vrf := &nc.VRF{
-		ObjectMeta: metav1.ObjectMeta{Name: "vrf-m2m", Namespace: "test-cluster"},
-		Spec:       nc.VRFSpec{VRF: "m2m", VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+		ObjectMeta: metav1.ObjectMeta{Name: testVRFName, Namespace: testClusterNamespace},
+		Spec:       nc.VRFSpec{VRF: testVRFValue, VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
 	}
 	network := &nc.Network{
-		ObjectMeta: metav1.ObjectMeta{Name: "net-vlan501", Namespace: "test-cluster"},
+		ObjectMeta: metav1.ObjectMeta{Name: testNetworkName, Namespace: testClusterNamespace},
 		Spec:       nc.NetworkSpec{VLAN: ptrInt32(501)},
 	}
 
@@ -513,17 +950,17 @@ func TestSyncMultipleCRDTypes(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := sc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "test-cluster", Name: "sync"},
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
 	})
 	if err != nil {
 		t.Fatalf("Reconcile failed: %v", err)
 	}
 
 	// Both should exist on remote.
-	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: "vrf-m2m"}, &nc.VRF{}); err != nil {
+	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: testVRFName}, &nc.VRF{}); err != nil {
 		t.Errorf("Remote VRF not found: %v", err)
 	}
-	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: "net-vlan501"}, &nc.Network{}); err != nil {
+	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: testNetworkName}, &nc.Network{}); err != nil {
 		t.Errorf("Remote Network not found: %v", err)
 	}
 }
@@ -640,20 +1077,42 @@ func TestSyncDoesNotPropagateFluxLabels(t *testing.T) {
 	}
 }
 
+func copyStringMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func assertNoOwnershipMetadata(t *testing.T, obj client.Object) {
+	t.Helper()
+	for _, key := range testOwnershipLabelKeys {
+		if _, ok := obj.GetLabels()[key]; ok {
+			t.Errorf("Expected ownership label %q to be stripped, got %v", key, obj.GetLabels())
+		}
+	}
+	for _, key := range testOwnershipAnnotationKeys {
+		if _, ok := obj.GetAnnotations()[key]; ok {
+			t.Errorf("Expected ownership annotation %q to be stripped, got %v", key, obj.GetAnnotations())
+		}
+	}
+}
+
 // TestSyncBGPSecretsMirrorsReferencedSecret verifies that a Secret referenced
 // by a BGPPeering.spec.authSecretRef is copied into the remote namespace,
 // stamped with our managed-by label, and contains the same Data.
 func TestSyncBGPSecretsMirrorsReferencedSecret(t *testing.T) {
 	bp := &nc.BGPPeering{
-		ObjectMeta: metav1.ObjectMeta{Name: "lp", Namespace: "test-cluster"},
+		ObjectMeta: metav1.ObjectMeta{Name: "lp", Namespace: testClusterNamespace},
 		Spec: nc.BGPPeeringSpec{
 			Mode:          nc.BGPPeeringModeLoopbackPeer,
 			Ref:           nc.BGPPeeringRef{InboundRefs: []string{"x"}},
-			AuthSecretRef: &corev1.LocalObjectReference{Name: "bgp-auth"},
+			AuthSecretRef: &corev1.LocalObjectReference{Name: testBGPAuthSecretName},
 		},
 	}
 	src := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "bgp-auth", Namespace: "test-cluster"},
+		ObjectMeta: metav1.ObjectMeta{Name: testBGPAuthSecretName, Namespace: testClusterNamespace},
 		Type:       corev1.SecretTypeOpaque,
 		Data:       map[string][]byte{"password": []byte("s3cret")},
 	}
@@ -662,14 +1121,14 @@ func TestSyncBGPSecretsMirrorsReferencedSecret(t *testing.T) {
 	ctx := context.Background()
 
 	if _, err := sc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "test-cluster", Name: "sync"},
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
 	}); err != nil {
 		t.Fatalf("Reconcile failed: %v", err)
 	}
 
 	got := &corev1.Secret{}
 	if err := remoteClient.Get(ctx, types.NamespacedName{
-		Namespace: testRemoteNamespace, Name: "bgp-auth",
+		Namespace: testRemoteNamespace, Name: testBGPAuthSecretName,
 	}, got); err != nil {
 		t.Fatalf("Remote Secret not found: %v", err)
 	}
@@ -679,8 +1138,85 @@ func TestSyncBGPSecretsMirrorsReferencedSecret(t *testing.T) {
 	if got.Labels[labelManagedBy] != labelManagedByValue {
 		t.Errorf("Expected managed-by label, got %v", got.Labels)
 	}
-	if got.Annotations[annotationSourceNS] != "test-cluster" {
+	if got.Annotations[annotationSourceNS] != testClusterNamespace {
 		t.Errorf("Expected source-namespace annotation, got %v", got.Annotations)
+	}
+}
+
+func TestSyncBGPSecretsPreservesRemoteOwnershipMetadataOnUpdate(t *testing.T) {
+	bp := &nc.BGPPeering{
+		ObjectMeta: metav1.ObjectMeta{Name: "lp", Namespace: testClusterNamespace},
+		Spec: nc.BGPPeeringSpec{
+			Mode:          nc.BGPPeeringModeLoopbackPeer,
+			Ref:           nc.BGPPeeringRef{InboundRefs: []string{"x"}},
+			AuthSecretRef: &corev1.LocalObjectReference{Name: testBGPAuthSecretName},
+		},
+	}
+	src := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: testBGPAuthSecretName, Namespace: testClusterNamespace},
+		Type:       corev1.SecretTypeOpaque,
+		Data:       map[string][]byte{testBGPPasswordKey: []byte("new-secret")},
+	}
+	remoteSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testBGPAuthSecretName,
+			Namespace: testRemoteNamespace,
+			Labels: map[string]string{
+				labelManagedBy:              labelManagedByValue,
+				testOwnershipManagedByLabel: testHelmManager,
+				testOwnershipFluxHelmName:   testRemoteReleaseName,
+				testOwnershipFluxHelmNS:     testRemoteReleaseNamespace,
+				testStaleMetadataKey:        testStaleMetadataValue,
+			},
+			Annotations: map[string]string{
+				annotationSourceNS:           testClusterNamespace,
+				testOwnershipHelmReleaseName: testRemoteReleaseName,
+				testOwnershipHelmReleaseNS:   testRemoteReleaseNamespace,
+				testStaleMetadataKey:         testStaleMetadataValue,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{testBGPPasswordKey: []byte("old-secret")},
+	}
+
+	sc, remoteClient := newFakeSyncController([]client.Object{bp, src}, []client.Object{remoteSecret})
+	ctx := context.Background()
+
+	if _, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
+	}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	got := &corev1.Secret{}
+	if err := remoteClient.Get(ctx, types.NamespacedName{
+		Namespace: testRemoteNamespace, Name: testBGPAuthSecretName,
+	}, got); err != nil {
+		t.Fatalf("Remote Secret not found: %v", err)
+	}
+	if string(got.Data[testBGPPasswordKey]) != "new-secret" {
+		t.Errorf("Expected password to be updated, got %q", string(got.Data[testBGPPasswordKey]))
+	}
+	if got.Labels[testOwnershipManagedByLabel] != testHelmManager {
+		t.Errorf("Expected remote Helm managed-by label to be preserved, got %v", got.Labels)
+	}
+	if got.Labels[testOwnershipFluxHelmName] != testRemoteReleaseName {
+		t.Errorf("Expected remote Flux Helm name label to be preserved, got %v", got.Labels)
+	}
+	if got.Labels[testOwnershipFluxHelmNS] != testRemoteReleaseNamespace {
+		t.Errorf("Expected remote Flux Helm namespace label to be preserved, got %v", got.Labels)
+	}
+	if got.Annotations[testOwnershipHelmReleaseName] != testRemoteReleaseName {
+		t.Errorf("Expected remote Helm release annotation to be preserved, got %v", got.Annotations)
+	}
+	if got.Annotations[testOwnershipHelmReleaseNS] != testRemoteReleaseNamespace {
+		t.Errorf("Expected remote Helm release namespace annotation to be preserved, got %v", got.Annotations)
+	}
+	if got.Labels[testStaleMetadataKey] != testStaleMetadataValue {
+		t.Errorf("Expected foreign non-ownership label to be preserved, got %v", got.Labels)
+	}
+	if got.Annotations[testStaleMetadataKey] != testStaleMetadataValue {
+		t.Errorf("Expected foreign non-ownership annotation to be preserved, got %v", got.Annotations)
 	}
 }
 
@@ -694,7 +1230,7 @@ func TestSyncBGPSecretsSweepsOrphan(t *testing.T) {
 			Namespace: testRemoteNamespace,
 			Labels:    map[string]string{labelManagedBy: labelManagedByValue},
 			Annotations: map[string]string{
-				annotationSourceNS: "test-cluster",
+				annotationSourceNS: testClusterNamespace,
 			},
 		},
 		Data: map[string][]byte{"password": []byte("old")},
@@ -704,7 +1240,7 @@ func TestSyncBGPSecretsSweepsOrphan(t *testing.T) {
 	ctx := context.Background()
 
 	if _, err := sc.Reconcile(ctx, ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "test-cluster", Name: "sync"},
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
 	}); err != nil {
 		t.Fatalf("Reconcile failed: %v", err)
 	}

--- a/controllers/sync/sync_controller_test.go
+++ b/controllers/sync/sync_controller_test.go
@@ -473,6 +473,42 @@ func TestSyncDeletion(t *testing.T) {
 	// err != nil (not found) is the expected case — object was GC'd.
 }
 
+func TestSyncDeletionRemovesLegacyManagedRemoteObject(t *testing.T) {
+	now := metav1.Now()
+	vrf := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              testVRFName,
+			Namespace:         testClusterNamespace,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{finalizerName},
+		},
+		Spec: nc.VRFSpec{VRF: testVRFValue, VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+	}
+
+	remoteVRF := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVRFName,
+			Namespace: testRemoteNamespace,
+			Labels:    map[string]string{labelManagedBy: labelManagedByValue},
+		},
+		Spec: nc.VRFSpec{VRF: testVRFValue, VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+	}
+
+	sc, remoteClient := newFakeSyncController([]client.Object{vrf}, []client.Object{remoteVRF})
+	ctx := context.Background()
+
+	if _, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
+	}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: testVRFName}, &nc.VRF{})
+	if err == nil {
+		t.Error("Expected legacy managed remote VRF to be deleted, but it still exists")
+	}
+}
+
 func TestSyncSweepsOrphanedRemoteIntentObject(t *testing.T) {
 	remoteVRF := &nc.VRF{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/sync/sync_controller_test.go
+++ b/controllers/sync/sync_controller_test.go
@@ -191,6 +191,9 @@ func TestSyncUpdatesRemoteObject(t *testing.T) {
 	if remoteVRF.Spec.VNI == nil || *remoteVRF.Spec.VNI != 2002026 {
 		t.Errorf("Expected VNI 2002026, got %v (drift not corrected)", remoteVRF.Spec.VNI)
 	}
+	if remoteVRF.Annotations[annotationSourceNS] != testClusterNamespace {
+		t.Errorf("Expected source-namespace annotation, got %v", remoteVRF.Annotations)
+	}
 }
 
 func TestSyncDoesNotCopySourceOwnershipMetadata(t *testing.T) {
@@ -806,6 +809,51 @@ func TestSyncRefusesUnmanagedObject(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Expected error when remote object is not managed by us")
+	}
+}
+
+func TestSyncRefusesManagedObjectFromOtherSourceNamespace(t *testing.T) {
+	vrf := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVRFName,
+			Namespace: testClusterNamespace,
+		},
+		Spec: nc.VRFSpec{VRF: testVRFValue, VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+	}
+
+	remoteFromOtherSource := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVRFName,
+			Namespace: testRemoteNamespace,
+			Labels: map[string]string{
+				labelManagedBy: labelManagedByValue,
+			},
+			Annotations: map[string]string{
+				annotationSourceNS: testOrphanedClusterNamespace,
+			},
+		},
+		Spec: nc.VRFSpec{VRF: testForeignVRFValue, VNI: ptrInt32(1), RouteTarget: ptrString("1:1")},
+	}
+
+	sc, remoteClient := newFakeSyncController([]client.Object{vrf}, []client.Object{remoteFromOtherSource})
+	ctx := context.Background()
+
+	_, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
+	})
+	if err == nil {
+		t.Fatal("Expected error when remote object is managed by another source namespace")
+	}
+
+	got := &nc.VRF{}
+	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: testVRFName}, got); err != nil {
+		t.Fatalf("Get remote VRF: %v", err)
+	}
+	if got.Spec.VRF != testForeignVRFValue {
+		t.Errorf("Expected other-source object to be left unchanged, got spec %v", got.Spec)
+	}
+	if got.Annotations[annotationSourceNS] != testOrphanedClusterNamespace {
+		t.Errorf("Expected other source namespace annotation to be preserved, got %v", got.Annotations)
 	}
 }
 

--- a/controllers/sync/sync_controller_test.go
+++ b/controllers/sync/sync_controller_test.go
@@ -432,9 +432,10 @@ func TestSyncDeletion(t *testing.T) {
 
 	remoteVRF := &nc.VRF{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVRFName,
-			Namespace: testRemoteNamespace,
-			Labels:    map[string]string{labelManagedBy: labelManagedByValue},
+			Name:        testVRFName,
+			Namespace:   testRemoteNamespace,
+			Labels:      map[string]string{labelManagedBy: labelManagedByValue},
+			Annotations: map[string]string{annotationSourceNS: testClusterNamespace},
 		},
 		Spec: nc.VRFSpec{VRF: testVRFValue, VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
 	}
@@ -903,6 +904,50 @@ func TestSyncDeleteLeavesUnmanagedHelmObjectUntouched(t *testing.T) {
 	}
 	if got.Labels[labelManagedBy] == labelManagedByValue {
 		t.Errorf("Expected sync ownership label not to be added to unmanaged object, got %v", got.Labels)
+	}
+}
+
+func TestSyncDeleteKeepsRemoteObjectFromOtherSourceNamespace(t *testing.T) {
+	now := metav1.Now()
+	vrf := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              testVRFName,
+			Namespace:         testClusterNamespace,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{finalizerName},
+		},
+		Spec: nc.VRFSpec{VRF: testVRFValue, VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+	}
+
+	remoteFromOtherSource := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVRFName,
+			Namespace: testRemoteNamespace,
+			Labels: map[string]string{
+				labelManagedBy: labelManagedByValue,
+			},
+			Annotations: map[string]string{
+				annotationSourceNS: testOrphanedClusterNamespace,
+			},
+		},
+		Spec: nc.VRFSpec{VRF: testForeignVRFValue, VNI: ptrInt32(1), RouteTarget: ptrString("1:1")},
+	}
+
+	sc, remoteClient := newFakeSyncController([]client.Object{vrf}, []client.Object{remoteFromOtherSource})
+	ctx := context.Background()
+
+	if _, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: testClusterNamespace, Name: syncRequestName},
+	}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	got := &nc.VRF{}
+	if err := remoteClient.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: testVRFName}, got); err != nil {
+		t.Fatalf("Expected remote VRF from other source namespace to survive source deletion: %v", err)
+	}
+	if got.Annotations[annotationSourceNS] != testOrphanedClusterNamespace {
+		t.Errorf("Expected other source namespace annotation to be preserved, got %v", got.Annotations)
 	}
 }
 

--- a/controllers/sync/sync_controller_test.go
+++ b/controllers/sync/sync_controller_test.go
@@ -98,6 +98,23 @@ func newFakeSyncController(mgmtObjs, remoteObjs []client.Object) (*Controller, c
 	}, remoteClient
 }
 
+func TestExtractItemsIteratesAllEntries(t *testing.T) {
+	list := &nc.VRFList{
+		Items: []nc.VRF{
+			{ObjectMeta: metav1.ObjectMeta{Name: "vrf-a"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "vrf-b"}},
+		},
+	}
+
+	items := extractItems(list)
+	if len(items) != 2 {
+		t.Fatalf("Expected 2 items, got %d", len(items))
+	}
+	if items[0].GetName() != "vrf-a" || items[1].GetName() != "vrf-b" {
+		t.Fatalf("Unexpected extracted items: %q, %q", items[0].GetName(), items[1].GetName())
+	}
+}
+
 // TestSyncCreatesRemoteObject verifies that a VRF in the mgmt namespace
 // gets created on the remote cluster.
 func TestSyncCreatesRemoteObject(t *testing.T) {

--- a/controllers/sync/sync_controller_test.go
+++ b/controllers/sync/sync_controller_test.go
@@ -8,6 +8,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -15,6 +16,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
@@ -47,6 +49,7 @@ const (
 	testRemoteClientNamespace    = "ns1"
 	testRemoteClientName         = "c1"
 	testBGPAuthSecretName        = "bgp-auth" // #nosec G101 -- test Secret object name, not a credential value.
+	testCAPIClusterFinalizer     = "cluster.x-k8s.io"
 	testScopeLabel               = "networking.telekom.com/scope"
 	testStorageScopeValue        = "storage"
 	testIntentAnnotation         = "networking.telekom.com/intent"
@@ -794,6 +797,76 @@ func TestSyncDrainsFinalizerWhenRemoteGone(t *testing.T) {
 		if len(got.Finalizers) != 0 {
 			t.Errorf("Expected finalizer to be drained, still present: %v", got.Finalizers)
 		}
+	}
+}
+
+func TestSyncKeepsFinalizerWhenClusterExistsButRemoteClientMissing(t *testing.T) {
+	now := metav1.Now()
+	vrf := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "vrf-waiting",
+			Namespace:         testPendingClusterNamespace,
+			Finalizers:        []string{finalizerName},
+			DeletionTimestamp: &now,
+		},
+		Spec: nc.VRFSpec{VRF: "waiting", VNI: ptrInt32(2002097), RouteTarget: ptrString("65188:97")},
+	}
+	cluster := &unstructured.Unstructured{}
+	cluster.SetGroupVersionKind(capiClusterGVK)
+	cluster.SetName("workload")
+	cluster.SetNamespace(testPendingClusterNamespace)
+
+	s := testScheme()
+	mgmtClient := fake.NewClientBuilder().WithScheme(s).WithObjects(vrf, cluster).Build()
+	remotes := NewRemoteClientManager(s, RemoteClientConfig{})
+	sc := &Controller{
+		Client:  mgmtClient,
+		Scheme:  s,
+		Log:     zap.New(zap.UseDevMode(true)),
+		Remotes: remotes,
+	}
+
+	result, err := sc.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: testPendingClusterNamespace, Name: syncRequestName},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("Expected requeue while Cluster exists but remote client is missing")
+	}
+
+	got := &nc.VRF{}
+	if err := mgmtClient.Get(context.Background(), types.NamespacedName{
+		Namespace: testPendingClusterNamespace,
+		Name:      "vrf-waiting",
+	}, got); err != nil {
+		t.Fatalf("VRF should still exist while remote client is missing: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(got, finalizerName) {
+		t.Fatalf("Expected finalizer to remain while Cluster exists but remote client is missing, got %v", got.Finalizers)
+	}
+}
+
+func TestRemoteClusterExistsIgnoresDeletingClusters(t *testing.T) {
+	now := metav1.Now()
+	cluster := &unstructured.Unstructured{}
+	cluster.SetGroupVersionKind(capiClusterGVK)
+	cluster.SetName("workload")
+	cluster.SetNamespace(testPendingClusterNamespace)
+	cluster.SetDeletionTimestamp(&now)
+	cluster.SetFinalizers([]string{testCAPIClusterFinalizer})
+
+	s := testScheme()
+	mgmtClient := fake.NewClientBuilder().WithScheme(s).WithObjects(cluster).Build()
+	sc := &Controller{Client: mgmtClient}
+
+	exists, err := sc.remoteClusterExists(context.Background(), testPendingClusterNamespace)
+	if err != nil {
+		t.Fatalf("remoteClusterExists returned error: %v", err)
+	}
+	if exists {
+		t.Fatal("Expected deleting CAPI Cluster not to count as an active remote cluster")
 	}
 }
 

--- a/controllers/sync/sync_controller_test.go
+++ b/controllers/sync/sync_controller_test.go
@@ -30,7 +30,7 @@ type listErrorClient struct {
 	err error
 }
 
-func (c listErrorClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+func (c listErrorClient) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
 	return c.err
 }
 

--- a/controllers/sync/sync_controller_test.go
+++ b/controllers/sync/sync_controller_test.go
@@ -2,14 +2,17 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -21,6 +24,15 @@ import (
 
 	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
 )
+
+type listErrorClient struct {
+	client.Client
+	err error
+}
+
+func (c listErrorClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return c.err
+}
 
 func testScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
@@ -867,6 +879,25 @@ func TestRemoteClusterExistsIgnoresDeletingClusters(t *testing.T) {
 	}
 	if exists {
 		t.Fatal("Expected deleting CAPI Cluster not to count as an active remote cluster")
+	}
+}
+
+func TestRemoteClusterExistsNoMatchIsNotAnError(t *testing.T) {
+	sc := &Controller{Client: listErrorClient{err: &apimeta.NoKindMatchError{GroupKind: schema.GroupKind{Group: "cluster.x-k8s.io", Kind: "Cluster"}}}}
+
+	exists, err := sc.remoteClusterExists(context.Background(), testPendingClusterNamespace)
+	if err != nil || exists {
+		t.Fatalf("expected no cluster and no error, got exists=%t err=%v", exists, err)
+	}
+}
+
+func TestRemoteClusterExistsPropagatesListError(t *testing.T) {
+	want := errors.New("list failed")
+	sc := &Controller{Client: listErrorClient{err: want}}
+
+	exists, err := sc.remoteClusterExists(context.Background(), testPendingClusterNamespace)
+	if exists || !errors.Is(err, want) {
+		t.Fatalf("expected propagated list error, got exists=%t err=%v", exists, err)
 	}
 }
 

--- a/e2etests/tests/intent_sync.go
+++ b/e2etests/tests/intent_sync.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -17,6 +18,15 @@ const (
 	remoteNS      = "default"
 	syncTimeout   = 120 * time.Second
 	syncInterval  = 5 * time.Second
+
+	syncManagedByLabel = "network-sync.telekom.com/managed-by"
+	syncManagedByValue = "network-sync"
+
+	helmManagedByLabel        = "app.kubernetes.io/managed-by"
+	fluxHelmNameLabel         = "helm.toolkit.fluxcd.io/name"
+	fluxHelmNamespaceLabel    = "helm.toolkit.fluxcd.io/namespace"
+	helmReleaseNameAnnotation = "meta.helm.sh/release-name"
+	helmReleaseNamespaceAnn   = "meta.helm.sh/release-namespace"
 )
 
 // Intent Sync tests validate that the network-sync controller propagates
@@ -72,7 +82,7 @@ var _ = Describe("Intent Sync Controller", Label("intent", "sync"), func() {
 			vrf := getCluster2Object(ctx, f, "vrfs", "vrf-sync-m2m")
 			Expect(vrf).NotTo(BeNil())
 			labels := vrf.GetLabels()
-			Expect(labels).To(HaveKeyWithValue("network-sync.telekom.com/managed-by", "network-sync"))
+			Expect(labels).To(HaveKeyWithValue(syncManagedByLabel, syncManagedByValue))
 		})
 
 		It("should sync Networks and Layer2Attachments to the workload cluster", func() {
@@ -133,12 +143,129 @@ spec:
 			}, syncTimeout, syncInterval).Should(BeTrue(), "VRF should be removed from cluster-2 after mgmt deletion")
 		})
 	})
+
+	Context("Flux Helm ownership metadata", func() {
+		const vrfName = "vrf-sync-helm-flux-ownership"
+
+		AfterEach(func() {
+			ctx = context.Background()
+			defer deleteCluster2Object(ctx, f, "vrfs", vrfName)
+
+			By("Cleaning up simulated Helm-owned sync VRF from mgmt cluster")
+			Expect(f.DeleteManifestInNamespace(ctx, []byte(helmOwnedSourceVRFUpdatedYAML), syncNamespace)).To(Succeed())
+
+			By("Waiting for simulated Helm-owned sync VRF to be removed from cluster-2")
+			Eventually(func() bool {
+				return !objectExistsOnCluster2(ctx, f, "vrfs", vrfName)
+			}, syncTimeout, syncInterval).Should(BeTrue())
+		})
+
+		It("should preserve simulated Flux Helm workload ownership metadata while syncing source changes", Label("ownership", "helm", "flux"), func() {
+			// The e2e lab does not install Flux Helm controllers. This simulates
+			// the metadata those controllers apply, then forces network-sync
+			// through its update path to catch ownership fights.
+			By("Applying a source VRF with Helm/Flux ownership metadata in the sync namespace")
+			Expect(f.ApplyManifestInNamespace(ctx, []byte(helmOwnedSourceVRFInitialYAML), syncNamespace)).To(Succeed())
+
+			By("Waiting for network-sync to create the workload VRF without copying source Helm ownership")
+			Eventually(func() error {
+				vrf := getCluster2Object(ctx, f, "vrfs", vrfName)
+				if vrf == nil {
+					return fmt.Errorf("workload VRF %q does not exist", vrfName)
+				}
+				if err := expectSyncedVRF(vrf, 2002040); err != nil {
+					return err
+				}
+				return expectNoHelmFluxOwnership(vrf)
+			}, syncTimeout, syncInterval).Should(Succeed())
+
+			By("Simulating Flux Helm ownership on the workload-cluster object")
+			Eventually(func() error {
+				vrf := getCluster2Object(ctx, f, "vrfs", vrfName)
+				if vrf == nil {
+					return fmt.Errorf("workload VRF %q does not exist", vrfName)
+				}
+				setHelmFluxOwnership(vrf, "workload-networking", "workload-flux-system")
+				return f.Cluster2Client().Update(ctx, vrf)
+			}, syncTimeout, syncInterval).Should(Succeed())
+
+			By("Updating the source VRF spec to force a network-sync reconciliation")
+			Expect(f.ApplyManifestInNamespace(ctx, []byte(helmOwnedSourceVRFUpdatedYAML), syncNamespace)).To(Succeed())
+
+			By("Verifying sync updates spec drift while preserving workload Helm ownership")
+			Eventually(func() error {
+				vrf := getCluster2Object(ctx, f, "vrfs", vrfName)
+				if vrf == nil {
+					return fmt.Errorf("workload VRF %q does not exist", vrfName)
+				}
+				if err := expectSyncedVRF(vrf, 2002041); err != nil {
+					return err
+				}
+				return expectHelmFluxOwnership(vrf, "workload-networking", "workload-flux-system")
+			}, syncTimeout, syncInterval).Should(Succeed())
+
+			By("Triggering another source reconciliation with the same spec")
+			Expect(f.ApplyManifestInNamespace(ctx, []byte(helmOwnedSourceVRFUpdatedYAML), syncNamespace)).To(Succeed())
+
+			By("Checking ownership metadata survives the subsequent sync")
+			Eventually(func() error {
+				vrf := getCluster2Object(ctx, f, "vrfs", vrfName)
+				if vrf == nil {
+					return fmt.Errorf("workload VRF %q does not exist", vrfName)
+				}
+				if err := expectSyncedVRF(vrf, 2002041); err != nil {
+					return err
+				}
+				return expectHelmFluxOwnership(vrf, "workload-networking", "workload-flux-system")
+			}, syncTimeout, syncInterval).Should(Succeed())
+		})
+	})
 })
+
+const helmOwnedSourceVRFInitialYAML = `apiVersion: network-connector.sylvaproject.org/v1alpha1
+kind: VRF
+metadata:
+  name: vrf-sync-helm-flux-ownership
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    helm.toolkit.fluxcd.io/name: source-networking
+    helm.toolkit.fluxcd.io/namespace: source-flux-system
+  annotations:
+    meta.helm.sh/release-name: source-networking
+    meta.helm.sh/release-namespace: source-flux-system
+spec:
+  vrf: "ownmeta"
+  vni: 2002040
+  routeTarget: "65188:2040"`
+
+const helmOwnedSourceVRFUpdatedYAML = `apiVersion: network-connector.sylvaproject.org/v1alpha1
+kind: VRF
+metadata:
+  name: vrf-sync-helm-flux-ownership
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    helm.toolkit.fluxcd.io/name: source-networking
+    helm.toolkit.fluxcd.io/namespace: source-flux-system
+  annotations:
+    meta.helm.sh/release-name: source-networking
+    meta.helm.sh/release-namespace: source-flux-system
+spec:
+  vrf: "ownmeta"
+  vni: 2002041
+  routeTarget: "65188:2041"`
 
 // objectExistsOnCluster2 checks if a network-connector CRD exists on cluster-2.
 func objectExistsOnCluster2(ctx context.Context, f *framework.Framework, resource, name string) bool {
 	obj := getCluster2Object(ctx, f, resource, name)
 	return obj != nil
+}
+
+func deleteCluster2Object(ctx context.Context, f *framework.Framework, resource, name string) {
+	obj := getCluster2Object(ctx, f, resource, name)
+	if obj == nil {
+		return
+	}
+	_ = f.Cluster2Client().Delete(ctx, obj)
 }
 
 // getCluster2Object fetches a network-connector CRD from cluster-2's default namespace.
@@ -173,4 +300,71 @@ func resourceToKind(resource string) string {
 	default:
 		return resource
 	}
+}
+
+func expectSyncedVRF(vrf *unstructured.Unstructured, expectedVNI int64) error {
+	labels := vrf.GetLabels()
+	if labels[syncManagedByLabel] != syncManagedByValue {
+		return fmt.Errorf("expected sync label %s=%s, got %v", syncManagedByLabel, syncManagedByValue, labels)
+	}
+	vni, found, err := unstructured.NestedInt64(vrf.Object, "spec", "vni")
+	if err != nil {
+		return fmt.Errorf("read spec.vni: %w", err)
+	}
+	if !found {
+		return fmt.Errorf("spec.vni is missing")
+	}
+	if vni != expectedVNI {
+		return fmt.Errorf("expected spec.vni %d, got %d", expectedVNI, vni)
+	}
+	return nil
+}
+
+func setHelmFluxOwnership(obj *unstructured.Unstructured, releaseName, releaseNamespace string) {
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[helmManagedByLabel] = "Helm"
+	labels[fluxHelmNameLabel] = releaseName
+	labels[fluxHelmNamespaceLabel] = releaseNamespace
+	obj.SetLabels(labels)
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[helmReleaseNameAnnotation] = releaseName
+	annotations[helmReleaseNamespaceAnn] = releaseNamespace
+	obj.SetAnnotations(annotations)
+}
+
+func expectHelmFluxOwnership(obj *unstructured.Unstructured, releaseName, releaseNamespace string) error {
+	labels := obj.GetLabels()
+	if labels[helmManagedByLabel] != "Helm" ||
+		labels[fluxHelmNameLabel] != releaseName ||
+		labels[fluxHelmNamespaceLabel] != releaseNamespace {
+		return fmt.Errorf("expected workload Helm/Flux labels for %s/%s, got %v", releaseNamespace, releaseName, labels)
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations[helmReleaseNameAnnotation] != releaseName ||
+		annotations[helmReleaseNamespaceAnn] != releaseNamespace {
+		return fmt.Errorf("expected workload Helm annotations for %s/%s, got %v", releaseNamespace, releaseName, annotations)
+	}
+	return nil
+}
+
+func expectNoHelmFluxOwnership(obj *unstructured.Unstructured) error {
+	for _, key := range []string{helmManagedByLabel, fluxHelmNameLabel, fluxHelmNamespaceLabel} {
+		if value, ok := obj.GetLabels()[key]; ok {
+			return fmt.Errorf("expected ownership label %q to be absent, got %q", key, value)
+		}
+	}
+	for _, key := range []string{helmReleaseNameAnnotation, helmReleaseNamespaceAnn} {
+		if value, ok := obj.GetAnnotations()[key]; ok {
+			return fmt.Errorf("expected ownership annotation %q to be absent, got %q", key, value)
+		}
+	}
+	return nil
 }

--- a/e2etests/tests/intent_sync.go
+++ b/e2etests/tests/intent_sync.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -149,7 +150,9 @@ spec:
 
 		AfterEach(func() {
 			ctx = context.Background()
-			defer deleteCluster2Object(ctx, f, "vrfs", vrfName)
+			defer func() {
+				Expect(deleteCluster2Object(ctx, f, "vrfs", vrfName)).To(Succeed())
+			}()
 
 			By("Cleaning up simulated Helm-owned sync VRF from mgmt cluster")
 			Expect(f.DeleteManifestInNamespace(ctx, []byte(helmOwnedSourceVRFUpdatedYAML), syncNamespace)).To(Succeed())
@@ -260,12 +263,15 @@ func objectExistsOnCluster2(ctx context.Context, f *framework.Framework, resourc
 	return obj != nil
 }
 
-func deleteCluster2Object(ctx context.Context, f *framework.Framework, resource, name string) {
+func deleteCluster2Object(ctx context.Context, f *framework.Framework, resource, name string) error {
 	obj := getCluster2Object(ctx, f, resource, name)
 	if obj == nil {
-		return
+		return nil
 	}
-	_ = f.Cluster2Client().Delete(ctx, obj)
+	if err := f.Cluster2Client().Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 // getCluster2Object fetches a network-connector CRD from cluster-2's default namespace.

--- a/e2etests/tests/intent_sync.go
+++ b/e2etests/tests/intent_sync.go
@@ -8,8 +8,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/telekom/das-schiff-network-operator/e2etests/framework"
 )
@@ -264,29 +266,50 @@ func objectExistsOnCluster2(ctx context.Context, f *framework.Framework, resourc
 }
 
 func deleteCluster2Object(ctx context.Context, f *framework.Framework, resource, name string) error {
-	obj := getCluster2Object(ctx, f, resource, name)
-	if obj == nil {
-		return nil
-	}
-	if err := f.Cluster2Client().Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	return nil
+	return deleteObject(ctx, f.Cluster2Client(), resource, remoteNS, name)
 }
 
 // getCluster2Object fetches a network-connector CRD from cluster-2's default namespace.
 func getCluster2Object(ctx context.Context, f *framework.Framework, resource, name string) *unstructured.Unstructured {
+	return getObject(ctx, f.Cluster2Client(), resource, remoteNS, name)
+}
+
+func getObject(ctx context.Context, c client.Client, resource, namespace, name string) *unstructured.Unstructured {
+	obj, err := fetchObject(ctx, c, resource, namespace, name)
+	if err != nil {
+		if !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+			GinkgoWriter.Printf("getting %s %s/%s failed: %v\n", resourceToKind(resource), namespace, name, err)
+		}
+		return nil
+	}
+	return obj
+}
+
+func fetchObject(ctx context.Context, c client.Client, resource, namespace, name string) (*unstructured.Unstructured, error) {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "network-connector.sylvaproject.org",
 		Version: "v1alpha1",
 		Kind:    resourceToKind(resource),
 	})
-	err := f.Cluster2Client().Get(ctx, framework.ObjectKey(remoteNS, name), obj)
-	if err != nil {
+	if err := c.Get(ctx, framework.ObjectKey(namespace, name), obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func deleteObject(ctx context.Context, c client.Client, resource, namespace, name string) error {
+	obj, err := fetchObject(ctx, c, resource, namespace, name)
+	if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 		return nil
 	}
-	return obj
+	if err != nil {
+		return fmt.Errorf("getting %s %s/%s before delete: %w", resourceToKind(resource), namespace, name, err)
+	}
+	if err := client.IgnoreNotFound(c.Delete(ctx, obj)); err != nil {
+		return err
+	}
+	return nil
 }
 
 func resourceToKind(resource string) string {

--- a/e2etests/tests/intent_sync.go
+++ b/e2etests/tests/intent_sync.go
@@ -266,7 +266,7 @@ func objectExistsOnCluster2(ctx context.Context, f *framework.Framework, resourc
 }
 
 func deleteCluster2Object(ctx context.Context, f *framework.Framework, resource, name string) error {
-	return deleteObject(ctx, f.Cluster2Client(), resource, remoteNS, name)
+	return deleteObject(ctx, f.Cluster2Client(), resource, name)
 }
 
 // getCluster2Object fetches a network-connector CRD from cluster-2's default namespace.
@@ -298,13 +298,13 @@ func fetchObject(ctx context.Context, c client.Client, resource, namespace, name
 	return obj, nil
 }
 
-func deleteObject(ctx context.Context, c client.Client, resource, namespace, name string) error {
-	obj, err := fetchObject(ctx, c, resource, namespace, name)
+func deleteObject(ctx context.Context, c client.Client, resource, name string) error {
+	obj, err := fetchObject(ctx, c, resource, remoteNS, name)
 	if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("getting %s %s/%s before delete: %w", resourceToKind(resource), namespace, name, err)
+		return fmt.Errorf("getting %s %s/%s before delete: %w", resourceToKind(resource), remoteNS, name, err)
 	}
 	if err := client.IgnoreNotFound(c.Delete(ctx, obj)); err != nil {
 		return err

--- a/e2etests/tests/intent_sync_helpers_test.go
+++ b/e2etests/tests/intent_sync_helpers_test.go
@@ -1,0 +1,89 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type objectClientStub struct {
+	client.Client
+	getErr    error
+	deleteErr error
+	deleteHit bool
+}
+
+func (s *objectClientStub) Get(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	return s.getErr
+}
+
+func (s *objectClientStub) Delete(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
+	s.deleteHit = true
+	return s.deleteErr
+}
+
+func TestDeleteObjectPropagatesUnexpectedGetError(t *testing.T) {
+	stub := &objectClientStub{
+		getErr: errors.New("boom"),
+	}
+
+	err := deleteObject(context.Background(), stub, "vrfs", remoteNS, "vrf-sync-m2m")
+	if err == nil {
+		t.Fatal("Expected deleteObject to fail when Get fails unexpectedly")
+	}
+	if !strings.Contains(err.Error(), "before delete") {
+		t.Fatalf("Expected contextual error, got %v", err)
+	}
+	if stub.deleteHit {
+		t.Fatal("Delete must not be called after unexpected Get failure")
+	}
+}
+
+func TestDeleteObjectIgnoresNotFoundAndNoMatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		getErr error
+	}{
+		{
+			name: "not found",
+			getErr: apierrors.NewNotFound(
+				schema.GroupResource{Group: "network-connector.sylvaproject.org", Resource: "vrfs"},
+				"vrf-sync-m2m",
+			),
+		},
+		{
+			name: "no match",
+			getErr: &meta.NoKindMatchError{
+				GroupKind: schema.GroupKind{Group: "network-connector.sylvaproject.org", Kind: "VRF"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &objectClientStub{getErr: tc.getErr}
+			if err := deleteObject(context.Background(), stub, "vrfs", remoteNS, "vrf-sync-m2m"); err != nil {
+				t.Fatalf("Expected nil, got %v", err)
+			}
+			if stub.deleteHit {
+				t.Fatal("Delete must not be called when object is already gone")
+			}
+		})
+	}
+}
+
+func TestDeleteObjectDeletesWhenObjectExists(t *testing.T) {
+	stub := &objectClientStub{}
+	if err := deleteObject(context.Background(), stub, "vrfs", remoteNS, "vrf-sync-m2m"); err != nil {
+		t.Fatalf("Expected deleteObject to succeed, got %v", err)
+	}
+	if !stub.deleteHit {
+		t.Fatal("Expected Delete to be called when object exists")
+	}
+}

--- a/e2etests/tests/intent_sync_helpers_test.go
+++ b/e2etests/tests/intent_sync_helpers_test.go
@@ -33,7 +33,7 @@ func TestDeleteObjectPropagatesUnexpectedGetError(t *testing.T) {
 		getErr: errors.New("boom"),
 	}
 
-	err := deleteObject(context.Background(), stub, "vrfs", remoteNS, "vrf-sync-m2m")
+	err := deleteObject(context.Background(), stub, "vrfs", "vrf-sync-m2m")
 	if err == nil {
 		t.Fatal("Expected deleteObject to fail when Get fails unexpectedly")
 	}
@@ -68,7 +68,7 @@ func TestDeleteObjectIgnoresNotFoundAndNoMatch(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			stub := &objectClientStub{getErr: tc.getErr}
-			if err := deleteObject(context.Background(), stub, "vrfs", remoteNS, "vrf-sync-m2m"); err != nil {
+			if err := deleteObject(context.Background(), stub, "vrfs", "vrf-sync-m2m"); err != nil {
 				t.Fatalf("Expected nil, got %v", err)
 			}
 			if stub.deleteHit {
@@ -80,7 +80,7 @@ func TestDeleteObjectIgnoresNotFoundAndNoMatch(t *testing.T) {
 
 func TestDeleteObjectDeletesWhenObjectExists(t *testing.T) {
 	stub := &objectClientStub{}
-	if err := deleteObject(context.Background(), stub, "vrfs", remoteNS, "vrf-sync-m2m"); err != nil {
+	if err := deleteObject(context.Background(), stub, "vrfs", "vrf-sync-m2m"); err != nil {
 		t.Fatalf("Expected deleteObject to succeed, got %v", err)
 	}
 	if !stub.deleteHit {


### PR DESCRIPTION
## Summary

- strip management-side Helm/Flux ownership metadata before network-sync creates workload intent CRDs
- preserve workload-local Helm/Flux ownership metadata when network-sync updates already-managed remote objects
- protect updates and deletes with the network-sync source namespace annotation, including safe handling for legacy managed objects that predate the annotation
- ignore Helm release annotation-only intent CRD updates while still comparing all labels semantically
- add focused controller tests and sync e2e coverage for ownership metadata behavior

## Validation

- `env GOCACHE=/tmp/dsno-go-cache go test -count=1 ./controllers/intent ./controllers/sync`
- `env GOCACHE=/tmp/dsno-go-cache go test -count=1 ./e2etests -run TestE2E --ginkgo.dry-run --ginkgo.focus='Flux Helm ownership metadata' --ginkgo.label-filter='intent && sync && ownership'`
- `env GOCACHE=/tmp/dsno-go-cache golangci-lint run --timeout=10m --new-from-rev=origin/main ./controllers/intent ./controllers/sync ./e2etests/...`
- `git diff --check`
- GitHub checks on 2026-07-02: 40 passed, 1 skipped

## Notes

The direct follow-up PR #317 replaces the simulated ownership e2e with an actual Flux deployment on both e2e clusters and verifies the workload Flux/Helm controller can still reconcile after network-sync updates the same object.
