### PR TITLE
fix(l2a): derive IRB/netplan gateway as network+1; require network-address Network CIDRs

### DIFF
--- a/api/v1alpha1/network-connector/network_types.go
+++ b/api/v1alpha1/network-connector/network_types.go
@@ -23,11 +23,15 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // It does not carry VRFs, node scope, or usage semantics.
 // +kubebuilder:validation:XValidation:rule="has(self.ipv4) || has(self.ipv6) || has(self.vlan)",message="at least one of ipv4, ipv6, or vlan must be specified"
 type NetworkSpec struct {
-	// IPv4 is the IPv4 address pool for this network.
+	// IPv4 is the IPv4 address pool for this network. The CIDR must be the
+	// network address (host bits zero), e.g. "198.51.100.224/27" — not an
+	// authored host address like "198.51.100.225/27". The anycast gateway is
+	// derived as the first usable host (network address + 1).
 	// +optional
 	IPv4 *IPNetwork `json:"ipv4,omitempty"`
 
-	// IPv6 is the IPv6 address pool for this network.
+	// IPv6 is the IPv6 address pool for this network. The CIDR must be the
+	// network address (host bits zero), e.g. "2001:db8::/64".
 	// +optional
 	IPv6 *IPNetwork `json:"ipv6,omitempty"`
 

--- a/api/v1alpha1/network-connector/network_vrf_webhook.go
+++ b/api/v1alpha1/network-connector/network_vrf_webhook.go
@@ -71,21 +71,29 @@ func (r *Network) validateNetwork() error {
 		return fmt.Errorf("at least one of ipv4, ipv6 or vlan must be set")
 	}
 	if r.Spec.IPv4 != nil {
-		ip, _, err := net.ParseCIDR(r.Spec.IPv4.CIDR)
+		ip, ipNet, err := net.ParseCIDR(r.Spec.IPv4.CIDR)
 		if err != nil {
 			return fmt.Errorf("invalid ipv4 CIDR %q: %w", r.Spec.IPv4.CIDR, err)
 		}
 		if ip.To4() == nil {
 			return fmt.Errorf("invalid ipv4 CIDR %q: must be an IPv4 CIDR", r.Spec.IPv4.CIDR)
 		}
+		if !ip.Equal(ipNet.IP) {
+			return fmt.Errorf("invalid ipv4 CIDR %q: must be the network address (host bits zero, e.g. %q)",
+				r.Spec.IPv4.CIDR, ipNet.String())
+		}
 	}
 	if r.Spec.IPv6 != nil {
-		ip, _, err := net.ParseCIDR(r.Spec.IPv6.CIDR)
+		ip, ipNet, err := net.ParseCIDR(r.Spec.IPv6.CIDR)
 		if err != nil {
 			return fmt.Errorf("invalid ipv6 CIDR %q: %w", r.Spec.IPv6.CIDR, err)
 		}
 		if ip.To4() != nil {
 			return fmt.Errorf("invalid ipv6 CIDR %q: must be an IPv6 CIDR", r.Spec.IPv6.CIDR)
+		}
+		if !ip.Equal(ipNet.IP) {
+			return fmt.Errorf("invalid ipv6 CIDR %q: must be the network address (host bits zero, e.g. %q)",
+				r.Spec.IPv6.CIDR, ipNet.String())
 		}
 	}
 	if r.Spec.VNI != nil && *r.Spec.VNI <= 0 {

--- a/api/v1alpha1/network-connector/network_vrf_webhook_test.go
+++ b/api/v1alpha1/network-connector/network_vrf_webhook_test.go
@@ -18,6 +18,7 @@ package networkconnector
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -113,6 +114,37 @@ func TestNetworkValidateCreate_InvalidIPv6CIDR(t *testing.T) {
 	n := &Network{Spec: NetworkSpec{IPv6: &IPNetwork{CIDR: "xyz"}}}
 	if _, err := n.ValidateCreate(context.Background(), n); err == nil {
 		t.Fatal("expected error for invalid IPv6 CIDR, got nil")
+	}
+}
+
+// A Network CIDR must be the network address (host bits zero); an authored host
+// address like "10.0.0.1/24" is rejected so the anycast gateway (network+1) is
+// unambiguous.
+func TestNetworkValidateCreate_IPv4NotNetworkAddress(t *testing.T) {
+	n := &Network{Spec: NetworkSpec{IPv4: &IPNetwork{CIDR: "10.0.0.1/24"}}}
+	if _, err := n.ValidateCreate(context.Background(), n); err == nil {
+		t.Fatal("expected error for non-network-address IPv4 CIDR, got nil")
+	}
+}
+
+func TestNetworkValidateCreate_IPv6NotNetworkAddress(t *testing.T) {
+	n := &Network{Spec: NetworkSpec{IPv6: &IPNetwork{CIDR: "2001:db8::1/64"}}}
+	if _, err := n.ValidateCreate(context.Background(), n); err == nil {
+		t.Fatal("expected error for non-network-address IPv6 CIDR, got nil")
+	}
+}
+
+// Point-to-point and single-host prefixes are valid as long as they are in
+// canonical (masked) form.
+func TestNetworkValidateCreate_NetworkAddressEdgePrefixes(t *testing.T) {
+	for _, cidr := range []string{"10.0.0.0/31", "10.0.0.4/32", "2001:db8::/127"} {
+		n := &Network{Spec: NetworkSpec{IPv4: &IPNetwork{CIDR: cidr}}}
+		if strings.Contains(cidr, ":") {
+			n = &Network{Spec: NetworkSpec{IPv6: &IPNetwork{CIDR: cidr}}}
+		}
+		if _, err := n.ValidateCreate(context.Background(), n); err != nil {
+			t.Fatalf("unexpected error for canonical CIDR %q: %v", cidr, err)
+		}
 	}
 }
 

--- a/config/crd/bases/network-connector.sylvaproject.org_networks.yaml
+++ b/config/crd/bases/network-connector.sylvaproject.org_networks.yaml
@@ -68,7 +68,11 @@ spec:
               It does not carry VRFs, node scope, or usage semantics.
             properties:
               ipv4:
-                description: IPv4 is the IPv4 address pool for this network.
+                description: |-
+                  IPv4 is the IPv4 address pool for this network. The CIDR must be the
+                  network address (host bits zero), e.g. "198.51.100.224/27" — not an
+                  authored host address like "198.51.100.225/27". The anycast gateway is
+                  derived as the first usable host (network address + 1).
                 properties:
                   cidr:
                     description: CIDR is the IP network in CIDR notation (e.g. "198.51.100.0/24").
@@ -89,7 +93,9 @@ spec:
                     or 2001:db8::/32)
                   rule: isCIDR(self.cidr)
               ipv6:
-                description: IPv6 is the IPv6 address pool for this network.
+                description: |-
+                  IPv6 is the IPv6 address pool for this network. The CIDR must be the
+                  network address (host bits zero), e.g. "2001:db8::/64".
                 properties:
                   cidr:
                     description: CIDR is the IP network in CIDR notation (e.g. "198.51.100.0/24").

--- a/e2etests/config/config.go
+++ b/e2etests/config/config.go
@@ -109,11 +109,12 @@ func LoadFromEnv() *Config {
 		FailoverPod02IPv4: "10.250.0.170",
 		FailoverPod02IPv6: "fd94:685b:30cf:501::170",
 
-		// Gateways
-		M2MGWIPv4: "10.102.0.1",
-		M2MGWIPv6: "fda5:25c1:193c::1",
-		C2MGWIPv4: "10.102.1.1",
-		C2MGWIPv6: "fda5:25c1:193d::1",
+		// Gateways (the IRB anycast gateway is network+1, i.e. .1/::1, so the
+		// gateway pods use .2/::2 to avoid colliding with it).
+		M2MGWIPv4: "10.102.0.2",
+		M2MGWIPv6: "fda5:25c1:193c::2",
+		C2MGWIPv4: "10.102.1.2",
+		C2MGWIPv6: "fda5:25c1:193d::2",
 
 		// Anycast MACs (VRRP standard MAC used by intent L2A builder)
 		AnycastMAC:        "00:00:5e:00:01:01",

--- a/e2etests/testdata/cluster2-gateway-pods.yaml
+++ b/e2etests/testdata/cluster2-gateway-pods.yaml
@@ -25,14 +25,14 @@ spec:
           "ipam": {
             "type": "static",
             "routes": [
-              {"dst": "10.250.0.0/16", "gw": "10.102.0.254"},
-              {"dst": "fd94:685b:30cf::/48", "gw": "fda5:25c1:193c::fe"},
-              {"dst": "fda5:25c1:193c::/48", "gw": "fda5:25c1:193c::fe"},
-              {"dst": "fdbb:6b17:90ba::/64", "gw": "fda5:25c1:193c::fe"},
-              {"dst": "fd90:4dbf:396d::/126", "gw": "fda5:25c1:193c::fe"},
-              {"dst": "fd90:4dbf:396e::/126", "gw": "fda5:25c1:193c::fe"},
-              {"dst": "fd90:4dbf:396f::/126", "gw": "fda5:25c1:193c::fe"},
-              {"dst": "fd75:2d70:f7f7::/64", "gw": "fda5:25c1:193c::fe"}
+              {"dst": "10.250.0.0/16", "gw": "10.102.0.1"},
+              {"dst": "fd94:685b:30cf::/48", "gw": "fda5:25c1:193c::1"},
+              {"dst": "fda5:25c1:193c::/48", "gw": "fda5:25c1:193c::1"},
+              {"dst": "fdbb:6b17:90ba::/64", "gw": "fda5:25c1:193c::1"},
+              {"dst": "fd90:4dbf:396d::/126", "gw": "fda5:25c1:193c::1"},
+              {"dst": "fd90:4dbf:396e::/126", "gw": "fda5:25c1:193c::1"},
+              {"dst": "fd90:4dbf:396f::/126", "gw": "fda5:25c1:193c::1"},
+              {"dst": "fd75:2d70:f7f7::/64", "gw": "fda5:25c1:193c::1"}
             ]
           }
         },
@@ -64,11 +64,11 @@ spec:
           "ipam": {
             "type": "static",
             "routes": [
-              {"dst": "10.250.0.0/16", "gw": "10.102.1.254"},
-              {"dst": "fd94:685b:30cf::/48", "gw": "fda5:25c1:193d::fe"},
-              {"dst": "fda5:25c1:193d::/48", "gw": "fda5:25c1:193d::fe"},
-              {"dst": "fdb2:e3e1:fcbf::/64", "gw": "fda5:25c1:193d::fe"},
-              {"dst": "fde8:e5cf:d314::/126", "gw": "fda5:25c1:193d::fe"}
+              {"dst": "10.250.0.0/16", "gw": "10.102.1.1"},
+              {"dst": "fd94:685b:30cf::/48", "gw": "fda5:25c1:193d::1"},
+              {"dst": "fda5:25c1:193d::/48", "gw": "fda5:25c1:193d::1"},
+              {"dst": "fdb2:e3e1:fcbf::/64", "gw": "fda5:25c1:193d::1"},
+              {"dst": "fde8:e5cf:d314::/126", "gw": "fda5:25c1:193d::1"}
             ]
           }
         },
