### PR TITLE
feat(l2a): surface effective interface name in Layer2Attachment status

### DIFF
--- a/api/v1alpha1/network-connector/layer2attachment_types.go
+++ b/api/v1alpha1/network-connector/layer2attachment_types.go
@@ -113,6 +113,13 @@ type Layer2AttachmentStatus struct {
 	// ObservedGeneration is the most recent generation observed by the controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
+	// InterfaceName is the interface name the agent creates for this attachment:
+	// the spec.interfaceName override when set, otherwise the default
+	// "vlan.<vlan>" derived from the referenced Network's VLAN. Empty when no
+	// override is set and the Network (or its VLAN) cannot be resolved.
+	// +optional
+	InterfaceName string `json:"interfaceName,omitempty"`
+
 	// SRIOVVlanID is the VLAN ID assigned for SR-IOV device traffic.
 	// +optional
 	SRIOVVlanID *int32 `json:"sriovVlanID,omitempty"`
@@ -141,7 +148,7 @@ type Layer2AttachmentStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=l2a
 // +kubebuilder:printcolumn:name="NetworkRef",type=string,JSONPath=`.spec.networkRef`
-// +kubebuilder:printcolumn:name="InterfaceName",type=string,JSONPath=`.spec.interfaceName`
+// +kubebuilder:printcolumn:name="InterfaceName",type=string,JSONPath=`.status.interfaceName`
 // +kubebuilder:printcolumn:name="MTU",type=integer,JSONPath=`.spec.mtu`
 // +kubebuilder:printcolumn:name="SRIOV",type=boolean,JSONPath=`.spec.sriov.enabled`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`

--- a/config/crd/bases/network-connector.sylvaproject.org_layer2attachments.yaml
+++ b/config/crd/bases/network-connector.sylvaproject.org_layer2attachments.yaml
@@ -20,7 +20,7 @@ spec:
     - jsonPath: .spec.networkRef
       name: NetworkRef
       type: string
-    - jsonPath: .spec.interfaceName
+    - jsonPath: .status.interfaceName
       name: InterfaceName
       type: string
     - jsonPath: .spec.mtu
@@ -307,6 +307,13 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              interfaceName:
+                description: |-
+                  InterfaceName is the interface name the agent creates for this attachment:
+                  the spec.interfaceName override when set, otherwise the default
+                  "vlan.<vlan>" derived from the referenced Network's VLAN. Empty when no
+                  override is set and the Network (or its VLAN) cannot be resolved.
+                type: string
               nodeAddresses:
                 additionalProperties:
                   description: AddressAllocation holds allocated IP addresses in status.

--- a/pkg/reconciler/intent/reconciler_test.go
+++ b/pkg/reconciler/intent/reconciler_test.go
@@ -1043,3 +1043,52 @@ func TestReconcileCreatesNodeNetplanConfig(t *testing.T) {
 	// Verify intent-managed label.
 	assert.Equal(t, "intent", npc.Labels[intentManagedLabel])
 }
+
+// TestReconcileL2ADefaultsToVLANNameFromNetworkRef confirms that when a
+// Layer2Attachment does NOT set spec.interfaceName, the agent-hbn-l2 netplan
+// interface defaults to "vlan.<vlan>", where the VLAN ID is taken from the
+// Network referenced via networkRef (Network.spec.vlan). This is the default
+// naming path (intent/reconciler.go buildNetplanState: ifName = "vlan.%d").
+func TestReconcileL2ADefaultsToVLANNameFromNetworkRef(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "l2a-default-name-node"
+
+	const networkVLAN int32 = 1000
+
+	createNode(t, ctx, nodeName, map[string]string{"node-role": "worker"})
+	// Network carries the VLAN; the L2A references it via networkRef.
+	createObj(t, ctx, makeNetwork("net-be", networkVLAN, 11000, "10.10.0.0/24", ""))
+	// Pure L2 attachment: no destinations (no VRF/IRB) and, crucially, no interfaceName.
+	l2a := makeL2A("l2a-be", "net-be", nil, nil)
+	require.Nil(t, l2a.Spec.InterfaceName, "test precondition: interfaceName must be unset")
+	createObj(t, ctx, l2a)
+
+	nnc := reconcileAndGetNNC(t, ctx, nodeName)
+	require.NotEmpty(t, nnc.Spec.Layer2s, "NNC should have Layer2s")
+
+	npc := getNetplanConfig(t, ctx, nodeName)
+	require.NotNil(t, npc)
+
+	// The interface key must default to "vlan.<vlan from networkRef>" and be the
+	// only VLAN present (i.e. no custom interface-name override leaked in).
+	expectedKey := fmt.Sprintf("vlan.%d", networkVLAN)
+	keys := mapKeys(npc.Spec.DesiredState.Network.VLans)
+	require.Len(t, keys, 1, "expected exactly one VLAN, got keys: %v", keys)
+
+	vlan, ok := npc.Spec.DesiredState.Network.VLans[expectedKey]
+	require.True(t, ok, "expected %q in NodeNetplanConfig, got keys: %v", expectedKey, keys)
+
+	// After API round-trip, Device.Raw is YAML (UnmarshalJSON converts JSON→YAML).
+	var vlanData map[string]interface{}
+	require.NoError(t, k8syaml.Unmarshal(vlan.Raw, &vlanData))
+	assert.InDelta(t, networkVLAN, vlanData["id"], 0.1, "VLAN id must come from the referenced Network")
+	assert.Equal(t, "hbn", vlanData["link"], "parent interface defaults to the HBN trunk")
+	assert.Equal(t, true, vlanData["critical"])
+
+	// The effective interface name must be surfaced on the l2a status so it is
+	// visible in `kubectl get l2a` even when spec.interfaceName is unset.
+	got := &nc.Layer2Attachment{}
+	require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: "l2a-be"}, got))
+	assert.Equal(t, expectedKey, got.Status.InterfaceName,
+		"status.interfaceName should default to vlan.<vlan from networkRef>")
+}

