### PR TITLE
fix(sync): normalize IPAM host IPs to CIDRs when promoting to spec.addresses

### DIFF
--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"fmt"
+	"net"
 	"reflect"
 	"sort"
 	"strings"
@@ -317,21 +318,59 @@ func (r *Controller) reconcileIPAM(ctx context.Context, namespace string) error 
 
 // promoteIPAMAddresses copies status.addresses into spec.addresses for Inbound/Outbound
 // so the workload operator sees pre-allocated IPs from mgmt-cluster IPAM.
+//
+// IPAM stores allocated addresses as bare host IPs (e.g. "10.100.148.1"), but
+// spec.addresses is a CIDR-typed field: the vinbound/voutbound webhooks validate
+// each entry with net.ParseCIDR. A bare IP therefore gets rejected on the remote
+// cluster. Inbound/Outbound addresses are advertised as individual routed hosts,
+// so each allocated IP is promoted to its /32 (IPv4) or /128 (IPv6) host CIDR.
 func (*Controller) promoteIPAMAddresses(obj client.Object) {
 	switch v := obj.(type) {
 	case *nc.Inbound:
 		if v.Spec.Addresses == nil && v.Status.Addresses != nil &&
 			(len(v.Status.Addresses.IPv4) > 0 || len(v.Status.Addresses.IPv6) > 0) {
-			v.Spec.Addresses = v.Status.Addresses.DeepCopy()
+			v.Spec.Addresses = hostCIDRAllocation(v.Status.Addresses)
 			v.Spec.Count = nil // Switch from count → manual mode
 		}
 	case *nc.Outbound:
 		if v.Spec.Addresses == nil && v.Status.Addresses != nil &&
 			(len(v.Status.Addresses.IPv4) > 0 || len(v.Status.Addresses.IPv6) > 0) {
-			v.Spec.Addresses = v.Status.Addresses.DeepCopy()
+			v.Spec.Addresses = hostCIDRAllocation(v.Status.Addresses)
 			v.Spec.Count = nil
 		}
 	}
+}
+
+// hostCIDRAllocation returns a copy of src with every bare host IP normalised to
+// its host CIDR (/32 for IPv4, /128 for IPv6). Entries that already carry a
+// prefix length are left untouched so explicit subnets survive round-trips.
+func hostCIDRAllocation(src *nc.AddressAllocation) *nc.AddressAllocation {
+	out := &nc.AddressAllocation{}
+	for _, addr := range src.IPv4 {
+		out.IPv4 = append(out.IPv4, toHostCIDR(addr))
+	}
+	for _, addr := range src.IPv6 {
+		out.IPv6 = append(out.IPv6, toHostCIDR(addr))
+	}
+	return out
+}
+
+// toHostCIDR normalises a single address to a host CIDR. A value that already
+// contains a prefix length is returned unchanged; a bare IP gets /32 (IPv4) or
+// /128 (IPv6). A value that parses as neither is returned as-is so the webhook
+// surfaces the original malformed input rather than a mangled one.
+func toHostCIDR(addr string) string {
+	if strings.Contains(addr, "/") {
+		return addr
+	}
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return addr
+	}
+	if ip.To4() != nil {
+		return addr + "/32"
+	}
+	return addr + "/128"
 }
 
 // applyRemote creates the object on the remote cluster if it does not yet exist,

--- a/controllers/sync/sync_controller_test.go
+++ b/controllers/sync/sync_controller_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"net"
 	"strings"
 	"testing"
 