@@ -81,7 +81,7 @@ spec:
       ]
     }
 ---
-# m2m gateway pod — provides 10.102.0.1 / fda5:25c1:193c::1
+# m2m gateway pod — provides 10.102.0.2 / fda5:25c1:193c::2 (anycast gw is .1)
 apiVersion: v1
 kind: Pod
 metadata:
@@ -89,7 +89,7 @@ metadata:
   namespace: e2e-gateways
   annotations:
     k8s.v1.cni.cncf.io/networks: |
-      [{"name": "macvlan-vlan601", "ips": ["10.102.0.1/24", "fda5:25c1:193c::1/64"]}]
+      [{"name": "macvlan-vlan601", "ips": ["10.102.0.2/24", "fda5:25c1:193c::2/64"]}]
 spec:
   containers:
   - name: gw
@@ -101,7 +101,7 @@ spec:
     operator: Exists
     effect: NoSchedule
 ---
-# c2m gateway pod — provides 10.102.1.1 / fda5:25c1:193d::1
+# c2m gateway pod — provides 10.102.1.2 / fda5:25c1:193d::2 (anycast gw is .1)
 apiVersion: v1
 kind: Pod
 metadata:
@@ -109,7 +109,7 @@ metadata:
   namespace: e2e-gateways
   annotations:
     k8s.v1.cni.cncf.io/networks: |