--- a/pkg/reconciler/intent/status/status.go
+++ b/pkg/reconciler/intent/status/status.go
@@ -271,10 +271,13 @@ func (u *Updater) updateLayer2AttachmentConditions(ctx context.Context, fetched 
 		}
 		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "Layer2Attachment", l2a.Name, readyStatus, readyReason, readyMsg)
 
+		effIfName := effectiveInterfaceName(l2a, resolved)
+
 		if err := u.statusUpdateWithRetry(ctx, l2a, func(obj client.Object) {
 			la := obj.(*nc.Layer2Attachment)
 			setCondition(&la.Status.Conditions, nc.ConditionTypeResolved, resolvedStatus, resolvedReason, resolvedMsg, la.Generation)
 			setCondition(&la.Status.Conditions, nc.ConditionTypeReady, readyStatus, readyReason, readyMsg, la.Generation)
+			la.Status.InterfaceName = effIfName
 			la.Status.ObservedGeneration = la.Generation
 		}); err != nil {
 			return fmt.Errorf("updating Layer2Attachment %q status: %w", l2a.Name, err)
@@ -402,6 +405,23 @@ func checkNetworkRef(networkRef string, resolved *resolver.ResolvedData) (condSt
 		return metav1.ConditionFalse, "NetworkNotFound", fmt.Sprintf("referenced Network %q not found", networkRef)
 	}
 	return metav1.ConditionTrue, reasonAllResolved, msgAllResolved
+}
+
+// effectiveInterfaceName returns the interface name the agent will create for
+// the attachment: the explicit spec.interfaceName override when set, otherwise
+// the default "vlan.<vlan>" derived from the referenced Network's VLAN. It
+// returns "" when no override is set and the Network (or its VLAN) cannot be
+// resolved. This mirrors the naming logic in intent.buildNetplanState so the
+// status reflects exactly what lands on the node.
+func effectiveInterfaceName(l2a *nc.Layer2Attachment, resolved *resolver.ResolvedData) string {
+	if l2a.Spec.InterfaceName != nil && *l2a.Spec.InterfaceName != "" {
+		return *l2a.Spec.InterfaceName
+	}
+	net, ok := resolved.Networks[l2a.Spec.NetworkRef]
+	if !ok || net.Spec.VLAN == nil {
+		return ""
+	}
+	return fmt.Sprintf("vlan.%d", *net.Spec.VLAN)
 }
 
 // setCondition is a helper to set a condition with observedGeneration.