@@ -245,6 +246,66 @@ func TestSyncIPAMPromotion(t *testing.T) {
 	}
 	if remoteInbound.Spec.Count != nil {
 		t.Error("Remote Inbound spec.count should be nil after IPAM promotion")
+	}
+
+	// IPAM stores bare host IPs in status; spec.addresses is a CIDR-typed field
+	// validated by the vinbound webhook (net.ParseCIDR). The promoted addresses
+	// must be valid CIDRs or the remote create is rejected. This is the exact
+	// production failure: "invalid IPv4 CIDR \"10.100.148.1\"".
+	for _, addr := range remoteInbound.Spec.Addresses.IPv4 {
+		if _, _, err := net.ParseCIDR(addr); err != nil {
+			t.Errorf("promoted IPv4 address %q is not a valid CIDR: %v", addr, err)
+		}
+	}
+	for _, addr := range remoteInbound.Spec.Addresses.IPv6 {
+		if _, _, err := net.ParseCIDR(addr); err != nil {
+			t.Errorf("promoted IPv6 address %q is not a valid CIDR: %v", addr, err)
+		}
+	}
+
+	// The promoted remote object must also pass the real admission webhook that
+	// rejected it in production.
+	if _, err := (&nc.Inbound{}).ValidateCreate(ctx, remoteInbound); err != nil {
+		t.Errorf("promoted remote Inbound rejected by vinbound webhook: %v", err)
+	}
+}
+
+// TestPromoteIPAMAddressesFormatsHostCIDR reproduces the production bug directly:
+// a bare host IP allocated by IPAM (e.g. "10.100.148.1") must be promoted into
+// spec.addresses as a host CIDR (/32 for IPv4, /128 for IPv6) so the vinbound
+// webhook accepts it. Entries that already carry a prefix must be left intact.
+func TestPromoteIPAMAddressesFormatsHostCIDR(t *testing.T) {
+	inbound := &nc.Inbound{
+		Spec: nc.InboundSpec{NetworkRef: "net"},
+		Status: nc.InboundStatus{
+			Addresses: &nc.AddressAllocation{
+				IPv4: []string{"10.100.148.1", "10.100.148.0/24"},
+				IPv6: []string{"fd00::1"},
+			},
+		},
+	}
+
+	(&Controller{}).promoteIPAMAddresses(inbound)
+
+	if inbound.Spec.Addresses == nil {
+		t.Fatal("spec.addresses should be populated from status")
+	}
+	wantV4 := []string{"10.100.148.1/32", "10.100.148.0/24"}
+	if len(inbound.Spec.Addresses.IPv4) != len(wantV4) {
+		t.Fatalf("expected %d IPv4 entries, got %v", len(wantV4), inbound.Spec.Addresses.IPv4)
+	}
+	for i, want := range wantV4 {
+		if inbound.Spec.Addresses.IPv4[i] != want {
+			t.Errorf("IPv4[%d] = %q, want %q", i, inbound.Spec.Addresses.IPv4[i], want)
+		}
+	}
+	if len(inbound.Spec.Addresses.IPv6) != 1 || inbound.Spec.Addresses.IPv6[0] != "fd00::1/128" {
+		t.Errorf("IPv6 = %v, want [fd00::1/128]", inbound.Spec.Addresses.IPv6)
+	}
+
+	// The whole point: the promoted spec now passes admission validation.
+	if _, err := (&nc.Inbound{}).ValidateCreate(context.Background(), inbound); err != nil {
+		t.Errorf("promoted Inbound rejected by vinbound webhook: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem
Production error from SyncController:
```
admission webhook "vinbound.kb.io" denied the request: invalid IPv4 CIDR "10.100.148.1": invalid CIDR address: 10.100.148.1
```

## Root cause
IPAM stores allocated addresses as bare host IPs (`ipam.go` `pool.nextIP.String()`). The SyncController promoted `status.addresses` verbatim into the CIDR-typed `spec.addresses` of the remote copy (`sync_controller.go:325`), and `vinbound.kb.io` validates each entry with `net.ParseCIDR`, which requires a prefix. Bare IP -> rejection.

## Fix
Normalize bare host IPs to host CIDRs (`/32` IPv4, `/128` IPv6) when promoting; existing subnet CIDRs pass through unchanged (idempotent). Added regression tests that exercise the real `ValidateCreate` webhook.

## Not addressed here
The observed `.0`->`.1` IPAM reselection after a status reset is a **separate instability** (L3 pool cursor starts on the network address; seeding advances +1 past the recorded value). Tracked/investigated separately — this PR only fixes the CIDR-formatting that breaks sync.

## Testing
`go test ./controllers/sync/... ./api/v1alpha1/network-connector/...` pass. Reverting the fix reproduces the exact production error in tests.