### PR TITLE
feat(bgppeering): reference Networks for listenRange, Inbounds for loopbackPeer

### DIFF
--- a/api/v1alpha1/network-connector/bgppeering_types.go
+++ b/api/v1alpha1/network-connector/bgppeering_types.go
@@ -37,25 +37,41 @@ const (
 )
 
 // BGPPeeringRef identifies the resources this peering session relates to.
-// inboundRefs is always required (both modes need IP pools).
-// attachmentRef is required for listenRange mode only.
+// The reference kind is mode-specific and mutually exclusive:
+//   - listenRange requires attachmentRef (the L2 segment to listen on) and
+//     networkRefs (the Networks whose prefixes L2 clients may announce);
+//     inboundRefs must not be set.
+//   - loopbackPeer requires inboundRefs (the allocated VIP pools the tenant
+//     advertises); attachmentRef and networkRefs must not be set.
 type BGPPeeringRef struct {
 	// AttachmentRef references a Layer2Attachment by name.
-	// Required for listenRange mode — identifies the L2 segment for the BGP listen-range.
-	// Must not be set for loopbackPeer mode.
+	// Required for listenRange mode — identifies the L2 segment the BGP
+	// listen-range is opened on (the listen-range CIDR comes from the L2A's
+	// Network). Must not be set for loopbackPeer mode.
 	// +optional
 	AttachmentRef *string `json:"attachmentRef,omitempty"`
 
-	// InboundRefs references Inbound resources whose IP pools are accepted/advertised.
-	// Required for both modes: listenRange uses them as prefix filters,
-	// loopbackPeer advertises VIPs from these pools.
-	// +kubebuilder:validation:Required
+	// NetworkRefs references Network resources by name. For listenRange mode
+	// their CIDRs form the import allow-list: L2 clients may only announce
+	// prefixes contained within these Networks (matched with le 32 / le 128),
+	// and those prefixes are re-exported into the EVPN fabric.
+	// Required for listenRange mode; must not be set for loopbackPeer mode.
+	// +optional
 	// +kubebuilder:validation:MinItems=1
-	InboundRefs []string `json:"inboundRefs"`
+	NetworkRefs []string `json:"networkRefs,omitempty"`
+
+	// InboundRefs references Inbound resources whose IP pools the tenant
+	// advertises (BGPaaS). Required for loopbackPeer mode; must not be set
+	// for listenRange mode.
+	// +optional
+	// +kubebuilder:validation:MinItems=1
+	InboundRefs []string `json:"inboundRefs,omitempty"`
 }
 
 // BGPPeeringSpec defines the desired state of BGPPeering.
 // +kubebuilder:validation:XValidation:rule="self.mode == 'listenRange' ? has(self.ref.attachmentRef) : !has(self.ref.attachmentRef)",message="attachmentRef is required for listenRange mode and forbidden for loopbackPeer mode"