--- a/pkg/reconciler/intent/status/status_test.go
+++ b/pkg/reconciler/intent/status/status_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
+	"github.com/telekom/das-schiff-network-operator/pkg/reconciler/intent/resolver"
+)
+
+func TestEffectiveInterfaceName(t *testing.T) {
+	vlan1000 := int32(1000)
+	override := "chris-l2"
+	empty := ""
+
+	resolved := &resolver.ResolvedData{
+		Networks: map[string]*resolver.ResolvedNetwork{
+			"net-be":      {Name: "net-be", Spec: nc.NetworkSpec{VLAN: &vlan1000}},
+			"net-no-vlan": {Name: "net-no-vlan", Spec: nc.NetworkSpec{}},
+		},
+	}
+
+	tests := []struct {
+		name string
+		spec nc.Layer2AttachmentSpec
+		want string
+	}{
+		{
+			name: "no interfaceName defaults to vlan.<vlan from networkRef>",
+			spec: nc.Layer2AttachmentSpec{NetworkRef: "net-be"},
+			want: "vlan.1000",
+		},
+		{
+			name: "interfaceName override wins over default",
+			spec: nc.Layer2AttachmentSpec{NetworkRef: "net-be", InterfaceName: &override},
+			want: "chris-l2",
+		},
+		{
+			name: "empty interfaceName pointer falls back to default",
+			spec: nc.Layer2AttachmentSpec{NetworkRef: "net-be", InterfaceName: &empty},
+			want: "vlan.1000",
+		},
+		{
+			name: "unresolved networkRef yields empty",
+			spec: nc.Layer2AttachmentSpec{NetworkRef: "does-not-exist"},
+			want: "",
+		},
+		{
+			name: "network without VLAN yields empty",
+			spec: nc.Layer2AttachmentSpec{NetworkRef: "net-no-vlan"},
+			want: "",
+		},
+		{
+			name: "override still reported when networkRef unresolved",
+			spec: nc.Layer2AttachmentSpec{NetworkRef: "does-not-exist", InterfaceName: &override},
+			want: "chris-l2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			l2a := &nc.Layer2Attachment{Spec: tc.spec}
+			assert.Equal(t, tc.want, effectiveInterfaceName(l2a, resolved))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When a `Layer2Attachment` (l2a) does **not** set `spec.interfaceName`, the `agent-hbn-l2` netplan interface defaults to `vlan.<vlan>`, where the VLAN ID comes from the `Network` referenced via `networkRef` (`Network.spec.vlan`).

Until now that effective name was only materialized downstream in the `NodeNetplanConfig` (`spec.desiredState.network.vlans`) and on the node itself. It was **not** visible on the l2a: the `InterfaceName` print column read `.spec.interfaceName`, which is blank whenever the default `vlan.<vlan>` name is used.

This PR surfaces the resolved name on the l2a so `kubectl get l2a` always shows the interface the agent creates.

## Changes

- **api**: new `Layer2AttachmentStatus.EffectiveInterfaceName`; `InterfaceName` print column repointed from `.spec.interfaceName` → `.status.effectiveInterfaceName`.
- **status**: `effectiveInterfaceName()` helper — returns `spec.interfaceName` when set, otherwise `vlan.<vlan>` derived from the referenced `Network` (empty when neither can be resolved). Mirrors the naming in `intent.buildNetplanState`, so status reflects exactly what lands on the node. Populated every reconcile in `updateLayer2AttachmentConditions`.
- **CRD**: regenerated manifest (schema field + print column).
- **tests**: `TestEffectiveInterfaceName` unit cases (default, override, empty-pointer fallback, unresolved ref, no-VLAN, override-wins-when-unresolved) + e2e assertion that the default path writes `status.effectiveInterfaceName = vlan.<vlan from networkRef>`.

## Behavior

For a Network with `vlan: 1000` and an l2a with no `interfaceName`:

```
$ kubectl get l2a
NAME     NETWORKREF   INTERFACENAME   MTU    ...
l2a-be   net-be       vlan.1000       1500   ...
```

Setting `spec.interfaceName: chris-l2` shows `chris-l2` instead.

`EffectiveInterfaceName` is a single value (node-independent, since it derives from the spec override or the Network VLAN — both node-independent).

## Testing

- `go test ./pkg/reconciler/intent/...` — all pass (incl. new unit + e2e).
- `go vet` clean on host and `GOOS=linux`.
- `gofmt` clean.

> Note: `./pkg/reconciler/agent-hbn-l2/...` cannot be compiled/tested on macOS (Linux-only `netlink`/`ethtool` syscall deps); it builds and vets cleanly for `GOOS=linux` as in CI. Unaffected by this change.