-      [{"name": "macvlan-vlan602", "ips": ["10.102.1.1/24", "fda5:25c1:193d::1/64"]}]
+      [{"name": "macvlan-vlan602", "ips": ["10.102.1.2/24", "fda5:25c1:193d::2/64"]}]
 spec:
   containers:
   - name: gw

--- a/e2etests/testdata/intent/base-configs.yaml
+++ b/e2etests/testdata/intent/base-configs.yaml
@@ -29,9 +29,9 @@ spec:
   vlan: 501
   vni: 4000002
   ipv4:
-    cidr: "10.250.0.1/24"
+    cidr: "10.250.0.0/24"
   ipv6:
-    cidr: "fd94:685b:30cf:501::1/64"
+    cidr: "fd94:685b:30cf:501::/64"
 ---
 apiVersion: network-connector.sylvaproject.org/v1alpha1
 kind: Network
@@ -42,9 +42,9 @@ spec:
   vlan: 502
   vni: 4000003
   ipv4:
-    cidr: "10.250.1.1/24"
+    cidr: "10.250.1.0/24"
   ipv6:
-    cidr: "fd94:685b:30cf:502::1/64"
+    cidr: "fd94:685b:30cf:502::/64"
 ---
 apiVersion: network-connector.sylvaproject.org/v1alpha1
 kind: Network
@@ -55,9 +55,9 @@ spec:
   vlan: 503
   vni: 4000004
   ipv4:
-    cidr: "10.250.30.1/24"
+    cidr: "10.250.30.0/24"
   ipv6:
-    cidr: "fd94:685b:30cf:503::1/64"
+    cidr: "fd94:685b:30cf:503::/64"
 ---
 apiVersion: network-connector.sylvaproject.org/v1alpha1
 kind: Destination

--- a/e2etests/testdata/intent/cluster2-configs.yaml
+++ b/e2etests/testdata/intent/cluster2-configs.yaml
@@ -24,7 +24,9 @@ spec:
   routeTarget: "65188:2027"
 ---
 # Networks for gateway VLANs.
-# CIDR is used directly as the anycast gateway IP by the L2A builder.
+# The CIDR is the network address (host bits zero); the L2A builder derives the
+# anycast gateway as the first usable host (network address + 1), e.g.
+# 10.102.0.0/24 -> anycast gateway 10.102.0.1. Gateway pods therefore avoid .1.
 apiVersion: network-connector.sylvaproject.org/v1alpha1
 kind: Network
 metadata:
@@ -34,9 +36,9 @@ spec:
   vlan: 601
   vni: 5000002
   ipv4:
-    cidr: "10.102.0.254/24"
+    cidr: "10.102.0.0/24"
   ipv6:
-    cidr: "fda5:25c1:193c::fe/64"
+    cidr: "fda5:25c1:193c::/64"
 ---
 apiVersion: network-connector.sylvaproject.org/v1alpha1
 kind: Network
@@ -47,9 +49,9 @@ spec:
   vlan: 602
   vni: 5000004
   ipv4:
-    cidr: "10.102.1.254/24"
+    cidr: "10.102.1.0/24"
   ipv6:
-    cidr: "fda5:25c1:193d::fe/64"
+    cidr: "fda5:25c1:193d::/64"
 ---
 # Destinations — export gateway subnets from cluster2 into the EVPN fabric
 apiVersion: network-connector.sylvaproject.org/v1alpha1

--- a/e2etests/testdata/intent/mirror/manifests.yaml
+++ b/e2etests/testdata/intent/mirror/manifests.yaml
@@ -29,7 +29,7 @@ spec:
   vlan: 590
   vni: 4000090
   ipv4:
-    cidr: "10.250.90.1/24"
+    cidr: "10.250.90.0/24"
 ---
 apiVersion: network-connector.sylvaproject.org/v1alpha1
 kind: Layer2Attachment

--- a/e2etests/testdata/intent/sync/cluster2-via-sync.yaml
+++ b/e2etests/testdata/intent/sync/cluster2-via-sync.yaml
@@ -26,9 +26,9 @@ spec:
   vlan: 601
   vni: 5000002
   ipv4:
-    cidr: "10.102.0.254/24"
+    cidr: "10.102.0.0/24"
   ipv6:
-    cidr: "fda5:25c1:193c::fe/64"
+    cidr: "fda5:25c1:193c::/64"
 ---
 apiVersion: network-connector.sylvaproject.org/v1alpha1
 kind: Network
@@ -38,9 +38,9 @@ spec:
   vlan: 602
   vni: 5000004
   ipv4:
-    cidr: "10.102.1.254/24"
+    cidr: "10.102.1.0/24"
   ipv6:
-    cidr: "fda5:25c1:193d::fe/64"
+    cidr: "fda5:25c1:193d::/64"
 ---
 apiVersion: network-connector.sylvaproject.org/v1alpha1
 kind: Destination