+// +kubebuilder:validation:XValidation:rule="self.mode == 'listenRange' ? (has(self.ref.networkRefs) && size(self.ref.networkRefs) > 0) : !has(self.ref.networkRefs)",message="networkRefs is required for listenRange mode and forbidden for loopbackPeer mode"
+// +kubebuilder:validation:XValidation:rule="self.mode == 'loopbackPeer' ? (has(self.ref.inboundRefs) && size(self.ref.inboundRefs) > 0) : !has(self.ref.inboundRefs)",message="inboundRefs is required for loopbackPeer mode and forbidden for listenRange mode"
 type BGPPeeringSpec struct {
 	// Mode selects the peering type: listenRange (L2 attachment BGP) or loopbackPeer (BGPaaS).
 	// Immutable after creation.

--- a/api/v1alpha1/network-connector/remaining_webhooks.go
+++ b/api/v1alpha1/network-connector/remaining_webhooks.go
@@ -77,17 +77,26 @@ func (r *BGPPeering) validateBGPPeering() error {
 	if r.Spec.Mode != BGPPeeringModeListenRange && r.Spec.Mode != BGPPeeringModeLoopbackPeer {
 		return fmt.Errorf("spec.mode must be %q or %q, got %q", BGPPeeringModeListenRange, BGPPeeringModeLoopbackPeer, r.Spec.Mode)
 	}
-	if len(r.Spec.Ref.InboundRefs) == 0 {
-		return fmt.Errorf("spec.ref.inboundRefs must not be empty")
-	}
 	if r.Spec.Mode == BGPPeeringModeListenRange {
 		if r.Spec.Ref.AttachmentRef == nil || *r.Spec.Ref.AttachmentRef == "" {
 			return fmt.Errorf("spec.ref.attachmentRef is required for listenRange mode")
 		}
+		if len(r.Spec.Ref.NetworkRefs) == 0 {
+			return fmt.Errorf("spec.ref.networkRefs must not be empty for listenRange mode")
+		}
+		if len(r.Spec.Ref.InboundRefs) != 0 {
+			return fmt.Errorf("spec.ref.inboundRefs must not be set for listenRange mode")
+		}
 	}
 	if r.Spec.Mode == BGPPeeringModeLoopbackPeer {
+		if len(r.Spec.Ref.InboundRefs) == 0 {
+			return fmt.Errorf("spec.ref.inboundRefs must not be empty for loopbackPeer mode")
+		}
 		if r.Spec.Ref.AttachmentRef != nil {
 			return fmt.Errorf("spec.ref.attachmentRef must not be set for loopbackPeer mode")
+		}
+		if len(r.Spec.Ref.NetworkRefs) != 0 {
+			return fmt.Errorf("spec.ref.networkRefs must not be set for loopbackPeer mode")
 		}
 	}
 	return nil

--- a/api/v1alpha1/network-connector/remaining_webhooks_test.go
+++ b/api/v1alpha1/network-connector/remaining_webhooks_test.go
@@ -34,7 +34,7 @@ func TestBGPPeeringValidateCreate_ListenRange_Valid(t *testing.T) {
 		Mode: BGPPeeringModeListenRange,
 		Ref: BGPPeeringRef{
 			AttachmentRef: strPtr("l2a-1"),
-			InboundRefs:   []string{"ib-1"},
+			NetworkRefs:   []string{"net-1"},
 		},
 	}}
 	if _, err := r.ValidateCreate(context.Background(), r); err != nil {
@@ -54,28 +54,52 @@ func TestBGPPeeringValidateCreate_LoopbackPeer_Valid(t *testing.T) {
 	}
 }
 
-func TestBGPPeeringValidateCreate_EmptyInboundRefs(t *testing.T) {
+func TestBGPPeeringValidateCreate_ListenRange_MissingNetworkRefs(t *testing.T) {
 	r := &BGPPeering{Spec: BGPPeeringSpec{
 		Mode: BGPPeeringModeListenRange,
 		Ref: BGPPeeringRef{
 			AttachmentRef: strPtr("l2a-1"),
-			InboundRefs:   []string{},
 		},
 	}}
 	if _, err := r.ValidateCreate(context.Background(), r); err == nil {
-		t.Fatal("expected error for empty inboundRefs, got nil")
+		t.Fatal("expected error for listenRange without networkRefs, got nil")
 	}
 }
 
-func TestBGPPeeringValidateCreate_NilInboundRefs(t *testing.T) {
+func TestBGPPeeringValidateCreate_ListenRange_WithInboundRefs(t *testing.T) {
 	r := &BGPPeering{Spec: BGPPeeringSpec{
 		Mode: BGPPeeringModeListenRange,
 		Ref: BGPPeeringRef{
 			AttachmentRef: strPtr("l2a-1"),
+			NetworkRefs:   []string{"net-1"},
+			InboundRefs:   []string{"ib-1"},
 		},
 	}}
 	if _, err := r.ValidateCreate(context.Background(), r); err == nil {
-		t.Fatal("expected error for nil inboundRefs, got nil")
+		t.Fatal("expected error for listenRange with inboundRefs, got nil")
+	}
+}
+
+func TestBGPPeeringValidateCreate_LoopbackPeer_EmptyInboundRefs(t *testing.T) {
+	r := &BGPPeering{Spec: BGPPeeringSpec{
+		Mode: BGPPeeringModeLoopbackPeer,
+		Ref:  BGPPeeringRef{InboundRefs: []string{}},
+	}}
+	if _, err := r.ValidateCreate(context.Background(), r); err == nil {
+		t.Fatal("expected error for loopbackPeer with empty inboundRefs, got nil")
+	}
+}
+
+func TestBGPPeeringValidateCreate_LoopbackPeer_WithNetworkRefs(t *testing.T) {
+	r := &BGPPeering{Spec: BGPPeeringSpec{
+		Mode: BGPPeeringModeLoopbackPeer,
+		Ref: BGPPeeringRef{
+			InboundRefs: []string{"ib-1"},
+			NetworkRefs: []string{"net-1"},
+		},
+	}}
+	if _, err := r.ValidateCreate(context.Background(), r); err == nil {
+		t.Fatal("expected error for loopbackPeer with networkRefs, got nil")
 	}
 }
 
@@ -83,7 +107,7 @@ func TestBGPPeeringValidateCreate_ListenRange_MissingAttachmentRef(t *testing.T)
 	r := &BGPPeering{Spec: BGPPeeringSpec{
 		Mode: BGPPeeringModeListenRange,
 		Ref: BGPPeeringRef{
-			InboundRefs: []string{"ib-1"},
+			NetworkRefs: []string{"net-1"},
 		},
 	}}
 	if _, err := r.ValidateCreate(context.Background(), r); err == nil {
@@ -121,7 +145,7 @@ func TestBGPPeeringValidateUpdate_ModeImmutable(t *testing.T) {
 		Mode: BGPPeeringModeListenRange,
 		Ref: BGPPeeringRef{
 			AttachmentRef: strPtr("l2a-1"),
-			InboundRefs:   []string{"ib-1"},
+			NetworkRefs:   []string{"net-1"},
 		},
 	}}
 	r := &BGPPeering{Spec: BGPPeeringSpec{

--- a/api/v1alpha1/network-connector/zz_generated.deepcopy.go
+++ b/api/v1alpha1/network-connector/zz_generated.deepcopy.go
@@ -314,6 +314,11 @@ func (in *BGPPeeringRef) DeepCopyInto(out *BGPPeeringRef) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.NetworkRefs != nil {
+		in, out := &in.NetworkRefs, &out.NetworkRefs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.InboundRefs != nil {
 		in, out := &in.InboundRefs, &out.InboundRefs
 		*out = make([]string, len(*in))

--- a/config/crd/bases/network-connector.sylvaproject.org_bgppeerings.yaml
+++ b/config/crd/bases/network-connector.sylvaproject.org_bgppeerings.yaml
@@ -140,20 +140,30 @@ spec:
                   attachmentRef:
                     description: |-
                       AttachmentRef references a Layer2Attachment by name.
-                      Required for listenRange mode — identifies the L2 segment for the BGP listen-range.
-                      Must not be set for loopbackPeer mode.
+                      Required for listenRange mode — identifies the L2 segment the BGP
+                      listen-range is opened on (the listen-range CIDR comes from the L2A's
+                      Network). Must not be set for loopbackPeer mode.
                     type: string
                   inboundRefs:
                     description: |-
-                      InboundRefs references Inbound resources whose IP pools are accepted/advertised.
-                      Required for both modes: listenRange uses them as prefix filters,
-                      loopbackPeer advertises VIPs from these pools.
+                      InboundRefs references Inbound resources whose IP pools the tenant
+                      advertises (BGPaaS). Required for loopbackPeer mode; must not be set
+                      for listenRange mode.
                     items:
                       type: string
                     minItems: 1
                     type: array
-                required:
-                - inboundRefs
+                  networkRefs:
+                    description: |-
+                      NetworkRefs references Network resources by name. For listenRange mode
+                      their CIDRs form the import allow-list: L2 clients may only announce
+                      prefixes contained within these Networks (matched with le 32 / le 128),
+                      and those prefixes are re-exported into the EVPN fabric.
+                      Required for listenRange mode; must not be set for loopbackPeer mode.
+                    items:
+                      type: string
+                    minItems: 1
+                    type: array
                 type: object
               workloadAS:
                 description: |-
@@ -173,6 +183,14 @@ spec:
                 for loopbackPeer mode
               rule: 'self.mode == ''listenRange'' ? has(self.ref.attachmentRef) :
                 !has(self.ref.attachmentRef)'
+            - message: networkRefs is required for listenRange mode and forbidden
+                for loopbackPeer mode
+              rule: 'self.mode == ''listenRange'' ? (has(self.ref.networkRefs) &&
+                size(self.ref.networkRefs) > 0) : !has(self.ref.networkRefs)'
+            - message: inboundRefs is required for loopbackPeer mode and forbidden
+                for listenRange mode
+              rule: 'self.mode == ''loopbackPeer'' ? (has(self.ref.inboundRefs) &&
+                size(self.ref.inboundRefs) > 0) : !has(self.ref.inboundRefs)'
           status:
             description: BGPPeeringStatus defines the observed state of BGPPeering.
             properties:

--- a/docs/crds/README.md
+++ b/docs/crds/README.md
@@ -16,7 +16,7 @@ across management and workload clusters.
 | **Inbound** | `ib` | Allocate IPs for MetalLB pools (ingress LBs) |
 | **Outbound** | `ob` | Allocate IPs for SNAT / Coil egress |
 | **PodNetwork** | `pnet` | Additional pod-level networks from a Network |
-| **BGPPeering** | `bgpp` | BGP session — listenRange (L2) or loopbackPeer (BGPaaS); always references Inbound pools |
+| **BGPPeering** | `bgpp` | BGP session — listenRange (references Networks as the client-announce allow-list) or loopbackPeer/BGPaaS (references Inbound pools) |
 | **Collector** | `col` | GRE collector endpoint + mirror VRF binding |
 | **TrafficMirror** | `tmir` | Mirror traffic from an attachment to a Collector |
 | **InterfaceConfig** | `ifc` | Node-level interface provisioning (bonds, NICs) |
@@ -71,7 +71,7 @@ graph TD
     end
 
     subgraph "BGP"
-        BGPPeering["<b>BGPPeering</b><br/>mode, inboundRefs, attachmentRef, timers, BFD"]
+        BGPPeering["<b>BGPPeering</b><br/>mode, networkRefs, inboundRefs, attachmentRef, timers, BFD"]
     end
 
     subgraph "Traffic Mirroring"
@@ -104,7 +104,8 @@ graph TD
     PodNetwork -- "destinations (selector)" --> Destination
 
     BGPPeering -- "attachmentRef (listenRange)" --> L2A
-    BGPPeering -- "inboundRefs (both modes)" --> Inbound
+    BGPPeering -- "networkRefs (listenRange)" --> Network
+    BGPPeering -- "inboundRefs (loopbackPeer)" --> Inbound
 
     TrafficMirror -- "collector" --> Collector
     TrafficMirror -- "source" --> L2A

--- a/docs/crds/REFERENCE.md
+++ b/docs/crds/REFERENCE.md
@@ -519,11 +519,16 @@ spec:
 
 Configures a BGP session in one of two modes:
 
-- **`listenRange`** — L2 attachment–based BGP peering (requires `attachmentRef`)
-- **`loopbackPeer`** — BGPaaS with auto-generated ULA IPv6 addresses (forbids `attachmentRef`)
+- **`listenRange`** — L2 attachment–based BGP peering. Requires `attachmentRef`
+  (the L2 segment to open the listen-range on; the listen-range CIDR comes from
+  the L2A's Network) and `networkRefs` (the Networks whose CIDRs L2 clients may
+  announce). Forbids `inboundRefs`. No Inbound/MetalLB pool is involved.
+- **`loopbackPeer`** — BGPaaS with auto-generated ULA IPv6 addresses. Requires
+  `inboundRefs` (the allocated VIP pools the tenant advertises). Forbids
+  `attachmentRef` and `networkRefs`.
 
-Both modes always reference one or more Inbound resources for IP pool
-advertisement.
+The reference kind is mode-specific and mutually exclusive — listenRange
+operates on Networks, loopbackPeer on Inbounds.
 
 #### Spec
 
@@ -532,7 +537,8 @@ advertisement.
 | `mode` | string | ✅ | 🔒 | `listenRange` or `loopbackPeer`. |
 | `ref` | BGPPeeringRef | ✅ | | Reference configuration. |
 | `ref.attachmentRef` | \*string | | | Layer2Attachment name. **Required** for `listenRange`, **forbidden** for `loopbackPeer`. |
-| `ref.inboundRefs` | []string | ✅ | | Inbound names (MinItems=1). |
+| `ref.networkRefs` | []string | | | Network names (MinItems=1). Their CIDRs form the listenRange import allow-list (matched le 32/128) and EVPN export set. **Required** for `listenRange`, **forbidden** for `loopbackPeer`. |
+| `ref.inboundRefs` | []string | | | Inbound names (MinItems=1). **Required** for `loopbackPeer`, **forbidden** for `listenRange`. |
 | `advertiseTransferNetwork` | \*bool | | | Advertise the transfer network prefix. |
 | `holdTime` | \*Duration | | | BGP hold timer. |
 | `keepaliveTime` | \*Duration | | | BGP keepalive timer. |
@@ -560,7 +566,10 @@ advertisement.
 - `mode` is immutable (CEL: `self.mode == oldSelf.mode`).
 - `attachmentRef` is **required** when `mode == listenRange` and **forbidden**
   when `mode == loopbackPeer` (CEL).
-- `ref.inboundRefs` must contain at least 1 item.
+- `networkRefs` is **required** (MinItems=1) when `mode == listenRange` and
+  **forbidden** when `mode == loopbackPeer` (CEL).
+- `inboundRefs` is **required** (MinItems=1) when `mode == loopbackPeer` and
+  **forbidden** when `mode == listenRange` (CEL).
 - `workloadAS` range: 1–4 294 967 295.
 - `bfdProfile.minInterval` range: 50–60 000 ms.
 
@@ -582,8 +591,8 @@ spec:
   mode: listenRange
   ref:
     attachmentRef: prod-l2
-    inboundRefs:
-      - prod-ingress
+    networkRefs:
+      - prod-clients
   holdTime: 90s
   keepaliveTime: 30s
   maximumPrefixes: 1000

--- a/e2etests/testdata/bgpaas/bgp-peering.yaml
+++ b/e2etests/testdata/bgpaas/bgp-peering.yaml
@@ -1,6 +1,6 @@
 # BGPPeering CR for BGPaaS test (intent API).
 # Configures FRR to accept dynamic BGP peers from the VLAN 501 subnet.
-# Requires a matching L2A and Inbound for the peering VLAN.
+# Requires a matching L2A for the peering VLAN and a Network for the allow-list.
 apiVersion: network-connector.sylvaproject.org/v1alpha1
 kind: Layer2Attachment
 metadata:
@@ -12,26 +12,21 @@ spec:
     matchLabels:
       type: gateway
 ---
-# Inbound with addresses the workload advertises via BGP.
-# These become the import filter on the BGP peer (only these prefixes accepted)
-# and the EVPN export entries (so the fabric distributes them).
+# Network whose CIDRs the workload is allowed to advertise via BGP.
+# These become the import filter on the BGP peer (only prefixes within these
+# CIDRs are accepted, matched le 32/128) and the EVPN export entries (so the
+# fabric distributes them). BIRD announces 10.250.3.1/32 and
+# fd75:2d70:f7f7::1/128, both contained here.
 apiVersion: network-connector.sylvaproject.org/v1alpha1
-kind: Inbound
+kind: Network
 metadata:
-  name: ib-bgpaas
+  name: net-bgpaas-clients
   namespace: default
 spec:
-  networkRef: "net-vlan501"
-  destinations:
-    matchLabels:
-      type: gateway
-  addresses:
-    ipv4:
-      - "10.250.3.0/24"
-    ipv6:
-      - "fd75:2d70:f7f7::/64"
-  advertisement:
-    type: bgp
+  ipv4:
+    cidr: "10.250.3.0/24"
+  ipv6:
+    cidr: "fd75:2d70:f7f7::/64"
 ---
 apiVersion: network-connector.sylvaproject.org/v1alpha1
 kind: BGPPeering
@@ -42,6 +37,6 @@ spec:
   mode: listenRange
   ref:
     attachmentRef: "l2a-bgpaas"
-    inboundRefs:
-      - "ib-bgpaas"
+    networkRefs:
+      - "net-bgpaas-clients"
   workloadAS: 65511

--- a/e2etests/testdata/intent/bgp/manifests.yaml
+++ b/e2etests/testdata/intent/bgp/manifests.yaml
@@ -1,3 +1,10 @@
+# Intent BGP listenRange test.
+# The BIRD pod (bird-pod.yaml) peers with CRA-FRR on VLAN 501 (m2m VRF) as
+# AS 65100 and announces 10.250.3.1/32 and fd75:2d70:f7f7::1/128.
+# The listen-range CIDR comes from the L2A's Network (net-vlan501); the
+# import allow-list + EVPN export come from the BGPPeering's networkRefs
+# (net-bgp-clients), which must contain the prefixes BIRD announces.
+# No Inbound is involved — listenRange no longer allocates MetalLB pools.
 apiVersion: network-connector.sylvaproject.org/v1alpha1
 kind: Layer2Attachment
 metadata:
@@ -9,21 +16,17 @@ spec:
     matchLabels:
       type: gateway
 ---
+# Network whose CIDRs L2 clients on VLAN 501 are permitted to announce.
 apiVersion: network-connector.sylvaproject.org/v1alpha1
-kind: Inbound
+kind: Network
 metadata:
-  name: ib-bgp
+  name: net-bgp-clients
   namespace: default
 spec:
-  networkRef: "net-vlan501"
-  destinations:
-    matchLabels:
-      type: gateway
-  addresses:
-    ipv4:
-      - "10.250.0.50/32"
-  advertisement:
-    type: bgp
+  ipv4:
+    cidr: "10.250.3.0/24"
+  ipv6:
+    cidr: "fd75:2d70:f7f7::/64"
 ---
 apiVersion: network-connector.sylvaproject.org/v1alpha1
 kind: BGPPeering
@@ -34,6 +37,6 @@ spec:
   mode: listenRange
   ref:
     attachmentRef: "l2a-bgp"
-    inboundRefs:
-      - "ib-bgp"
+    networkRefs:
+      - "net-bgp-clients"
   workloadAS: 65100

--- a/e2etests/tests/intent_bgp_peering.go
+++ b/e2etests/tests/intent_bgp_peering.go
@@ -10,7 +10,7 @@ import (
 	"github.com/telekom/das-schiff-network-operator/e2etests/framework"
 )
 
-// Intent-based BGP Peering test using BGPPeering, Layer2Attachment, and Inbound CRDs.
+// Intent-based BGP Peering test using BGPPeering, Layer2Attachment, and Network CRDs.
 // Validates that intent CRDs can be applied alongside legacy config without conflict.
 // Full pipeline validation is in Tier 1 envtest (pkg/reconciler/intent/reconciler_test.go).
 var _ = Describe("Intent BGP Peering", Label("intent", "bgp"), func() {
@@ -39,7 +39,7 @@ var _ = Describe("Intent BGP Peering", Label("intent", "bgp"), func() {
 	It("should accept BGPPeering intent CRDs without breaking existing connectivity", func() {
 		cfg := f.Config
 
-		By("Applying intent BGP manifests (L2A + Inbound + BGPPeering)")
+		By("Applying intent BGP manifests (L2A + Network + BGPPeering)")
 		manifest, err := readTestdata("intent/bgp/manifests.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.ApplyManifest(ctx, manifest)).To(Succeed())

--- a/pkg/reconciler/intent/builder/bgp_announcement_test.go
+++ b/pkg/reconciler/intent/builder/bgp_announcement_test.go
@@ -69,6 +69,13 @@ func TestBGPPeeringBuilder_ListenRange(t *testing.T) { //nolint:funlen // table-
 					IPv6: &nc.IPNetwork{CIDR: "fd00:100::/64"},
 				},
 			},
+			"allowed-net": {
+				Name: "allowed-net",
+				Spec: nc.NetworkSpec{
+					IPv4: &nc.IPNetwork{CIDR: "10.200.0.0/24"},
+					IPv6: &nc.IPNetwork{CIDR: "fd00:200::/64"},
+				},
+			},
 		},
 		VRFs: map[string]*resolver.ResolvedVRF{
 			"prod-vrf": {
@@ -107,7 +114,7 @@ func TestBGPPeeringBuilder_ListenRange(t *testing.T) { //nolint:funlen // table-
 					Mode: nc.BGPPeeringModeListenRange,
 					Ref: nc.BGPPeeringRef{
 						AttachmentRef: ptr("transfer-l2a"),
-						InboundRefs:   []string{"my-inbound"},
+						NetworkRefs:   []string{"allowed-net"},
 					},
 					WorkloadAS: ptr(int64(65100)),
 				},
@@ -149,11 +156,15 @@ func TestBGPPeeringBuilder_ListenRange(t *testing.T) { //nolint:funlen // table-
 		t.Errorf("expected RemoteASN 65100, got %d", p4.RemoteASN)
 	}
 	if p4.IPv4 == nil {
-		t.Error("expected IPv4 address family on IPv4 peer")
+		t.Fatal("expected IPv4 address family on IPv4 peer")
 	}
 	if p4.IPv6 != nil {
 		t.Error("expected nil IPv6 address family on IPv4 peer")
 	}
+
+	// The import allow-list must come from the BGPPeering's networkRefs
+	// (allowed-net IPv4 CIDR), matched le 32 — NOT from the listen-range Network.
+	assertImportAllows(t, p4.IPv4, "10.200.0.0/24", 32)
 
 	// Check IPv6 peer.
 	p6 := fvrf.BGPPeers[1]
@@ -164,10 +175,44 @@ func TestBGPPeeringBuilder_ListenRange(t *testing.T) { //nolint:funlen // table-
 		t.Errorf("expected RemoteASN 65100, got %d", p6.RemoteASN)
 	}
 	if p6.IPv6 == nil {
-		t.Error("expected IPv6 address family on IPv6 peer")
+		t.Fatal("expected IPv6 address family on IPv6 peer")
 	}
 	if p6.IPv4 != nil {
 		t.Error("expected nil IPv4 address family on IPv6 peer")
+	}
+	assertImportAllows(t, p6.IPv6, "fd00:200::/64", 128)
+
+	// networkRefs CIDRs are also added to the VRF's EVPN export filter.
+	if fvrf.EVPNExportFilter == nil {
+		t.Fatal("expected EVPNExportFilter to be set from networkRefs")
+	}
+	if len(fvrf.EVPNExportFilter.Items) != 2 {
+		t.Fatalf("expected 2 EVPN export items (IPv4 + IPv6), got %d", len(fvrf.EVPNExportFilter.Items))
+	}
+}
+
+// assertImportAllows checks that af has a reject-default import filter with a
+// single accept item for the given prefix and le bound.
+func assertImportAllows(t *testing.T, af *networkv1alpha1.AddressFamily, prefix string, le int) {
+	t.Helper()
+	if af.ImportFilter == nil {
+		t.Fatal("expected import filter")
+	}
+	if af.ImportFilter.DefaultAction.Type != networkv1alpha1.Reject {
+		t.Errorf("expected reject-default import filter, got %v", af.ImportFilter.DefaultAction.Type)
+	}
+	if len(af.ImportFilter.Items) != 1 {
+		t.Fatalf("expected 1 import allow item, got %d", len(af.ImportFilter.Items))
+	}
+	item := af.ImportFilter.Items[0]
+	if item.Action.Type != networkv1alpha1.Accept {
+		t.Errorf("expected accept action, got %v", item.Action.Type)
+	}
+	if item.Matcher.Prefix == nil || item.Matcher.Prefix.Prefix != prefix {
+		t.Errorf("expected import allow prefix %q, got %v", prefix, item.Matcher.Prefix)
+	}
+	if item.Matcher.Prefix != nil && (item.Matcher.Prefix.Le == nil || *item.Matcher.Prefix.Le != le) {
+		t.Errorf("expected le %d, got %v", le, item.Matcher.Prefix.Le)
 	}
 }
 
@@ -220,7 +265,7 @@ func TestBGPPeeringBuilder_ListenRangeFanOut(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "lp"},
 				Spec: nc.BGPPeeringSpec{
 					Mode:       nc.BGPPeeringModeListenRange,
-					Ref:        nc.BGPPeeringRef{AttachmentRef: ptr("transfer-l2a")},
+					Ref:        nc.BGPPeeringRef{AttachmentRef: ptr("transfer-l2a"), NetworkRefs: []string{"transfer-net"}},
 					WorkloadAS: ptr(int64(65100)),
 				},
 			},
@@ -424,7 +469,7 @@ func TestBGPPeeringBuilder_MissingAttachmentRef(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "missing-ref"},
 				Spec: nc.BGPPeeringSpec{
 					Mode: nc.BGPPeeringModeListenRange,
-					Ref:  nc.BGPPeeringRef{InboundRefs: []string{"x"}},
+					Ref:  nc.BGPPeeringRef{NetworkRefs: []string{"x"}},
 					// AttachmentRef intentionally omitted.
 				},
 			},

--- a/pkg/reconciler/intent/builder/bgppeering.go
+++ b/pkg/reconciler/intent/builder/bgppeering.go
@@ -104,13 +104,15 @@ func (b *BGPPeeringBuilder) buildListenRange(bp *nc.BGPPeering, data *resolver.R
 		return fmt.Errorf("Layer2Attachment %q has no VRF for IRB", l2a.Name)
 	}
 
-	// Resolve inboundRefs to get the addresses the workload advertises.
-	inboundIPv4, inboundIPv6 := b.resolveInboundAddresses(bp, data)
+	// Resolve networkRefs to get the CIDRs L2 clients may announce. These
+	// form the import allow-list and the EVPN export set. The listen-range
+	// CIDR itself comes from the L2A's Network (net), not from here.
+	allowIPv4, allowIPv6 := b.resolveNetworkCIDRs(bp, data)
 
-	// Build BGPPeer with ListenRange, import filter from Inbound addresses,
-	// and EVPN export items for those same addresses.
-	peers := b.buildListenRangePeers(bp, net, inboundIPv4, inboundIPv6, data)
-	evpnExportItems := b.inboundEVPNExportItems(inboundIPv4, inboundIPv6)
+	// Build BGPPeer with ListenRange, import filter from networkRefs CIDRs,
+	// and EVPN export items for those same CIDRs.
+	peers := b.buildListenRangePeers(bp, net, allowIPv4, allowIPv6, data)
+	evpnExportItems := b.evpnExportItems(allowIPv4, allowIPv6)
 
 	// Sorted iteration for deterministic output.
 	vrfNames := make([]string, 0, len(vrfs))
@@ -184,17 +186,18 @@ func (*BGPPeeringBuilder) resolveL2AVRFs(l2a *nc.Layer2Attachment, data *resolve
 	return resolveSelectorVRFs(l2a.Spec.Destinations, data)
 }
 
-// buildListenRangePeers creates BGPPeer entries with ListenRange from Network CIDRs.
-// Import filter is scoped to the Inbound addresses (what the workload may advertise).
+// buildListenRangePeers creates BGPPeer entries with ListenRange from the L2A
+// Network CIDR. The import filter is scoped to the allow-list prefixes
+// (networkRefs CIDRs — what the L2 clients may announce, matched le 32/128).
 // Export filter is permit-all (workload sees all VRF routes).
-func (b *BGPPeeringBuilder) buildListenRangePeers(bp *nc.BGPPeering, net *resolver.ResolvedNetwork, inboundIPv4, inboundIPv6 []string, data *resolver.ResolvedData) []networkv1alpha1.BGPPeer {
+func (b *BGPPeeringBuilder) buildListenRangePeers(bp *nc.BGPPeering, net *resolver.ResolvedNetwork, allowIPv4, allowIPv6 []string, data *resolver.ResolvedData) []networkv1alpha1.BGPPeer {
 	var peers []networkv1alpha1.BGPPeer
 
 	if net.Spec.IPv4 != nil {
 		peer := b.buildBasePeer(bp, data)
 		cidr := net.Spec.IPv4.CIDR
 		peer.ListenRange = &cidr
-		peer.IPv4 = b.buildPeerAF(bp, inboundIPv4, true)
+		peer.IPv4 = b.buildPeerAF(bp, allowIPv4, true)
 		peers = append(peers, peer)
 	}
 
@@ -202,46 +205,36 @@ func (b *BGPPeeringBuilder) buildListenRangePeers(bp *nc.BGPPeering, net *resolv
 		peer := b.buildBasePeer(bp, data)
 		cidr := net.Spec.IPv6.CIDR
 		peer.ListenRange = &cidr
-		peer.IPv6 = b.buildPeerAF(bp, inboundIPv6, false)
+		peer.IPv6 = b.buildPeerAF(bp, allowIPv6, false)
 		peers = append(peers, peer)
 	}
 
 	return peers
 }
 
-// resolveInboundAddresses collects IPv4 and IPv6 addresses from the Inbound CRDs
-// referenced by the BGPPeering's inboundRefs.
-func (*BGPPeeringBuilder) resolveInboundAddresses(bp *nc.BGPPeering, data *resolver.ResolvedData) (ipv4, ipv6 []string) {
-	if bp.Spec.Ref.InboundRefs == nil {
-		return nil, nil
-	}
-
-	refSet := make(map[string]struct{}, len(bp.Spec.Ref.InboundRefs))
-	for _, ref := range bp.Spec.Ref.InboundRefs {
-		refSet[ref] = struct{}{}
-	}
-
-	for i := range data.Inbounds {
-		ib := &data.Inbounds[i]
-		if _, ok := refSet[ib.Name]; !ok {
+// resolveNetworkCIDRs collects the IPv4 and IPv6 CIDRs from the Network CRDs
+// referenced by the BGPPeering's networkRefs. These CIDRs form the listenRange
+// import allow-list (L2 clients may announce prefixes within them) and the
+// EVPN export set.
+func (*BGPPeeringBuilder) resolveNetworkCIDRs(bp *nc.BGPPeering, data *resolver.ResolvedData) (ipv4, ipv6 []string) {
+	for _, ref := range bp.Spec.Ref.NetworkRefs {
+		net, ok := data.Networks[ref]
+		if !ok {
 			continue
 		}
-		addrs := ib.Spec.Addresses
-		if addrs == nil {
-			addrs = ib.Status.Addresses
+		if net.Spec.IPv4 != nil && net.Spec.IPv4.CIDR != "" {
+			ipv4 = append(ipv4, net.Spec.IPv4.CIDR)
 		}
-		if addrs == nil {
-			continue
+		if net.Spec.IPv6 != nil && net.Spec.IPv6.CIDR != "" {
+			ipv6 = append(ipv6, net.Spec.IPv6.CIDR)
 		}
-		ipv4 = append(ipv4, addrs.IPv4...)
-		ipv6 = append(ipv6, addrs.IPv6...)
 	}
-
 	return ipv4, ipv6
 }
 
-// buildPeerAF builds an AddressFamily with an import filter from Inbound addresses
-// and a permit-all export filter. isIPv4 controls the le value (32 vs 128).
+// buildPeerAF builds an AddressFamily with an import filter from the allow-list
+// prefixes (networkRefs CIDRs) and a permit-all export filter. isIPv4 controls
+// the le value (32 vs 128), so a CIDR accepts any more-specific prefix within it.
 func (*BGPPeeringBuilder) buildPeerAF(bp *nc.BGPPeering, prefixes []string, isIPv4 bool) *networkv1alpha1.AddressFamily {
 	le := 128
 	if isIPv4 {
@@ -274,9 +267,9 @@ func (*BGPPeeringBuilder) buildPeerAF(bp *nc.BGPPeering, prefixes []string, isIP
 	return af
 }
 
-// inboundEVPNExportItems builds EVPN export filter items from Inbound addresses
-// so those prefixes are distributed across the fabric.
-func (*BGPPeeringBuilder) inboundEVPNExportItems(ipv4, ipv6 []string) []networkv1alpha1.FilterItem {
+// evpnExportItems builds EVPN export filter items from the allow-list prefixes
+// (networkRefs CIDRs) so those prefixes are distributed across the fabric.
+func (*BGPPeeringBuilder) evpnExportItems(ipv4, ipv6 []string) []networkv1alpha1.FilterItem {
 	items := make([]networkv1alpha1.FilterItem, 0, len(ipv4)+len(ipv6))
 	for _, pfx := range ipv4 {
 		le := 32

--- a/pkg/reconciler/intent/reconciler_test.go
+++ b/pkg/reconciler/intent/reconciler_test.go
@@ -606,16 +606,16 @@ func TestBGPPeeringListenRange(t *testing.T) {
 	createObj(t, ctx, makeNetwork("net-bgp-lr", 560, 4600001, "10.250.60.0/24", "fd96::1/64"))
 	createObj(t, ctx, makeDestination("dest-bgp-lr", "vrf-bgp-lr", map[string]string{"type": "bgp-lr"}, []string{"10.102.0.0/16"}))
 	createObj(t, ctx, makeL2A("l2a-bgp-lr", "net-bgp-lr", destSelector("bgp-lr"), nil))
-	createObj(t, ctx, makeInbound("ib-bgp-lr", "net-bgp-lr", destSelector("bgp-lr"), []string{"10.250.60.10/32"}))
 
-	// BGPPeering in listenRange mode referencing the L2A
+	// BGPPeering in listenRange mode referencing the L2A (for the listen-range
+	// CIDR + VRFs) and a Network (the client-announce allow-list). No Inbound.
 	bgpPeering := &nc.BGPPeering{
 		ObjectMeta: metav1.ObjectMeta{Name: "bgpp-listen", Namespace: testNamespace},
 		Spec: nc.BGPPeeringSpec{
 			Mode: nc.BGPPeeringModeListenRange,
 			Ref: nc.BGPPeeringRef{
 				AttachmentRef: ptr("l2a-bgp-lr"),
-				InboundRefs:   []string{"ib-bgp-lr"},
+				NetworkRefs:   []string{"net-bgp-lr"},
 			},
 			WorkloadAS: ptr(int64(65100)),
 		},


### PR DESCRIPTION
## Summary

`listenRange` BGP peering previously reused `inboundRefs` as a prefix filter. That forced a **mandatory Inbound** and — with `platform-metallb` deployed — an unwanted MetalLB `IPAddressPool` for what is really just an **L2-client BGP session**. The import allow-list also came from IPAM-allocated host addresses (e.g. `count: 4`), not from the referenced Network CIDR.

This makes the reference kind **mode-specific and mutually exclusive**:

| Mode | Requires | Forbids | Allow-list source |
|------|----------|---------|-------------------|
| `listenRange` | `attachmentRef` + `networkRefs` | `inboundRefs` | referenced **Network** CIDRs (`le 32/128`) |
| `loopbackPeer` | `inboundRefs` | `attachmentRef`, `networkRefs` | Inbound VIP pools (BGPaaS) |

- `attachmentRef` still supplies the **listen-range CIDR** (L2A's Network) and the **VRF set** (L2A's `destinations`), fanned out equally to every matched VRF.
- `networkRefs` CIDRs now form both the **import allow-list** and the **EVPN export** set.
- No Inbound → **no MetalLB pool** for plain L2-client BGP.

## Changes
- **API** (`bgppeering_types.go`): add `ref.networkRefs`; `inboundRefs` now optional; 3 mode-conditional CEL rules.
- **Webhook** (`remaining_webhooks.go`): mode-conditional validation mirroring the CEL.
- **Builder** (`bgppeering.go`): `buildListenRange` sources import filter + EVPN export from `networkRefs` Network CIDRs (`resolveNetworkCIDRs`).
- **Generated**: CRD YAML + deepcopy (controller-gen v0.20.0).
- **Tests**: webhook, builder (adds import-filter assertion), envtest reconciler updated.
- **E2E + docs**: intent and bgpaas (BIRD) manifests converted — the Inbound's allow-list CIDRs (`10.250.3.0/24`, `fd75:2d70:f7f7::/64`) become a `Network` via `networkRefs`, so BIRD's `10.250.3.1/32` + `/128` are still accepted (identical `le 32/128` semantics). `REFERENCE.md`/`README.md` updated.

## Verification notes
- `go test ./api/v1alpha1/network-connector/... ./pkg/reconciler/intent/builder/...` — green locally.
- The `intent` envtest package and full `go build ./...` require Linux-only deps (etcd/kubebuilder binaries, `ethtool`/`unix` syscalls) not available on darwin; those test binaries compile but must run in CI.

## Follow-up (not in this PR)
- `BGPPeering.networkRefs` does not add a `network-in-use` finalizer on the referenced Network (matches prior `inboundRefs` behavior). Deletion-protection could be a follow-up in `pkg/reconciler/intent/finalizer`.