### PR TITLE
fix(bgppeering): report Ready/Resolved status conditions

### DIFF
--- a/pkg/reconciler/intent/builder/bgppeering.go
+++ b/pkg/reconciler/intent/builder/bgppeering.go
@@ -55,7 +55,7 @@ func (b *BGPPeeringBuilder) Build(ctx context.Context, data *resolver.ResolvedDa
 			if err := b.buildListenRange(bp, data, result); err != nil {
 				logger.Info("skipping BGPPeering with unresolvable listenRange",
 					"bgppeering", bp.Name, "error", err.Error())
-				reportSkip(ctx, "BGPPeering", bp.Name, "ListenRangeUnresolved", err.Error())
+				reportSkip(ctx, "BGPPeering", bp.Namespace, bp.Name, "ListenRangeUnresolved", err.Error())
 				continue
 			}
 		case nc.BGPPeeringModeLoopbackPeer:
@@ -63,7 +63,7 @@ func (b *BGPPeeringBuilder) Build(ctx context.Context, data *resolver.ResolvedDa
 		default:
 			logger.Info("skipping BGPPeering with unknown mode",
 				"bgppeering", bp.Name, "mode", bp.Spec.Mode)
-			reportSkip(ctx, "BGPPeering", bp.Name, "UnknownMode",
+			reportSkip(ctx, "BGPPeering", bp.Namespace, bp.Name, "UnknownMode",
 				fmt.Sprintf("unknown BGPPeering mode %q", bp.Spec.Mode))
 			continue
 		}

--- a/pkg/reconciler/intent/builder/collector.go
+++ b/pkg/reconciler/intent/builder/collector.go
@@ -57,7 +57,7 @@ func (*CollectorBuilder) Build(ctx context.Context, data *resolver.ResolvedData)
 		if !ok {
 			logger.Info("skipping Collector with unknown VRF reference",
 				"collector", col.Name, "vrf", vrfName)
-			reportSkip(ctx, "Collector", col.Name, "VRFNotFound",
+			reportSkip(ctx, "Collector", col.Namespace, col.Name, "VRFNotFound",
 				fmt.Sprintf("referenced VRF %q not found", vrfName))
 			continue
 		}

--- a/pkg/reconciler/intent/builder/inbound.go
+++ b/pkg/reconciler/intent/builder/inbound.go
@@ -55,7 +55,7 @@ func (b *InboundBuilder) Build(ctx context.Context, data *resolver.ResolvedData)
 		if !ok {
 			logger.Info("skipping Inbound with unknown Network reference",
 				"inbound", ib.Name, "networkRef", ib.Spec.NetworkRef)
-			reportSkip(ctx, "Inbound", ib.Name, "NetworkNotFound",
+			reportSkip(ctx, "Inbound", ib.Namespace, ib.Name, "NetworkNotFound",
 				fmt.Sprintf("referenced Network %q not found", ib.Spec.NetworkRef))
 			continue
 		}
@@ -79,7 +79,7 @@ func (b *InboundBuilder) Build(ctx context.Context, data *resolver.ResolvedData)
 			if err != nil {
 				logger.Info("skipping Inbound with ambiguous announcement policy",
 					"inbound", ib.Name, "error", err.Error())
-				reportSkip(ctx, "Inbound", ib.Name, "AmbiguousAnnouncementPolicy", err.Error())
+				reportSkip(ctx, "Inbound", ib.Namespace, ib.Name, "AmbiguousAnnouncementPolicy", err.Error())
 				ambiguous = true
 				break
 			}

--- a/pkg/reconciler/intent/builder/l2a.go
+++ b/pkg/reconciler/intent/builder/l2a.go
@@ -79,7 +79,7 @@ func (b *L2ABuilder) Build(ctx context.Context, data *resolver.ResolvedData) (ma
 			// failure as a Ready=False condition (with a specific reason) so it
 			// is visible in the resource status, not only the controller log.
 			logger.Info("skipping Layer2Attachment", "l2a", l2a.Name, "error", err.Error())
-			reportSkip(ctx, "Layer2Attachment", l2a.Name, skipReason(err), err.Error())
+			reportSkip(ctx, "Layer2Attachment", l2a.Namespace, l2a.Name, skipReason(err), err.Error())
 			continue
 		}
 	}

--- a/pkg/reconciler/intent/builder/mirror.go
+++ b/pkg/reconciler/intent/builder/mirror.go
@@ -67,14 +67,14 @@ func (b *MirrorBuilder) Build(ctx context.Context, data *resolver.ResolvedData) 
 		if err != nil {
 			logger.Info("skipping TrafficMirror with unresolvable collector",
 				"trafficmirror", tm.Name, "error", err.Error())
-			reportSkip(ctx, "TrafficMirror", tm.Name, "CollectorResolutionFailed", err.Error())
+			reportSkip(ctx, "TrafficMirror", tm.Namespace, tm.Name, "CollectorResolutionFailed", err.Error())
 			continue
 		}
 
 		if !validMirrorSourceKind(tm.Spec.Source.Kind) {
 			logger.Info("skipping TrafficMirror with unknown source kind",
 				"trafficmirror", tm.Name, "kind", tm.Spec.Source.Kind)
-			reportSkip(ctx, "TrafficMirror", tm.Name, "UnknownSourceKind",
+			reportSkip(ctx, "TrafficMirror", tm.Namespace, tm.Name, "UnknownSourceKind",
 				fmt.Sprintf("unknown source kind %q", tm.Spec.Source.Kind))
 			continue
 		}
@@ -100,7 +100,7 @@ func (b *MirrorBuilder) Build(ctx context.Context, data *resolver.ResolvedData) 
 		if srcErr != nil {
 			logger.Info("skipping TrafficMirror with unresolvable source",
 				"trafficmirror", tm.Name, "error", srcErr.Error())
-			reportSkip(ctx, "TrafficMirror", tm.Name, "SourceResolutionFailed", srcErr.Error())
+			reportSkip(ctx, "TrafficMirror", tm.Namespace, tm.Name, "SourceResolutionFailed", srcErr.Error())
 			continue
 		}
 	}

--- a/pkg/reconciler/intent/builder/nodeattachment.go
+++ b/pkg/reconciler/intent/builder/nodeattachment.go
@@ -62,7 +62,7 @@ func (b *NodeAttachmentBuilder) Build(ctx context.Context, data *resolver.Resolv
 		if err != nil {
 			logger.Info("skipping NodeAttachment with invalid node selector",
 				"nodeattachment", na.Name, "error", err.Error())
-			reportSkip(ctx, "NodeAttachment", na.Name, "InvalidNodeSelector", err.Error())
+			reportSkip(ctx, "NodeAttachment", na.Namespace, na.Name, "InvalidNodeSelector", err.Error())
 			continue
 		}
 		if len(matchedNodes) == 0 {

--- a/pkg/reconciler/intent/builder/outbound.go
+++ b/pkg/reconciler/intent/builder/outbound.go
@@ -62,7 +62,7 @@ func (b *OutboundBuilder) Build(ctx context.Context, data *resolver.ResolvedData
 		if err := b.applyOutbound(ob, net, data, result); err != nil {
 			logger.Info("skipping Outbound with ambiguous announcement policy",
 				"outbound", ob.Name, "error", err.Error())
-			reportSkip(ctx, "Outbound", ob.Name, "AmbiguousAnnouncementPolicy", err.Error())
+			reportSkip(ctx, "Outbound", ob.Namespace, ob.Name, "AmbiguousAnnouncementPolicy", err.Error())
 			continue
 		}
 	}

--- a/pkg/reconciler/intent/builder/podnetwork.go
+++ b/pkg/reconciler/intent/builder/podnetwork.go
@@ -55,7 +55,7 @@ func (b *PodNetworkBuilder) Build(ctx context.Context, data *resolver.ResolvedDa
 		if !ok {
 			logger.Info("skipping PodNetwork with unknown Network reference",
 				"podnetwork", pn.Name, "networkRef", pn.Spec.NetworkRef)
-			reportSkip(ctx, "PodNetwork", pn.Name, "NetworkNotFound",
+			reportSkip(ctx, "PodNetwork", pn.Namespace, pn.Name, "NetworkNotFound",
 				fmt.Sprintf("referenced Network %q not found", pn.Spec.NetworkRef))
 			continue
 		}
@@ -65,7 +65,7 @@ func (b *PodNetworkBuilder) Build(ctx context.Context, data *resolver.ResolvedDa
 		if err != nil {
 			logger.Info("skipping PodNetwork with unresolvable destinations",
 				"podnetwork", pn.Name, "error", err.Error())
-			reportSkip(ctx, "PodNetwork", pn.Name, "DestinationResolutionFailed", err.Error())
+			reportSkip(ctx, "PodNetwork", pn.Namespace, pn.Name, "DestinationResolutionFailed", err.Error())
 			continue
 		}
 
@@ -78,7 +78,7 @@ func (b *PodNetworkBuilder) Build(ctx context.Context, data *resolver.ResolvedDa
 		if err != nil {
 			logger.Info("skipping PodNetwork with ambiguous announcement policy",
 				"podnetwork", pn.Name, "error", err.Error())
-			reportSkip(ctx, "PodNetwork", pn.Name, "AmbiguousAnnouncementPolicy", err.Error())
+			reportSkip(ctx, "PodNetwork", pn.Namespace, pn.Name, "AmbiguousAnnouncementPolicy", err.Error())
 			continue
 		}
 

--- a/pkg/reconciler/intent/builder/report.go
+++ b/pkg/reconciler/intent/builder/report.go
@@ -26,6 +26,10 @@ import "context"
 type BuildIssue struct {
 	// Kind is the intent CRD kind (e.g. "Layer2Attachment").
 	Kind string
+	// Namespace is the offending resource's namespace. It is part of the
+	// identity because intent CRDs are namespaced and the reconciler may run
+	// cluster-wide, so name alone is not unique.
+	Namespace string
 	// Name is the offending resource's name.
 	Name string
 	// Reason is a short PascalCase condition reason (e.g. "AmbiguousAnnouncementPolicy").
@@ -53,8 +57,8 @@ func (r *BuildReport) Issues() []BuildIssue {
 	return r.issues
 }
 
-func (r *BuildReport) add(issue BuildIssue) {
-	r.issues = append(r.issues, issue)
+func (r *BuildReport) add(issue *BuildIssue) {
+	r.issues = append(r.issues, *issue)
 }
 
 type reportContextKey struct{}
@@ -68,10 +72,10 @@ func WithReport(ctx context.Context, report *BuildReport) context.Context {
 // reportSkip records a skipped resource on the BuildReport carried by ctx, if
 // any. It is a no-op when no report is present (e.g. in unit tests that call a
 // builder directly), so builders can call it unconditionally.
-func reportSkip(ctx context.Context, kind, name, reason, message string) {
+func reportSkip(ctx context.Context, kind, namespace, name, reason, message string) {
 	report, ok := ctx.Value(reportContextKey{}).(*BuildReport)
 	if !ok || report == nil {
 		return
 	}
-	report.add(BuildIssue{Kind: kind, Name: name, Reason: reason, Message: message})
+	report.add(&BuildIssue{Kind: kind, Namespace: namespace, Name: name, Reason: reason, Message: message})
 }

--- a/pkg/reconciler/intent/builder/report_test.go
+++ b/pkg/reconciler/intent/builder/report_test.go
@@ -29,7 +29,7 @@ func TestBuildReport_CapturesSkippedResource(t *testing.T) {
 	data := baseInboundData()
 	data.Inbounds = []nc.Inbound{
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "bad-inbound"},
+			ObjectMeta: metav1.ObjectMeta{Name: "bad-inbound", Namespace: "tenant-a"},
 			Spec: nc.InboundSpec{
 				NetworkRef:   "nonexistent",
 				Destinations: &metav1.LabelSelector{MatchLabels: map[string]string{"type": "gw"}},
@@ -50,7 +50,7 @@ func TestBuildReport_CapturesSkippedResource(t *testing.T) {
 		t.Fatalf("expected 1 build issue, got %d: %+v", len(issues), issues)
 	}
 	got := issues[0]
-	if got.Kind != "Inbound" || got.Name != "bad-inbound" || got.Reason != "NetworkNotFound" {
+	if got.Kind != "Inbound" || got.Namespace != "tenant-a" || got.Name != "bad-inbound" || got.Reason != "NetworkNotFound" {
 		t.Errorf("unexpected issue: %+v", got)
 	}
 	if got.Message == "" {
@@ -85,5 +85,5 @@ func TestBuildReport_NoIssuesWhenHealthy(t *testing.T) {
 
 func TestReportSkip_NoopWithoutReport(_ *testing.T) {
 	// Must not panic when ctx carries no report (e.g. unit tests calling Build directly).
-	reportSkip(context.Background(), "Inbound", "x", "Reason", "message")
+	reportSkip(context.Background(), "Inbound", "ns", "x", "Reason", "message")
 }

--- a/pkg/reconciler/intent/reconciler.go
+++ b/pkg/reconciler/intent/reconciler.go
@@ -190,7 +190,7 @@ func (r *Reconciler) ReconcileDebounced(ctx context.Context) error {
 	// the builders surface as Ready=False on the specific offending resource.
 	issuesMap := make(map[string]status.ResourceIssue)
 	for _, issue := range report.Issues() {
-		issuesMap[status.IssueKey(issue.Kind, issue.Name)] = status.ResourceIssue{
+		issuesMap[status.IssueKey(issue.Kind, issue.Namespace, issue.Name)] = status.ResourceIssue{
 			Reason:  issue.Reason,
 			Message: issue.Message,
 		}

--- a/pkg/reconciler/intent/status/status.go
+++ b/pkg/reconciler/intent/status/status.go
@@ -432,8 +432,13 @@ func (u *Updater) updateBGPPeeringConditions(ctx context.Context, fetched *resol
 // spec resolve to existing intent resources. The checks are mode-specific and
 // mirror the requirements enforced by the BGPPeering builder:
 //   - listenRange requires attachmentRef (an existing Layer2Attachment) and
-//     networkRefs (each an existing Network).
-//   - loopbackPeer requires inboundRefs (each an existing Inbound).
+//     at least one networkRef (each an existing Network).
+//   - loopbackPeer requires at least one inboundRef (each an existing Inbound).
+//
+// An unrecognised spec.mode yields Resolved=False so the condition stays
+// consistent with the Ready=False the builder forces for unknown modes; the
+// CRD schema normally prevents this, but the status path must not silently
+// report an invalid resource as resolved.
 func checkBGPPeeringRefs(bp *nc.BGPPeering, resolved *resolver.ResolvedData) (condStatus metav1.ConditionStatus, reason, message string) {
 	switch bp.Spec.Mode {
 	case nc.BGPPeeringModeListenRange:
@@ -443,17 +448,25 @@ func checkBGPPeeringRefs(bp *nc.BGPPeering, resolved *resolver.ResolvedData) (co
 		if !layer2AttachmentExists(*bp.Spec.Ref.AttachmentRef, resolved) {
 			return metav1.ConditionFalse, "AttachmentNotFound", fmt.Sprintf("referenced Layer2Attachment %q not found", *bp.Spec.Ref.AttachmentRef)
 		}
+		if len(bp.Spec.Ref.NetworkRefs) == 0 {
+			return metav1.ConditionFalse, "NetworkRefsMissing", "listenRange mode requires at least one networkRef"
+		}
 		for _, ref := range bp.Spec.Ref.NetworkRefs {
 			if _, ok := resolved.Networks[ref]; !ok {
 				return metav1.ConditionFalse, "NetworkNotFound", fmt.Sprintf("referenced Network %q not found", ref)
 			}
 		}
 	case nc.BGPPeeringModeLoopbackPeer:
+		if len(bp.Spec.Ref.InboundRefs) == 0 {
+			return metav1.ConditionFalse, "InboundRefsMissing", "loopbackPeer mode requires at least one inboundRef"
+		}
 		for _, ref := range bp.Spec.Ref.InboundRefs {
 			if !inboundExists(ref, resolved) {
 				return metav1.ConditionFalse, "InboundNotFound", fmt.Sprintf("referenced Inbound %q not found", ref)
 			}
 		}
+	default:
+		return metav1.ConditionFalse, "UnknownMode", fmt.Sprintf("unknown BGPPeering mode %q", bp.Spec.Mode)
 	}
 	return metav1.ConditionTrue, reasonAllResolved, msgAllResolved
 }

--- a/pkg/reconciler/intent/status/status.go
+++ b/pkg/reconciler/intent/status/status.go
@@ -142,6 +142,9 @@ func (u *Updater) UpdateConditions(ctx context.Context, fetched *resolver.Fetche
 	if err := u.updateNodeAttachmentConditions(ctx, fetched, resolved, issues); err != nil {
 		return fmt.Errorf("nodeAttachment conditions: %w", err)
 	}
+	if err := u.updateBGPPeeringConditions(ctx, fetched, resolved, issues); err != nil {
+		return fmt.Errorf("bgpPeering conditions: %w", err)
+	}
 	return nil
 }
 
@@ -397,6 +400,84 @@ func (u *Updater) updateNodeAttachmentConditions(ctx context.Context, fetched *r
 		}
 	}
 	return nil
+}
+
+func (u *Updater) updateBGPPeeringConditions(ctx context.Context, fetched *resolver.FetchedResources, resolved *resolver.ResolvedData, issues map[string]ResourceIssue) error {
+	for i := range fetched.BGPPeerings {
+		bp := &fetched.BGPPeerings[i]
+		resolvedStatus, resolvedReason, resolvedMsg := checkBGPPeeringRefs(bp, resolved)
+
+		readyStatus := resolvedStatus
+		readyReason := resolvedReason
+		readyMsg := "BGPPeering is ready"
+		if resolvedStatus != metav1.ConditionTrue {
+			readyMsg = resolvedMsg
+		}
+		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "BGPPeering", bp.Name, readyStatus, readyReason, readyMsg)
+
+		if err := u.statusUpdateWithRetry(ctx, bp, func(obj client.Object) {
+			b := obj.(*nc.BGPPeering)
+			setCondition(&b.Status.Conditions, nc.ConditionTypeResolved, resolvedStatus, resolvedReason, resolvedMsg, b.Generation)
+			setCondition(&b.Status.Conditions, nc.ConditionTypeReady, readyStatus, readyReason, readyMsg, b.Generation)
+			b.Status.WorkloadASNumber = b.Spec.WorkloadAS
+			b.Status.ObservedGeneration = b.Generation
+		}); err != nil {
+			return fmt.Errorf("updating BGPPeering %q status: %w", bp.Name, err)
+		}
+	}
+	return nil
+}
+
+// checkBGPPeeringRefs validates that the references declared in a BGPPeering
+// spec resolve to existing intent resources. The checks are mode-specific and
+// mirror the requirements enforced by the BGPPeering builder:
+//   - listenRange requires attachmentRef (an existing Layer2Attachment) and
+//     networkRefs (each an existing Network).
+//   - loopbackPeer requires inboundRefs (each an existing Inbound).
+func checkBGPPeeringRefs(bp *nc.BGPPeering, resolved *resolver.ResolvedData) (condStatus metav1.ConditionStatus, reason, message string) {
+	switch bp.Spec.Mode {
+	case nc.BGPPeeringModeListenRange:
+		if bp.Spec.Ref.AttachmentRef == nil {
+			return metav1.ConditionFalse, "AttachmentRefMissing", "listenRange mode requires attachmentRef"
+		}
+		if !layer2AttachmentExists(*bp.Spec.Ref.AttachmentRef, resolved) {
+			return metav1.ConditionFalse, "AttachmentNotFound", fmt.Sprintf("referenced Layer2Attachment %q not found", *bp.Spec.Ref.AttachmentRef)
+		}
+		for _, ref := range bp.Spec.Ref.NetworkRefs {
+			if _, ok := resolved.Networks[ref]; !ok {
+				return metav1.ConditionFalse, "NetworkNotFound", fmt.Sprintf("referenced Network %q not found", ref)
+			}
+		}
+	case nc.BGPPeeringModeLoopbackPeer:
+		for _, ref := range bp.Spec.Ref.InboundRefs {
+			if !inboundExists(ref, resolved) {
+				return metav1.ConditionFalse, "InboundNotFound", fmt.Sprintf("referenced Inbound %q not found", ref)
+			}
+		}
+	}
+	return metav1.ConditionTrue, reasonAllResolved, msgAllResolved
+}
+
+// layer2AttachmentExists reports whether a Layer2Attachment with the given name
+// is present in the resolved data.
+func layer2AttachmentExists(name string, resolved *resolver.ResolvedData) bool {
+	for i := range resolved.Layer2Attachments {
+		if resolved.Layer2Attachments[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// inboundExists reports whether an Inbound with the given name is present in the
+// resolved data.
+func inboundExists(name string, resolved *resolver.ResolvedData) bool {
+	for i := range resolved.Inbounds {
+		if resolved.Inbounds[i].Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // checkNetworkRef checks if a networkRef resolves to an existing Network.

--- a/pkg/reconciler/intent/status/status.go
+++ b/pkg/reconciler/intent/status/status.go
@@ -45,19 +45,22 @@ type ResourceIssue struct {
 	Message string
 }
 
-// IssueKey builds the map key used to look up a ResourceIssue by kind and name.
-func IssueKey(kind, name string) string {
-	return kind + "/" + name
+// IssueKey builds the map key used to look up a ResourceIssue by kind,
+// namespace and name. Namespace is part of the key because intent CRDs are
+// namespaced and the reconciler may run cluster-wide, so name alone is not
+// unique across namespaces.
+func IssueKey(kind, namespace, name string) string {
+	return kind + "/" + namespace + "/" + name
 }
 
 // applyBuildIssue forces Ready=False (with the issue's reason/message) when the
 // resource has a recorded build issue; otherwise the inputs are returned
 // unchanged. The Resolved condition is left untouched — references may have
 // resolved fine while the build still failed for another reason.
-func applyBuildIssue(issues map[string]ResourceIssue, kind, name string,
+func applyBuildIssue(issues map[string]ResourceIssue, kind, namespace, name string,
 	status metav1.ConditionStatus, reason, message string,
 ) (readyStatus metav1.ConditionStatus, readyReason, readyMessage string) {
-	if issue, ok := issues[IssueKey(kind, name)]; ok {
+	if issue, ok := issues[IssueKey(kind, namespace, name)]; ok {
 		return metav1.ConditionFalse, issue.Reason, issue.Message
 	}
 	return status, reason, message
@@ -109,7 +112,7 @@ func (u *Updater) statusUpdateWithRetry(ctx context.Context, obj client.Object, 
 }
 
 // UpdateConditions sets Ready/Resolved conditions on intent CRDs. The issues
-// map (keyed by IssueKey(kind, name)) carries per-resource build failures so
+// map (keyed by IssueKey(kind, namespace, name)) carries per-resource build failures so
 // resources skipped during the build phase surface Ready=False.
 func (u *Updater) UpdateConditions(ctx context.Context, fetched *resolver.FetchedResources, resolved *resolver.ResolvedData, issues map[string]ResourceIssue) error {
 	if err := u.updateVRFConditions(ctx, fetched); err != nil {
@@ -222,7 +225,7 @@ func (u *Updater) updateInboundConditions(ctx context.Context, fetched *resolver
 		if resolvedStatus != metav1.ConditionTrue {
 			readyMsg = resolvedMsg
 		}
-		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "Inbound", inb.Name, readyStatus, readyReason, readyMsg)
+		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "Inbound", inb.Namespace, inb.Name, readyStatus, readyReason, readyMsg)
 
 		if err := u.statusUpdateWithRetry(ctx, inb, func(obj client.Object) {
 			in := obj.(*nc.Inbound)
@@ -247,7 +250,7 @@ func (u *Updater) updateOutboundConditions(ctx context.Context, fetched *resolve
 		if resolvedStatus != metav1.ConditionTrue {
 			readyMsg = resolvedMsg
 		}
-		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "Outbound", outb.Name, readyStatus, readyReason, readyMsg)
+		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "Outbound", outb.Namespace, outb.Name, readyStatus, readyReason, readyMsg)
 
 		if err := u.statusUpdateWithRetry(ctx, outb, func(obj client.Object) {
 			o := obj.(*nc.Outbound)
@@ -272,7 +275,7 @@ func (u *Updater) updateLayer2AttachmentConditions(ctx context.Context, fetched 
 		if resolvedStatus != metav1.ConditionTrue {
 			readyMsg = resolvedMsg
 		}
-		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "Layer2Attachment", l2a.Name, readyStatus, readyReason, readyMsg)
+		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "Layer2Attachment", l2a.Namespace, l2a.Name, readyStatus, readyReason, readyMsg)
 
 		effIfName := effectiveInterfaceName(l2a, resolved)
 
@@ -300,7 +303,7 @@ func (u *Updater) updatePodNetworkConditions(ctx context.Context, fetched *resol
 		if resolvedStatus != metav1.ConditionTrue {
 			readyMsg = resolvedMsg
 		}
-		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "PodNetwork", pn.Name, readyStatus, readyReason, readyMsg)
+		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "PodNetwork", pn.Namespace, pn.Name, readyStatus, readyReason, readyMsg)
 
 		if err := u.statusUpdateWithRetry(ctx, pn, func(obj client.Object) {
 			p := obj.(*nc.PodNetwork)
@@ -317,7 +320,7 @@ func (u *Updater) updatePodNetworkConditions(ctx context.Context, fetched *resol
 func (u *Updater) updateCollectorConditions(ctx context.Context, fetched *resolver.FetchedResources, issues map[string]ResourceIssue) error {
 	for i := range fetched.Collectors {
 		col := &fetched.Collectors[i]
-		readyStatus, readyReason, readyMsg := applyBuildIssue(issues, "Collector", col.Name,
+		readyStatus, readyReason, readyMsg := applyBuildIssue(issues, "Collector", col.Namespace, col.Name,
 			metav1.ConditionTrue, "Ready", "Collector is ready")
 		if err := u.statusUpdateWithRetry(ctx, col, func(obj client.Object) {
 			c := obj.(*nc.Collector)
@@ -355,7 +358,7 @@ func (u *Updater) updateTrafficMirrorConditions(ctx context.Context, fetched *re
 		if resolvedStatus != metav1.ConditionTrue {
 			readyMsg = resolvedMsg
 		}
-		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "TrafficMirror", tm.Name, readyStatus, readyReason, readyMsg)
+		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "TrafficMirror", tm.Namespace, tm.Name, readyStatus, readyReason, readyMsg)
 
 		if err := u.statusUpdateWithRetry(ctx, tm, func(obj client.Object) {
 			t := obj.(*nc.TrafficMirror)
@@ -388,7 +391,7 @@ func (u *Updater) updateNodeAttachmentConditions(ctx context.Context, fetched *r
 		if resolvedStatus != metav1.ConditionTrue {
 			readyMsg = resolvedMsg
 		}
-		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "NodeAttachment", na.Name, readyStatus, readyReason, readyMsg)
+		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "NodeAttachment", na.Namespace, na.Name, readyStatus, readyReason, readyMsg)
 
 		if err := u.statusUpdateWithRetry(ctx, na, func(obj client.Object) {
 			n := obj.(*nc.NodeAttachment)
@@ -413,7 +416,7 @@ func (u *Updater) updateBGPPeeringConditions(ctx context.Context, fetched *resol
 		if resolvedStatus != metav1.ConditionTrue {
 			readyMsg = resolvedMsg
 		}
-		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "BGPPeering", bp.Name, readyStatus, readyReason, readyMsg)
+		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "BGPPeering", bp.Namespace, bp.Name, readyStatus, readyReason, readyMsg)
 
 		if err := u.statusUpdateWithRetry(ctx, bp, func(obj client.Object) {
 			b := obj.(*nc.BGPPeering)
@@ -428,9 +431,11 @@ func (u *Updater) updateBGPPeeringConditions(ctx context.Context, fetched *resol
 	return nil
 }
 
-// checkBGPPeeringRefs validates that the references declared in a BGPPeering
-// spec resolve to existing intent resources. The checks are mode-specific and
-// mirror the requirements enforced by the BGPPeering builder:
+// checkBGPPeeringRefs validates, for status reporting, that the references
+// declared in a BGPPeering spec point at intent resources that actually exist.
+// This drives the Resolved condition and is independent of the builder, which
+// silently skips unresolved networkRefs and does not consume inboundRefs at
+// all. The required references are mode-specific:
 //   - listenRange requires attachmentRef (an existing Layer2Attachment) and
 //     at least one networkRef (each an existing Network).
 //   - loopbackPeer requires at least one inboundRef (each an existing Inbound).

--- a/pkg/reconciler/intent/status/status_test.go
+++ b/pkg/reconciler/intent/status/status_test.go
@@ -140,6 +140,15 @@ func TestCheckBGPPeeringRefs(t *testing.T) {
 			wantReason: "NetworkNotFound",
 		},
 		{
+			name: "listenRange missing networkRefs",
+			spec: nc.BGPPeeringSpec{
+				Mode: nc.BGPPeeringModeListenRange,
+				Ref:  nc.BGPPeeringRef{AttachmentRef: &attachment},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "NetworkRefsMissing",
+		},
+		{
 			name: "loopbackPeer inbound resolves",
 			spec: nc.BGPPeeringSpec{
 				Mode: nc.BGPPeeringModeLoopbackPeer,
@@ -156,6 +165,32 @@ func TestCheckBGPPeeringRefs(t *testing.T) {
 			},
 			wantStatus: metav1.ConditionFalse,
 			wantReason: "InboundNotFound",
+		},
+		{
+			name: "loopbackPeer missing inboundRefs",
+			spec: nc.BGPPeeringSpec{
+				Mode: nc.BGPPeeringModeLoopbackPeer,
+				Ref:  nc.BGPPeeringRef{},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "InboundRefsMissing",
+		},
+		{
+			name: "unknown mode is not resolved",
+			spec: nc.BGPPeeringSpec{
+				Mode: nc.BGPPeeringMode("bogus"),
+				Ref:  nc.BGPPeeringRef{},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "UnknownMode",
+		},
+		{
+			name: "empty mode is not resolved",
+			spec: nc.BGPPeeringSpec{
+				Ref: nc.BGPPeeringRef{},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "UnknownMode",
 		},
 	}
 

--- a/pkg/reconciler/intent/status/status_test.go
+++ b/pkg/reconciler/intent/status/status_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
 	"github.com/telekom/das-schiff-network-operator/pkg/reconciler/intent/resolver"
@@ -81,3 +82,91 @@ func TestEffectiveInterfaceName(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckBGPPeeringRefs(t *testing.T) {
+	attachment := "l2a-be"
+	resolved := &resolver.ResolvedData{
+		Networks: map[string]*resolver.ResolvedNetwork{
+			"net-be": {Name: "net-be"},
+		},
+		Layer2Attachments: []nc.Layer2Attachment{
+			{ObjectMeta: metav1.ObjectMeta{Name: "l2a-be"}},
+		},
+		Inbounds: []nc.Inbound{
+			{ObjectMeta: metav1.ObjectMeta{Name: "inb-vip"}},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		spec       nc.BGPPeeringSpec
+		wantStatus metav1.ConditionStatus
+		wantReason string
+	}{
+		{
+			name: "listenRange all references resolve",
+			spec: nc.BGPPeeringSpec{
+				Mode: nc.BGPPeeringModeListenRange,
+				Ref:  nc.BGPPeeringRef{AttachmentRef: &attachment, NetworkRefs: []string{"net-be"}},
+			},
+			wantStatus: metav1.ConditionTrue,
+			wantReason: reasonAllResolved,
+		},
+		{
+			name: "listenRange missing attachmentRef",
+			spec: nc.BGPPeeringSpec{
+				Mode: nc.BGPPeeringModeListenRange,
+				Ref:  nc.BGPPeeringRef{NetworkRefs: []string{"net-be"}},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "AttachmentRefMissing",
+		},
+		{
+			name: "listenRange unknown attachment",
+			spec: nc.BGPPeeringSpec{
+				Mode: nc.BGPPeeringModeListenRange,
+				Ref:  nc.BGPPeeringRef{AttachmentRef: ptr("nope"), NetworkRefs: []string{"net-be"}},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "AttachmentNotFound",
+		},
+		{
+			name: "listenRange unknown network",
+			spec: nc.BGPPeeringSpec{
+				Mode: nc.BGPPeeringModeListenRange,
+				Ref:  nc.BGPPeeringRef{AttachmentRef: &attachment, NetworkRefs: []string{"missing"}},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "NetworkNotFound",
+		},
+		{
+			name: "loopbackPeer inbound resolves",
+			spec: nc.BGPPeeringSpec{
+				Mode: nc.BGPPeeringModeLoopbackPeer,
+				Ref:  nc.BGPPeeringRef{InboundRefs: []string{"inb-vip"}},
+			},
+			wantStatus: metav1.ConditionTrue,
+			wantReason: reasonAllResolved,
+		},
+		{
+			name: "loopbackPeer unknown inbound",
+			spec: nc.BGPPeeringSpec{
+				Mode: nc.BGPPeeringModeLoopbackPeer,
+				Ref:  nc.BGPPeeringRef{InboundRefs: []string{"missing"}},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "InboundNotFound",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bp := &nc.BGPPeering{Spec: tc.spec}
+			gotStatus, gotReason, _ := checkBGPPeeringRefs(bp, resolved)
+			assert.Equal(t, tc.wantStatus, gotStatus)
+			assert.Equal(t, tc.wantReason, gotReason)
+		})
+	}
+}
+
+func ptr(s string) *string { return &s }


### PR DESCRIPTION
## Problem

BGPPeerings never reported `ready` status or conditions.

The intent `BGPPeering` CRD (`api/v1alpha1/network-connector/bgppeering_types.go`) declares a full `Status.Conditions` field **and** a `Ready` printcolumn — exactly like its sibling intent CRDs (VRF, Network, Inbound, Layer2Attachment, …). But the status updater in `pkg/reconciler/intent/status/status.go` had per-kind handlers for 10 sibling CRDs and **omitted BGPPeering entirely**.

As a consequence:
- BGPPeerings never got `Ready`/`Resolved` conditions (the `Ready` printcolumn was always empty).
- Build failures reported by the BGPPeering builder via `reportSkip(ctx, "BGPPeering", …)` were collected into `issuesMap` (reconciler.go:191) but, with no consumer calling `applyBuildIssue`, were **silently dropped**.

## Fix

- Register `updateBGPPeeringConditions` in the `UpdateConditions` dispatcher.
- Add `updateBGPPeeringConditions`, which sets `Resolved`/`Ready` conditions, populates `Status.WorkloadASNumber` and `Status.ObservedGeneration`, and consumes build issues through the existing `applyBuildIssue` path — matching the sibling-CRD pattern.
- Add `checkBGPPeeringRefs` (+ `layer2AttachmentExists`/`inboundExists` helpers) validating references per mode:
  - `listenRange`: requires an existing `attachmentRef` (Layer2Attachment) and existing `networkRefs`.
  - `loopbackPeer`: requires existing `inboundRefs`.

RBAC for `bgppeerings/status` was already present (intent_controller.go:62), so no change there.

## Testing

- Added `TestCheckBGPPeeringRefs` covering resolve/not-found cases for both modes.
- `go test ./pkg/reconciler/intent/status/...` passes.
- `golangci-lint run ./pkg/reconciler/intent/...` → 0 issues.

## Notes

There are two separate `BGPPeering` types. This targets the intent (`network-connector`) one, which has the conditions schema. The legacy `api/v1alpha1` `BGPPeering` has an intentionally empty status (like legacy VRFRouteConfiguration/Layer2NetworkConfiguration) and is out of scope.