--- a/e2etests/tests/intent_destination_nnc.go
+++ b/e2etests/tests/intent_destination_nnc.go
@@ -52,9 +52,9 @@ var _ = Describe("Intent: Destination NNC Validation", Label("intent", "destinat
 			By("Verifying FabricVRF has VRFImport from cluster VRF and aggregate routes")
 			Expect(framework.NNCFabricVRFHasVRFImport(nnc, "m2m", "cluster")).To(BeTrue(),
 				"FabricVRF m2m should import from cluster VRF")
-			Expect(framework.NNCFabricVRFHasAggregateRoute(nnc, "m2m", "10.250.0.1/24")).To(BeTrue(),
+			Expect(framework.NNCFabricVRFHasAggregateRoute(nnc, "m2m", "10.250.0.0/24")).To(BeTrue(),
 				"FabricVRF m2m should have aggregate static route for IPv4 Network CIDR")
-			Expect(framework.NNCFabricVRFHasAggregateRoute(nnc, "m2m", "fd94:685b:30cf:501::1/64")).To(BeTrue(),
+			Expect(framework.NNCFabricVRFHasAggregateRoute(nnc, "m2m", "fd94:685b:30cf:501::/64")).To(BeTrue(),
 				"FabricVRF m2m should have aggregate static route for IPv6 Network CIDR")
 
 			By("Checking NNC has Layer2 entry")
@@ -196,9 +196,9 @@ var _ = Describe("Intent: Destination NNC Validation", Label("intent", "destinat
 				"FabricVRF m2m should import from cluster VRF")
 			Expect(framework.NNCFabricVRFHasVRFImport(nnc, "c2m", "cluster")).To(BeTrue(),
 				"FabricVRF c2m should import from cluster VRF")
-			Expect(framework.NNCFabricVRFHasAggregateRoute(nnc, "m2m", "10.250.0.1/24")).To(BeTrue(),
+			Expect(framework.NNCFabricVRFHasAggregateRoute(nnc, "m2m", "10.250.0.0/24")).To(BeTrue(),
 				"FabricVRF m2m should have aggregate route for net-vlan501 IPv4 CIDR")
-			Expect(framework.NNCFabricVRFHasAggregateRoute(nnc, "c2m", "10.250.30.1/24")).To(BeTrue(),
+			Expect(framework.NNCFabricVRFHasAggregateRoute(nnc, "c2m", "10.250.30.0/24")).To(BeTrue(),
 				"FabricVRF c2m should have aggregate route for net-vlan503 IPv4 CIDR")
 
 			_ = f.DeleteManifest(ctx, manifest)

--- a/e2etests/tests/intent_l3_connectivity.go
+++ b/e2etests/tests/intent_l3_connectivity.go
@@ -73,9 +73,10 @@ var _ = Describe("Intent: L3 Connectivity", Label("intent", "l3"), func() {
 		Expect(f.EnsureIPv6NoDad(ctx, ns, "intent-l3-03", cfg.Macvlan03IPv6, "net1")).To(Succeed())
 
 		By("Verifying IPv4 cross-VLAN connectivity: intent-l3-01 (501) → intent-l3-03 (502)")
-		result, err := f.PingFromPod(ctx, ns, "intent-l3-01", cfg.Macvlan03IPv4, 5)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result.Success).To(BeTrue(), "Cross-VLAN IPv4 ping failed: %s", result.Output)
+		Eventually(func() bool {
+			r, _ := f.PingFromPod(ctx, ns, "intent-l3-01", cfg.Macvlan03IPv4, 3)
+			return r != nil && r.Success
+		}).WithTimeout(90*time.Second).WithPolling(5*time.Second).Should(BeTrue(), "Cross-VLAN IPv4 ping failed")
 
 		By("Verifying IPv6 cross-VLAN connectivity: intent-l3-01 (501) → intent-l3-03 (502)")
 		Eventually(func() bool {

--- a/pkg/reconciler/intent/builder/l2a.go
+++ b/pkg/reconciler/intent/builder/l2a.go
@@ -18,9 +18,10 @@ package builder
 
 import (
 	"context"
+	"encoding/binary"
+	"errors"
 	"fmt"
-	gonet "net"
-	"strings"
+	"net/netip"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -74,8 +75,11 @@ func (b *L2ABuilder) Build(ctx context.Context, data *resolver.ResolvedData) (ma
 		}
 
 		if err := b.applyL2AToNodes(l2a, net, vrfName, vrfSpec, data, result, ifOwner); err != nil {
+			// Never abort the reconcile for one bad L2A: skip it and surface the
+			// failure as a Ready=False condition (with a specific reason) so it
+			// is visible in the resource status, not only the controller log.
 			logger.Info("skipping Layer2Attachment", "l2a", l2a.Name, "error", err.Error())
-			reportSkip(ctx, "Layer2Attachment", l2a.Name, "BuildFailed", err.Error())
+			reportSkip(ctx, "Layer2Attachment", l2a.Name, skipReason(err), err.Error())
 			continue
 		}
 	}
@@ -225,12 +229,40 @@ func (b *L2ABuilder) buildLayer2(l2a *nc.Layer2Attachment, net *resolver.Resolve
 	if vrfName != "" && (l2a.Spec.DisableAnycast == nil || !*l2a.Spec.DisableAnycast) {
 		irb, err := b.buildIRB(l2a, net, vrfName)
 		if err != nil {
-			return nil, err
+			// A Network CIDR with no usable gateway (e.g. a /32 or /128) is a
+			// configuration error, not a reason to abort the reconcile. Tag it
+			// with a specific reason so the L2A's Ready condition is actionable.
+			return nil, &skipReasonError{reason: reasonInvalidIRBGateway, err: err}
 		}
 		layer2.IRB = irb
 	}
 
 	return layer2, nil
+}
+
+// reasonInvalidIRBGateway is the Ready-condition reason used when an L2A's
+// referenced Network CIDR yields no usable anycast gateway (e.g. /32, /128).
+const reasonInvalidIRBGateway = "InvalidIRBGateway"
+
+// skipReasonError wraps a build error with a specific condition reason to
+// report. Builders return it so a skipped resource surfaces an actionable
+// Ready=False reason instead of the generic "BuildFailed".
+type skipReasonError struct {
+	reason string
+	err    error
+}
+
+func (e *skipReasonError) Error() string { return e.err.Error() }
+func (e *skipReasonError) Unwrap() error { return e.err }
+
+// skipReason returns the condition reason to report for a build error,
+// defaulting to "BuildFailed" when the error carries no specific reason.
+func skipReason(err error) string {
+	var s *skipReasonError
+	if errors.As(err, &s) {
+		return s.reason
+	}
+	return "BuildFailed"
 }
 
 // buildIRB constructs the IRB config for an L2A with VRF plumbing.
@@ -239,14 +271,24 @@ func (*L2ABuilder) buildIRB(_ *nc.Layer2Attachment, net *resolver.ResolvedNetwor
 		VRF: vrfName,
 	}
 
-	// Collect anycast gateway IPs from the Network CIDR.
-	// The gateway address is typically the first usable IP in the subnet.
+	// Collect anycast gateway IPs from the Network CIDR. The Network resource
+	// carries the network address (host bits zero); the anycast gateway is the
+	// first usable host (network address + 1), preserving the prefix length.
+	// See gatewayCIDR for point-to-point (/31, /127) and single-host handling.
 	var ipAddresses []string
 	if net.Spec.IPv4 != nil {
-		ipAddresses = append(ipAddresses, net.Spec.IPv4.CIDR)
+		gw, err := gatewayCIDR(net.Spec.IPv4.CIDR)
+		if err != nil {
+			return nil, fmt.Errorf("network %q IPv4 CIDR: %w", net.Name, err)
+		}
+		ipAddresses = append(ipAddresses, gw)
 	}
 	if net.Spec.IPv6 != nil {
-		ipAddresses = append(ipAddresses, net.Spec.IPv6.CIDR)
+		gw, err := gatewayCIDR(net.Spec.IPv6.CIDR)
+		if err != nil {
+			return nil, fmt.Errorf("network %q IPv6 CIDR: %w", net.Name, err)
+		}
+		ipAddresses = append(ipAddresses, gw)
 	}
 
 	if len(ipAddresses) == 0 {
@@ -354,19 +396,96 @@ func buildNetplanNodeIP(l2a *nc.Layer2Attachment, nw *resolver.ResolvedNetwork, 
 	return result
 }
 
-// parseCIDRParts extracts the host IP and prefix length string from a CIDR
-// like "10.0.1.1/24" → ("10.0.1.1", "24").
+// gatewayCIDR returns the anycast gateway CIDR for a Network CIDR: the first
+// usable host (network address + 1) with the original prefix length preserved,
+// e.g. "198.51.100.224/27" → "198.51.100.225/27" and "2001:db8::/64"
+// → "2001:db8::1/64".
+//
+// NOTE: Network resources are expected to carry the *network address* (host
+// bits zero) — not an authored host address like "10.0.1.1/24". The
+// vnetwork.kb.io webhook enforces this, so we can treat the CIDR's base as the
+// network address and derive the gateway as network+1.
+func gatewayCIDR(cidr string) (string, error) {
+	gw, bits, err := gatewayAddr(cidr)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/%d", gw.String(), bits), nil
+}
+
+// parseCIDRParts extracts the anycast gateway host IP (network address + 1) and
+// the prefix length string from a Network CIDR, e.g. "198.51.100.224/27" →
+// ("198.51.100.225", "27"). The gateway is returned without a prefix because
+// callers use it as a bare default gateway. On any error (unparseable CIDR or a
+// prefix with no usable host, e.g. /32) it returns empty strings so the caller
+// skips gateway rendering.
 func parseCIDRParts(cidr string) (gatewayIP, prefixLen string) {
-	ip, ipNet, err := gonet.ParseCIDR(cidr)
+	gw, bits, err := gatewayAddr(cidr)
 	if err != nil {
 		return "", ""
 	}
-	ones, _ := ipNet.Mask.Size()
+	return gw.String(), fmt.Sprintf("%d", bits)
+}
 
-	// The Network CIDR host part is the gateway (e.g., "10.0.1.1/24" → gw "10.0.1.1").
-	gwIP := ip.String()
-	if strings.Contains(cidr, ":") && ip.To4() == nil {
-		gwIP = ip.String()
+// gatewayAddr derives the anycast gateway for a Network CIDR, returning the
+// gateway address and the original prefix length.
+//
+// Network resources carry the network address (host bits zero; enforced by the
+// vnetwork.kb.io webhook), so the gateway is the first usable host: network
+// address + 1. Two edge cases are handled:
+//
+//   - Point-to-point prefixes (/31 for IPv4, /127 for IPv6, RFC 3021) have no
+//     dedicated network/broadcast address; both addresses are usable hosts, so
+//     the network address itself is used as the gateway.
+//   - Single-host prefixes (/32, /128) — and any case where network+1 would
+//     fall outside the prefix or land on the IPv4 broadcast address — have no
+//     usable gateway and return an error rather than emitting an invalid CIDR.
+func gatewayAddr(cidr string) (netip.Addr, int, error) {
+	prefix, err := netip.ParsePrefix(cidr)
+	if err != nil {
+		return netip.Addr{}, 0, fmt.Errorf("invalid CIDR %q: %w", cidr, err)
 	}
-	return gwIP, fmt.Sprintf("%d", ones)
+	// Mask defensively so a stray host bit never skews the derived gateway.
+	prefix = prefix.Masked()
+	network := prefix.Addr()
+	bits := prefix.Bits()
+	maxBits := network.BitLen() // 32 for IPv4, 128 for IPv6
+
+	// Point-to-point (/31, /127): use the network address itself.
+	if bits == maxBits-1 {
+		return network, bits, nil
+	}
+
+	gw := network.Next()
+	if !gw.IsValid() || !prefix.Contains(gw) {
+		return netip.Addr{}, 0, fmt.Errorf(
+			"cannot derive gateway for CIDR %q: no usable host address in prefix", cidr)
+	}
+	// Reject the IPv4 broadcast (all-ones host) address. For prefixes wider
+	// than /31 network+1 is never the broadcast, but guard explicitly so the
+	// invariant is enforced rather than assumed.
+	if bcast, ok := broadcastAddr(prefix); ok && gw == bcast {
+		return netip.Addr{}, 0, fmt.Errorf(
+			"cannot derive gateway for CIDR %q: only the broadcast address is available", cidr)
+	}
+	return gw, bits, nil
+}
+
+// broadcastAddr returns the IPv4 broadcast (last) address of a prefix. The
+// second return value is false for IPv6 (no broadcast concept) and for prefixes
+// without host bits.
+func broadcastAddr(prefix netip.Prefix) (netip.Addr, bool) {
+	addr := prefix.Masked().Addr()
+	if !addr.Is4() {
+		return netip.Addr{}, false
+	}
+	hostBits := ipv4MaxPrefixLen - prefix.Bits()
+	if hostBits == 0 {
+		return netip.Addr{}, false
+	}
+	b := addr.As4()
+	v := binary.BigEndian.Uint32(b[:])
+	v |= (uint32(1) << hostBits) - 1 // set the host bits to all-ones
+	binary.BigEndian.PutUint32(b[:], v)
+	return netip.AddrFrom4(b), true
 }

--- a/pkg/reconciler/intent/builder/l2a_test.go
+++ b/pkg/reconciler/intent/builder/l2a_test.go
@@ -235,8 +235,8 @@ func TestL2ABuilder_WithDestinationVRF(t *testing.T) {
 	if l2.IRB.VRF != "prod" {
 		t.Errorf("expected IRB VRF 'prod' (backbone name), got %q", l2.IRB.VRF)
 	}
-	if len(l2.IRB.IPAddresses) != 1 || l2.IRB.IPAddresses[0] != "10.100.0.0/24" {
-		t.Errorf("expected IRB IP [10.100.0.0/24], got %v", l2.IRB.IPAddresses)
+	if len(l2.IRB.IPAddresses) != 1 || l2.IRB.IPAddresses[0] != "10.100.0.1/24" {
+		t.Errorf("expected IRB IP [10.100.0.1/24], got %v", l2.IRB.IPAddresses)
 	}
 
 	// L2 VNI RouteTarget must be empty — FRR auto-derives it.
@@ -676,4 +676,158 @@ func TestL2ABuilder_InterfaceNameAndRef(t *testing.T) {
 	require.True(t, ok, "expected NetplanNodeIPs entry for key 501")
 	assert.Equal(t, "chris-l2", nip.InterfaceName, "InterfaceName should be propagated to netplan device")
 	assert.Equal(t, "bond0", nip.InterfaceRef, "InterfaceRef should be propagated to netplan device")
+}
+
+// TestL2ABuilder_IRBGateway_NetworkAddressCIDR reproduces the production bug
+// where a Network authored with the network-address form of the CIDR (host bits
+// zero) must yield the anycast gateway (network address + 1) in the IRB and in
+// the per-node netplan default gateway, for both IPv4 and IPv6.
+func TestL2ABuilder_IRBGateway_NetworkAddressCIDR(t *testing.T) {
+	b := NewL2ABuilder()
+	vlan := int32(149)
+	vni := int32(100149)
+	data := &resolver.ResolvedData{
+		Nodes: []corev1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+		},
+		Networks: map[string]*resolver.ResolvedNetwork{
+			"net-vlan149": {Name: "net-vlan149", Spec: nc.NetworkSpec{
+				VLAN: &vlan, VNI: &vni,
+				IPv4: &nc.IPNetwork{CIDR: "198.51.100.224/27"},
+				IPv6: &nc.IPNetwork{CIDR: "2001:db8::/64"},
+			}},
+		},
+		RawDestinations: []nc.Destination{
+			{ObjectMeta: metav1.ObjectMeta{Name: "dest-gw", Labels: map[string]string{"type": "gateway"}},
+				Spec: nc.DestinationSpec{VRFRef: ptr("vrf-ztn")}},
+		},
+		Destinations: map[string]*resolver.ResolvedDestination{
+			"dest-gw": {Name: "dest-gw", Spec: nc.DestinationSpec{VRFRef: ptr("vrf-ztn")}, VRFSpec: &nc.VRFSpec{VRF: "ztn", VNI: ptr(int32(100))}},
+		},
+		Layer2Attachments: []nc.Layer2Attachment{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "net-vlan149-l2a"},
+				Spec: nc.Layer2AttachmentSpec{
+					NetworkRef:   "net-vlan149",
+					Destinations: &metav1.LabelSelector{MatchLabels: map[string]string{"type": "gateway"}},
+					NodeIPs:      &nc.NodeIPConfig{Enabled: true},
+				},
+				Status: nc.Layer2AttachmentStatus{
+					NodeAddresses: map[string]nc.AddressAllocation{
+						"node-1": {IPv4: []string{"198.51.100.230"}, IPv6: []string{"2001:db8::30"}},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := b.Build(context.Background(), data)
+	require.NoError(t, err)
+
+	// IRB anycast gateways must be network address + 1, preserving prefix length.
+	l2 := result["node-1"].Layer2s["149"]
+	require.NotNil(t, l2.IRB, "expected IRB to be set")
+	assert.Equal(t, []string{"198.51.100.225/27", "2001:db8::1/64"}, l2.IRB.IPAddresses)
+
+	// The per-node netplan default gateways must also be network address + 1
+	// (bare, without prefix), while the allocated host addresses are unchanged.
+	nip := result["node-1"].NetplanNodeIPs["149"]
+	assert.Equal(t, []string{"198.51.100.230/27", "2001:db8::30/64"}, nip.Addresses)
+	assert.Equal(t, []string{"198.51.100.225", "2001:db8::1"}, nip.Gateways)
+}
+
+// TestL2ABuilder_IRBGateway_SingleHostReportsSkip verifies that a Network CIDR
+// with no usable anycast gateway (a /32) does not abort the reconcile: the L2A
+// is skipped, no IRB is emitted, and a Ready=False build issue with the
+// specific "InvalidIRBGateway" reason is reported for the resource.
+func TestL2ABuilder_IRBGateway_SingleHostReportsSkip(t *testing.T) {
+	b := NewL2ABuilder()
+	vlan := int32(151)
+	vni := int32(100151)
+	data := &resolver.ResolvedData{
+		Nodes: []corev1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+		},
+		Networks: map[string]*resolver.ResolvedNetwork{
+			"single-host": {Name: "single-host", Spec: nc.NetworkSpec{
+				VLAN: &vlan, VNI: &vni,
+				IPv4: &nc.IPNetwork{CIDR: "10.0.0.4/32"},
+			}},
+		},
+		RawDestinations: []nc.Destination{
+			{ObjectMeta: metav1.ObjectMeta{Name: "dest-gw", Labels: map[string]string{"type": "gateway"}},
+				Spec: nc.DestinationSpec{VRFRef: ptr("vrf-sh")}},
+		},
+		Destinations: map[string]*resolver.ResolvedDestination{
+			"dest-gw": {Name: "dest-gw", Spec: nc.DestinationSpec{VRFRef: ptr("vrf-sh")}, VRFSpec: &nc.VRFSpec{VRF: "sh", VNI: ptr(int32(100))}},
+		},
+		Layer2Attachments: []nc.Layer2Attachment{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "l2a-single-host"},
+				Spec: nc.Layer2AttachmentSpec{
+					NetworkRef:   "single-host",
+					Destinations: &metav1.LabelSelector{MatchLabels: map[string]string{"type": "gateway"}},
+				},
+			},
+		},
+	}
+
+	report := NewBuildReport()
+	ctx := WithReport(context.Background(), report)
+
+	// Build must not error (reconcile is not aborted) even though the L2A is skipped.
+	result, err := b.Build(ctx, data)
+	require.NoError(t, err)
+
+	// The L2A produced no Layer2 contribution for the node.
+	if contrib, ok := result["node-1"]; ok {
+		_, hasL2 := contrib.Layer2s["151"]
+		assert.False(t, hasL2, "expected no Layer2 for a Network with no usable gateway")
+	}
+
+	// A build issue with the specific reason is reported for the L2A.
+	issues := report.Issues()
+	require.Len(t, issues, 1)
+	assert.Equal(t, "Layer2Attachment", issues[0].Kind)
+	assert.Equal(t, "l2a-single-host", issues[0].Name)
+	assert.Equal(t, reasonInvalidIRBGateway, issues[0].Reason)
+	assert.Contains(t, issues[0].Message, "no usable host address")
+}
+
+// TestGatewayAddr covers the gateway-derivation edge cases: normal subnets use
+// the first usable host (network address + 1); point-to-point prefixes (/31,
+// /127) use the network address itself; and single-host prefixes (/32, /128)
+// have no usable gateway and return an error.
+func TestGatewayAddr(t *testing.T) {
+	tests := []struct {
+		name     string
+		cidr     string
+		wantCIDR string // expected gatewayCIDR result; "" means expect error
+		wantIP   string // expected parseCIDRParts gateway IP ("" on error)
+		wantLen  string // expected parseCIDRParts prefix length ("" on error)
+	}{
+		{"ipv4 network address /24", "10.0.1.0/24", "10.0.1.1/24", "10.0.1.1", "24"},
+		{"ipv4 network address /27", "198.51.100.224/27", "198.51.100.225/27", "198.51.100.225", "27"},
+		{"ipv6 network address /64", "2001:db8::/64", "2001:db8::1/64", "2001:db8::1", "64"},
+		{"ipv4 point-to-point /31", "10.0.0.0/31", "10.0.0.0/31", "10.0.0.0", "31"},
+		{"ipv6 point-to-point /127", "2001:db8::/127", "2001:db8::/127", "2001:db8::", "127"},
+		{"ipv4 single host /32", "10.0.0.5/32", "", "", ""},
+		{"ipv6 single host /128", "2001:db8::5/128", "", "", ""},
+		{"unparseable", "not-a-cidr", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gwCIDR, err := gatewayCIDR(tt.cidr)
+			if tt.wantCIDR == "" {
+				assert.Error(t, err, "expected error for %q", tt.cidr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantCIDR, gwCIDR)
+			}
+
+			ip, plen := parseCIDRParts(tt.cidr)
+			assert.Equal(t, tt.wantIP, ip)
+			assert.Equal(t, tt.wantLen, plen)
+		})
+	}
 }

--- a/pkg/reconciler/intent/reconciler_test.go
+++ b/pkg/reconciler/intent/reconciler_test.go
@@ -253,7 +253,7 @@ func TestL2APipeline(t *testing.T) {
 
 	createNode(t, ctx, nodeName, nil)
 	createObj(t, ctx, makeVRF("vrf-l2a", "m2m", 2002026, "65188:2026"))
-	createObj(t, ctx, makeNetwork("net-l2a-501", 501, 4000002, "10.250.0.0/24", "fd94::1/64"))
+	createObj(t, ctx, makeNetwork("net-l2a-501", 501, 4000002, "10.250.0.0/24", "fd94::/64"))
 	createObj(t, ctx, makeDestination("dest-l2a-gw", "vrf-l2a", map[string]string{"type": "gateway"}, []string{"10.102.0.0/16"}))
 	createObj(t, ctx, makeL2A("l2a-pipeline", "net-l2a-501", destSelector("gateway"), nil))
 
@@ -488,11 +488,12 @@ func TestLifecycleUpdate(t *testing.T) {
 
 	assert.NotEqual(t, rev1, nnc2.Spec.Revision, "expected revision to change after Network update")
 
-	// Verify updated CIDR in IRB
+	// Verify updated CIDR in IRB — the IRB carries the gateway (network+1),
+	// so the anycast gateway for 10.250.11.0/24 is 10.250.11.1/24.
 	l2, ok := nnc2.Spec.Layer2s["510"]
 	require.True(t, ok, "expected Layer2 '510' after update")
 	require.NotNil(t, l2.IRB, "expected IRB after update")
-	assert.Contains(t, l2.IRB.IPAddresses, "10.250.11.0/24")
+	assert.Contains(t, l2.IRB.IPAddresses, "10.250.11.1/24")
 }
 
 func TestLifecycleDelete(t *testing.T) {
@@ -612,7 +613,7 @@ func TestBGPPeeringListenRange(t *testing.T) {
 
 	createNode(t, ctx, nodeName, nil)
 	createObj(t, ctx, makeVRF("vrf-bgp-lr", "bgplr", 2002090, "65188:2090"))
-	createObj(t, ctx, makeNetwork("net-bgp-lr", 560, 4600001, "10.250.60.0/24", "fd96::1/64"))
+	createObj(t, ctx, makeNetwork("net-bgp-lr", 560, 4600001, "10.250.60.0/24", "fd96::/64"))
 	createObj(t, ctx, makeDestination("dest-bgp-lr", "vrf-bgp-lr", map[string]string{"type": "bgp-lr"}, []string{"10.102.0.0/16"}))
 	createObj(t, ctx, makeL2A("l2a-bgp-lr", "net-bgp-lr", destSelector("bgp-lr"), nil))
 


### PR DESCRIPTION
## Summary
Fixes the Layer2Attachment IRB (anycast gateway) and per-node netplan gateway so they use the **first usable host (network address + 1)** of the referenced Network CIDR, instead of the network address. Also enforces that `Network` CIDRs are authored in network-address form, since the gateway derivation depends on it.

Three commits:
1. `fix(l2a)` — network+1 gateway derivation + edge cases + non-aborting condition.
2. `feat(network)` — Network webhook requires network-address CIDRs.
3. `test(e2e)` — migrate intent e2e fixtures to the new model.

## Problem
`buildIRB` passed the Network CIDR through verbatim and `parseCIDRParts` returned the CIDR host part as the gateway. Both assumed the CIDR was authored with the gateway as the host part (e.g. `198.51.100.1/24`), but Networks created by the network-binding-controller use the network-address form (e.g. `198.51.100.224/27`), so the IRB became the **network address**:
```
irb.ipAddresses:
  - 198.51.100.224/27   # WRONG (network address)
  - 2001:db8::/64       # WRONG (network address)
```

## Fix (gateway derivation)
New `gatewayCIDR`/`gatewayAddr` helpers using `net/netip` (`prefix.Masked().Addr().Next()`, correct IPv4/IPv6 carry). IRB IPs and the netplan default gateway now use network+1, prefix preserved:
```
- 198.51.100.225/27
- 2001:db8::1/64
```
Edge cases:
- point-to-point prefixes (`/31`, `/127`) use the network address itself;
- single-host (`/32`, `/128`), out-of-range and IPv4-broadcast results return an error rather than emitting an invalid gateway.

An unresolvable gateway does **not** abort the reconcile: the L2A is skipped and surfaced as a `Ready=False` `InvalidIRBGateway` condition (via a typed `skipReasonError`). Per-node allocated host addresses are unchanged.

## ⚠️ Breaking change (Network validation)
`vnetwork.kb.io` now **requires `Network` CIDRs to be the network address (host bits zero)** on both create and update. Host-form CIDRs such as `198.51.100.1/24` or `2001:db8::1/64` are rejected with a message pointing at the canonical form (e.g. `198.51.100.0/24`). Point-to-point (`/31`, `/127`) and single-host (`/32`) prefixes remain valid in masked form.

This is intentional: the gateway is derived as network+1, which is only unambiguous when the CIDR carries the network address. Consequences:
- **Existing Networks authored in host-form cannot be updated** until their CIDR is corrected to network-address form. In practice the network-binding-controller already emits network-address CIDRs, so managed Networks are unaffected; only hand-authored host-form Networks need a one-time correction.
- On the derivation being "backward-compatible": for a `/24` authored as `198.51.100.1/24`, network+1 is `198.51.100.1` — the same gateway as before — so the **rendered gateway is unchanged**. The breaking part is admission: such a CIDR is no longer accepted as input and must be written as `198.51.100.0/24`.

If strict enforcement is later deemed too aggressive, the alternative is to accept host-form CIDRs, mask them internally, and return an admission warning instead of hard-failing — but per design intent this PR enforces network-address form.

## E2E migration
The intent e2e fixtures were authored in host-form (CIDR host part doubling as the gateway). Updated to the new model:
- Cluster1 (base-configs, mirror): masked to network-address form; network+1 equals the old host part (`.1`/`::1`), so the gateway is unchanged.
- Cluster2: the gateway moves `.254`/`::fe` -> `.1`/`::1`, which would collide with the gateway pods at `.1`; moved the gateway pods to `.2`/`::2`, pointed their routes at the new `.1`/`::1` IRB, and updated the M2M/C2M gateway IP constants.
- Destination NNC test: aggregate static route mirrors the Network CIDR verbatim, so expected aggregate prefixes updated to network-address form.
- L3 connectivity test: wrapped the one-shot IPv4 cross-VLAN ping in `Eventually` (matching the existing IPv6 check) so it tolerates EVPN convergence.

## Testing
Unit + webhook tests, `validate generated files`, lint, and the full E2E suite pass.