### PR TITLE
feat(sync): mirror Ready/Resolved conditions from workload to management

### DIFF
--- a/cmd/network-sync/main.go
+++ b/cmd/network-sync/main.go
@@ -101,6 +101,7 @@ func main() {
 		Remotes:         remotes,
 		RemoteNamespace: remoteNamespace,
 		IPAMAllocator:   ipam.NewAllocator(mgr.GetClient(), mgr.GetLogger()),
+		Recorder:        mgr.GetEventRecorderFor("network-sync"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Sync")
 		os.Exit(1)

--- a/controllers/sync/status_back_test.go
+++ b/controllers/sync/status_back_test.go
@@ -2,11 +2,14 @@ package sync
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -278,42 +281,59 @@ func TestReconcileStatusBackDoesNotWipeAddresses(t *testing.T) {
 	}
 }
 
-// TestReconcileSkipsStatusBackForMultipleRemotes verifies that with more than
-// one workload cluster in the namespace, status sync-back is skipped (we cannot
-// attribute a single status) while forward sync still runs.
-func TestReconcileSkipsStatusBackForMultipleRemotes(t *testing.T) {
+// TestReconcileBlocksNamespaceWithMultipleRemotes verifies that a namespace
+// mapping to more than one workload cluster is refused entirely: no forward sync
+// happens, every intent resource is marked Ready=False/MultipleWorkloadClusters,
+// and a Warning event is emitted.
+func TestReconcileBlocksNamespaceWithMultipleRemotes(t *testing.T) {
 	vrf := &nc.VRF{
 		ObjectMeta: metav1.ObjectMeta{Name: "vrf-m2m", Namespace: "test-cluster"},
 		Spec:       nc.VRFSpec{VRF: "m2m", VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
 	}
-	remoteA := &nc.VRF{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vrf-m2m",
-			Namespace: testRemoteNamespace,
-			Labels:    map[string]string{labelManagedBy: labelManagedByValue},
-		},
-		Spec:   nc.VRFSpec{VRF: "m2m", VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
-		Status: nc.VRFStatus{Conditions: []metav1.Condition{readyCondition(metav1.ConditionTrue, 0)}},
-	}
 
-	sc, _ := newFakeSyncControllerAllStatus([]client.Object{vrf}, []client.Object{remoteA})
-	// Register a second remote in the same namespace.
+	// Two empty remotes in the same namespace; neither must receive the VRF.
+	remoteA := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+	sc, _ := newFakeSyncControllerAllStatus([]client.Object{vrf}, nil)
+	sc.Remotes.clients[types.NamespacedName{Namespace: "test-cluster", Name: "test-cluster"}] = remoteA
 	sc.Remotes.clients[types.NamespacedName{Namespace: "test-cluster", Name: "second"}] =
 		fake.NewClientBuilder().WithScheme(testScheme()).Build()
+	recorder := record.NewFakeRecorder(10)
+	sc.Recorder = recorder
 
 	ctx := context.Background()
-	if _, err := sc.Reconcile(ctx, ctrl.Request{
+	_, err := sc.Reconcile(ctx, ctrl.Request{
 		NamespacedName: types.NamespacedName{Namespace: "test-cluster", Name: "sync"},
-	}); err != nil {
-		t.Fatalf("Reconcile failed: %v", err)
+	})
+	// The error is returned so the controller's rate limiter applies exponential
+	// backoff while the misconfiguration persists.
+	if !errors.Is(err, errMultipleWorkloadClusters) {
+		t.Fatalf("expected errMultipleWorkloadClusters, got %v", err)
 	}
 
+	// No forward sync: the VRF must not have been created on either remote.
+	remoteVRF := &nc.VRF{}
+	if err := remoteA.Get(ctx, types.NamespacedName{Namespace: testRemoteNamespace, Name: "vrf-m2m"}, remoteVRF); err == nil {
+		t.Error("VRF was forward-synced to a remote despite the namespace being blocked")
+	}
+
+	// The mgmt VRF must be marked not-ready with the block reason.
 	got := &nc.VRF{}
 	if err := sc.Client.Get(ctx, types.NamespacedName{Namespace: "test-cluster", Name: "vrf-m2m"}, got); err != nil {
 		t.Fatalf("Get mgmt VRF: %v", err)
 	}
-	if findCondition(got.Status.Conditions, nc.ConditionTypeReady) != nil {
-		t.Errorf("status sync-back should be skipped with multiple remotes, but a Ready condition was mirrored: %+v", got.Status.Conditions)
+	cond := findCondition(got.Status.Conditions, nc.ConditionTypeReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "MultipleWorkloadClusters" {
+		t.Fatalf("expected Ready=False/MultipleWorkloadClusters, got %+v", got.Status.Conditions)
+	}
+
+	// A Warning event must have been emitted.
+	select {
+	case e := <-recorder.Events:
+		if !strings.Contains(e, "MultipleWorkloadClusters") {
+			t.Errorf("unexpected event %q", e)
+		}
+	default:
+		t.Error("expected a Warning event for the multiple-workload-cluster block")
 	}
 }
 

--- a/controllers/sync/status_back_test.go
+++ b/controllers/sync/status_back_test.go
@@ -1,0 +1,327 @@
+package sync
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
+)
+
+// newFakeSyncControllerAllStatus builds a controller whose management client
+// registers every intent type as a status subresource, so status sync-back can
+// be exercised for any CRD (not just Inbound/Outbound).
+func newFakeSyncControllerAllStatus(mgmtObjs, remoteObjs []client.Object) (*Controller, client.Client) {
+	s := testScheme()
+
+	mgmtClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(mgmtObjs...).
+		WithStatusSubresource(
+			&nc.VRF{}, &nc.Network{}, &nc.Destination{}, &nc.Layer2Attachment{},
+			&nc.Inbound{}, &nc.Outbound{}, &nc.PodNetwork{}, &nc.BGPPeering{},
+			&nc.Collector{}, &nc.TrafficMirror{}, &nc.AnnouncementPolicy{},
+			&nc.NodeAttachment{}, &nc.InterfaceConfig{},
+		).
+		Build()
+
+	remoteClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(remoteObjs...).
+		Build()
+
+	remotes := NewRemoteClientManager(s, RemoteClientConfig{})
+	remotes.clients[types.NamespacedName{Namespace: "test-cluster", Name: "test-cluster"}] = remoteClient
+
+	return &Controller{
+		Client:  mgmtClient,
+		Scheme:  s,
+		Log:     zap.New(zap.UseDevMode(true)),
+		Remotes: remotes,
+	}, remoteClient
+}
+
+// readyCondition is a small helper for constructing test conditions.
+func readyCondition(status metav1.ConditionStatus, gen int64) metav1.Condition {
+	return metav1.Condition{
+		Type:               nc.ConditionTypeReady,
+		Status:             status,
+		Reason:             "Ready",
+		Message:            "VRF is ready",
+		ObservedGeneration: gen,
+	}
+}
+
+// TestDesiredMirroredConditionsCaughtUp verifies the allowlist and the
+// observedGeneration rewrite: only Ready/Resolved survive, off-allowlist types
+// are dropped, and each mirrored condition carries the management generation.
+func TestDesiredMirroredConditionsCaughtUp(t *testing.T) {
+	remote := []metav1.Condition{
+		{Type: nc.ConditionTypeReady, Status: metav1.ConditionTrue, Reason: "Ready", ObservedGeneration: 99},
+		{Type: nc.ConditionTypeResolved, Status: metav1.ConditionTrue, Reason: "AllResolved", ObservedGeneration: 99},
+		{Type: nc.ConditionTypeApplied, Status: metav1.ConditionTrue, Reason: "Applied", ObservedGeneration: 99},
+		{Type: nc.ConditionTypeInterfaceNotFound, Status: metav1.ConditionFalse, Reason: "x", ObservedGeneration: 99},
+	}
+
+	got := desiredMirroredConditions(remote, true, 7)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 mirrored conditions (Ready, Resolved), got %d: %+v", len(got), got)
+	}
+	for _, c := range got {
+		if c.Type != nc.ConditionTypeReady && c.Type != nc.ConditionTypeResolved {
+			t.Errorf("off-allowlist condition %q was mirrored", c.Type)
+		}
+		if c.ObservedGeneration != 7 {
+			t.Errorf("condition %q observedGeneration = %d, want mgmt gen 7", c.Type, c.ObservedGeneration)
+		}
+	}
+}
+
+// TestDesiredMirroredConditionsProgressing verifies that a workload that has not
+// caught up yields non-authoritative Ready=False/Progressing and
+// Resolved=Unknown/Progressing conditions, never a stale Ready=True or
+// Resolved=True from the workload.
+func TestDesiredMirroredConditionsProgressing(t *testing.T) {
+	remote := []metav1.Condition{
+		{Type: nc.ConditionTypeReady, Status: metav1.ConditionTrue, Reason: "Ready", ObservedGeneration: 3},
+		{Type: nc.ConditionTypeResolved, Status: metav1.ConditionTrue, Reason: "AllResolved", ObservedGeneration: 3},
+	}
+
+	got := desiredMirroredConditions(remote, false, 5)
+
+	if len(got) != 2 {
+		t.Fatalf("expected Ready+Resolved Progressing conditions, got %d: %+v", len(got), got)
+	}
+	ready := findCondition(got, nc.ConditionTypeReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != "Progressing" {
+		t.Errorf("expected Ready=False/Progressing, got %+v", ready)
+	}
+	resolved := findCondition(got, nc.ConditionTypeResolved)
+	if resolved == nil || resolved.Status != metav1.ConditionUnknown || resolved.Reason != "Progressing" {
+		t.Errorf("expected Resolved=Unknown/Progressing, got %+v", resolved)
+	}
+	for _, c := range got {
+		if c.ObservedGeneration != 5 {
+			t.Errorf("condition %q observedGeneration = %d, want mgmt gen 5", c.Type, c.ObservedGeneration)
+		}
+	}
+}
+
+// TestWorkloadCaughtUp exercises the two gates: the source-generation annotation
+// must match the current management generation, and the workload must have
+// observed its own current spec.
+func TestWorkloadCaughtUp(t *testing.T) {
+	makeRemote := func(sourceGen string, gen, observed int64) *nc.VRF {
+		return &nc.VRF{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "vrf",
+				Generation:  gen,
+				Annotations: map[string]string{annotationSourceGeneration: sourceGen},
+			},
+			Status: nc.VRFStatus{ObservedGeneration: observed},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		remote  *nc.VRF
+		mgmtGen int64
+		want    bool
+	}{
+		{"caught up", makeRemote("4", 2, 2), 4, true},
+		{"annotation stale", makeRemote("3", 2, 2), 4, false},
+		{"workload lagging", makeRemote("4", 2, 1), 4, false},
+		{"annotation missing", &nc.VRF{ObjectMeta: metav1.ObjectMeta{Name: "vrf"}}, 4, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := workloadCaughtUp(tc.remote, tc.mgmtGen); got != tc.want {
+				t.Errorf("workloadCaughtUp = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStatusConditionsPtr verifies the reflection helper returns a live pointer
+// for intent CRDs and nil for types without a status.conditions field.
+func TestStatusConditionsPtr(t *testing.T) {
+	vrf := &nc.VRF{}
+	ptr := statusConditionsPtr(vrf)
+	if ptr == nil {
+		t.Fatal("expected non-nil conditions pointer for VRF")
+	}
+	*ptr = append(*ptr, readyCondition(metav1.ConditionTrue, 1))
+	if len(vrf.Status.Conditions) != 1 {
+		t.Errorf("pointer is not live: VRF conditions = %d", len(vrf.Status.Conditions))
+	}
+
+	if statusConditionsPtr(&corev1.Secret{}) != nil {
+		t.Error("expected nil conditions pointer for Secret")
+	}
+}
+
+// TestStatusObservedGeneration verifies the reflection reader.
+func TestStatusObservedGeneration(t *testing.T) {
+	vrf := &nc.VRF{Status: nc.VRFStatus{ObservedGeneration: 12}}
+	got, ok := statusObservedGeneration(vrf)
+	if !ok || got != 12 {
+		t.Errorf("statusObservedGeneration(VRF) = %d, %v; want 12, true", got, ok)
+	}
+
+	if _, ok := statusObservedGeneration(&corev1.Secret{}); ok {
+		t.Error("expected ok=false for Secret (no observedGeneration field)")
+	}
+}
+
+// TestReconcileMirrorsWorkloadReadyBack is the happy-path integration test: a
+// workload VRF that is Ready and caught up has its Ready condition mirrored onto
+// the management VRF after Reconcile.
+func TestReconcileMirrorsWorkloadReadyBack(t *testing.T) {
+	vrf := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{Name: "vrf-m2m", Namespace: "test-cluster"},
+		Spec:       nc.VRFSpec{VRF: "m2m", VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+	}
+	// Workload copy: managed by us, already reconciled and Ready. source-generation
+	// is stamped by the forward pass during Reconcile, so it does not need to be
+	// pre-set here; observedGeneration==generation makes it caught up.
+	remote := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vrf-m2m",
+			Namespace: testRemoteNamespace,
+			Labels:    map[string]string{labelManagedBy: labelManagedByValue},
+		},
+		Spec: nc.VRFSpec{VRF: "m2m", VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+		Status: nc.VRFStatus{
+			ObservedGeneration: 0,
+			Conditions:         []metav1.Condition{readyCondition(metav1.ConditionTrue, 0)},
+		},
+	}
+
+	sc, _ := newFakeSyncControllerAllStatus([]client.Object{vrf}, []client.Object{remote})
+	ctx := context.Background()
+
+	if _, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "test-cluster", Name: "sync"},
+	}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	got := &nc.VRF{}
+	if err := sc.Client.Get(ctx, types.NamespacedName{Namespace: "test-cluster", Name: "vrf-m2m"}, got); err != nil {
+		t.Fatalf("Get mgmt VRF: %v", err)
+	}
+	cond := findCondition(got.Status.Conditions, nc.ConditionTypeReady)
+	if cond == nil {
+		t.Fatalf("Ready condition was not mirrored back onto mgmt VRF: %+v", got.Status.Conditions)
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("mirrored Ready = %q, want True", cond.Status)
+	}
+	if cond.ObservedGeneration != got.Generation {
+		t.Errorf("mirrored observedGeneration = %d, want mgmt generation %d", cond.ObservedGeneration, got.Generation)
+	}
+}
+
+// TestReconcileStatusBackDoesNotWipeAddresses is the brick regression: an empty
+// workload status must never overwrite the management-owned status.addresses
+// (which feed the workload spec via IPAM promotion). Addresses and spec must
+// survive a status sync-back.
+func TestReconcileStatusBackDoesNotWipeAddresses(t *testing.T) {
+	count := int32(2)
+	inbound := &nc.Inbound{
+		ObjectMeta: metav1.ObjectMeta{Name: "ib-test", Namespace: "test-cluster"},
+		Spec: nc.InboundSpec{
+			NetworkRef:    "net-vlan501",
+			Count:         &count,
+			Advertisement: nc.AdvertisementConfig{Type: "bgp"},
+		},
+		Status: nc.InboundStatus{
+			Addresses: &nc.AddressAllocation{IPv4: []string{"10.250.0.2", "10.250.0.3"}},
+		},
+	}
+	// Workload copy with an EMPTY status (no addresses, no conditions).
+	remote := &nc.Inbound{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ib-test",
+			Namespace: testRemoteNamespace,
+			Labels:    map[string]string{labelManagedBy: labelManagedByValue},
+		},
+		Spec: nc.InboundSpec{NetworkRef: "net-vlan501", Advertisement: nc.AdvertisementConfig{Type: "bgp"}},
+	}
+
+	sc, _ := newFakeSyncControllerAllStatus([]client.Object{inbound}, []client.Object{remote})
+	ctx := context.Background()
+
+	if _, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "test-cluster", Name: "sync"},
+	}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	got := &nc.Inbound{}
+	if err := sc.Client.Get(ctx, types.NamespacedName{Namespace: "test-cluster", Name: "ib-test"}, got); err != nil {
+		t.Fatalf("Get mgmt Inbound: %v", err)
+	}
+	if got.Status.Addresses == nil || len(got.Status.Addresses.IPv4) != 2 {
+		t.Fatalf("mgmt status.addresses was clobbered by status sync-back: %+v", got.Status.Addresses)
+	}
+	if got.Spec.NetworkRef != "net-vlan501" {
+		t.Errorf("mgmt spec was mutated: %+v", got.Spec)
+	}
+}
+
+// TestReconcileSkipsStatusBackForMultipleRemotes verifies that with more than
+// one workload cluster in the namespace, status sync-back is skipped (we cannot
+// attribute a single status) while forward sync still runs.
+func TestReconcileSkipsStatusBackForMultipleRemotes(t *testing.T) {
+	vrf := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{Name: "vrf-m2m", Namespace: "test-cluster"},
+		Spec:       nc.VRFSpec{VRF: "m2m", VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+	}
+	remoteA := &nc.VRF{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vrf-m2m",
+			Namespace: testRemoteNamespace,
+			Labels:    map[string]string{labelManagedBy: labelManagedByValue},
+		},
+		Spec:   nc.VRFSpec{VRF: "m2m", VNI: ptrInt32(2002026), RouteTarget: ptrString("65188:2026")},
+		Status: nc.VRFStatus{Conditions: []metav1.Condition{readyCondition(metav1.ConditionTrue, 0)}},
+	}
+
+	sc, _ := newFakeSyncControllerAllStatus([]client.Object{vrf}, []client.Object{remoteA})
+	// Register a second remote in the same namespace.
+	sc.Remotes.clients[types.NamespacedName{Namespace: "test-cluster", Name: "second"}] =
+		fake.NewClientBuilder().WithScheme(testScheme()).Build()
+
+	ctx := context.Background()
+	if _, err := sc.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "test-cluster", Name: "sync"},
+	}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	got := &nc.VRF{}
+	if err := sc.Client.Get(ctx, types.NamespacedName{Namespace: "test-cluster", Name: "vrf-m2m"}, got); err != nil {
+		t.Fatalf("Get mgmt VRF: %v", err)
+	}
+	if findCondition(got.Status.Conditions, nc.ConditionTypeReady) != nil {
+		t.Errorf("status sync-back should be skipped with multiple remotes, but a Ready condition was mirrored: %+v", got.Status.Conditions)
+	}
+}
+
+func findCondition(conds []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conds {
+		if conds[i].Type == condType {
+			return &conds[i]
+		}
+	}
+	return nil
+}

--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -6,12 +6,14 @@ import (
 	"net"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -32,6 +34,14 @@ const (
 	labelManagedBy      = "network-sync.telekom.com/managed-by"
 	labelManagedByValue = "network-sync"
 	annotationSourceNS  = "network-sync.telekom.com/source-namespace"
+
+	// annotationSourceGeneration records the management object's
+	// metadata.generation that the remote object's spec was built from. Status
+	// sync-back (workload → management) uses it to decide whether the workload
+	// status it reads back corresponds to the intent we last pushed: the remote
+	// copy must carry the current management generation before its Ready/Resolved
+	// conditions are treated as authoritative.
+	annotationSourceGeneration = "network-sync.telekom.com/source-generation"
 
 	// annotationManagedLabels and annotationManagedAnnotations record the label
 	// and annotation keys this controller propagated on the last sync. They let a
@@ -57,6 +67,24 @@ var gitOpsKeyPrefixes = []string{
 }
 
 const syncRequeueInterval = 10 * time.Second
+
+// statusPollInterval is how often Reconcile requeues on success so that status
+// sync-back (workload → management) is refreshed. The controller only watches
+// management-cluster intent CRDs; workload-side status changes do not wake it,
+// so status is pulled on this cadence instead.
+const statusPollInterval = 30 * time.Second
+
+// mirroredConditionTypes is the allowlist of status condition types copied from
+// the workload cluster back onto the management object. Everything else in
+// status — addresses, interfaceName, workloadASNumber, observedGeneration — is
+// deliberately NOT mirrored: those fields are either owned by the management
+// cluster or feed the workload spec (mgmt status.addresses → workload
+// spec.addresses), so copying an empty or lagging workload value back would
+// corrupt the management source of truth.
+var mirroredConditionTypes = map[string]bool{
+	nc.ConditionTypeReady:    true,
+	nc.ConditionTypeResolved: true,
+}
 
 // Controller watches intent CRDs on the management cluster and syncs them
 // to workload clusters via the RemoteClientManager.
@@ -139,6 +167,12 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
+	// A single workload cluster per namespace is required for status sync-back:
+	// with several, one management object cannot carry a single authoritative
+	// status, so we mirror nothing back (forward sync below still fans out to
+	// every workload cluster).
+	singleRemote := len(remoteClients) == 1
+
 	// List and sync every intent CRD type in this namespace.
 	for _, list := range intentCRDLists() {
 		if err := r.Client.List(ctx, list, client.InNamespace(req.Namespace)); err != nil {
@@ -148,6 +182,15 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		for i := range items {
 			for _, remoteClient := range remoteClients {
 				if err := r.syncObject(ctx, log, remoteClient, items[i]); err != nil {
+					return ctrl.Result{}, err
+				}
+			}
+			// Mirror Ready/Resolved conditions from the workload copy back onto
+			// the management object, reusing the object already listed above so
+			// status sync-back adds no extra LIST traffic. Objects mid-deletion
+			// are handled by the forward path and are not resurrected.
+			if singleRemote && items[i].GetDeletionTimestamp().IsZero() {
+				if err := r.syncObjectStatusBack(ctx, log, remoteClients[0], items[i]); err != nil {
 					return ctrl.Result{}, err
 				}
 			}
@@ -163,6 +206,15 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
+	// Requeue only when status sync-back is active, so workload status changes
+	// are pulled back periodically (the controller does not watch workload
+	// clusters). With multiple workload clusters there is nothing to poll back,
+	// so a change-driven reconcile is enough and we avoid needless full resyncs.
+	if singleRemote {
+		return ctrl.Result{RequeueAfter: statusPollInterval}, nil
+	}
+	log.V(1).Info("Multiple workload clusters in namespace; skipping status sync-back",
+		"count", len(remoteClients))
 	return ctrl.Result{}, nil
 }
 
@@ -238,6 +290,199 @@ func (r *Controller) syncObject(ctx context.Context, log logr.Logger, remoteClie
 	return r.applyRemote(ctx, remoteClient, remote)
 }
 
+// syncObjectStatusBack reads the workload copy of a single intent object and
+// mirrors its Ready/Resolved conditions back onto the management object. It is
+// the reverse of the spec sync — workload → management — and is deliberately
+// restricted to mirroredConditionTypes so a lagging or empty workload status can
+// never overwrite management-owned status fields (addresses, interfaceName,
+// workloadASNumber) that feed the workload spec.
+func (r *Controller) syncObjectStatusBack(ctx context.Context, log logr.Logger, remoteClient client.Client, mgmtObj client.Object) error {
+	kind := mgmtObj.GetObjectKind().GroupVersionKind().Kind
+	name := mgmtObj.GetName()
+
+	mgmtConds := statusConditionsPtr(mgmtObj)
+	if mgmtConds == nil {
+		// Type carries no status.conditions field; nothing to mirror.
+		return nil
+	}
+
+	remote, ok := mgmtObj.DeepCopyObject().(client.Object)
+	if !ok {
+		return fmt.Errorf("DeepCopyObject did not return client.Object for %s/%s", mgmtObj.GetNamespace(), name)
+	}
+	err := remoteClient.Get(ctx, types.NamespacedName{Namespace: r.remoteNamespace(), Name: name}, remote)
+	if apierrors.IsNotFound(err) {
+		// Not synced yet; the forward pass will create it. Nothing to mirror.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("getting remote %s/%s for status sync-back: %w", kind, name, err)
+	}
+
+	remoteConds := statusConditionsPtr(remote)
+	if remoteConds == nil {
+		return nil
+	}
+
+	caughtUp := workloadCaughtUp(remote, mgmtObj.GetGeneration())
+	desired := desiredMirroredConditions(*remoteConds, caughtUp, mgmtObj.GetGeneration())
+	if len(desired) == 0 {
+		return nil
+	}
+
+	if err := r.writeMirroredConditions(ctx, mgmtObj, desired); err != nil {
+		return err
+	}
+	log.V(1).Info("Mirrored workload status back to management", "kind", kind, "name", name, "caughtUp", caughtUp)
+	return nil
+}
+
+// writeMirroredConditions applies the desired conditions onto obj's status and
+// persists them via the status subresource, retrying on optimistic-lock
+// conflicts. Only the status subresource is written, so spec is never touched.
+// SetStatusCondition is a no-op when a condition is unchanged, so a stable
+// workload status produces no writes and no lastTransitionTime flapping.
+func (r *Controller) writeMirroredConditions(ctx context.Context, obj client.Object, desired []metav1.Condition) error {
+	const maxRetries = 3
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		conds := statusConditionsPtr(obj)
+		if conds == nil {
+			return nil
+		}
+		changed := false
+		for i := range desired {
+			if apimeta.SetStatusCondition(conds, desired[i]) {
+				changed = true
+			}
+		}
+		if !changed {
+			return nil
+		}
+		err := r.Client.Status().Update(ctx, obj)
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsConflict(err) {
+			return fmt.Errorf("updating status for %s/%s: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err)
+		}
+		// Conflict: re-fetch to pick up the current resourceVersion and retry.
+		fresh, ok := obj.DeepCopyObject().(client.Object)
+		if !ok {
+			return fmt.Errorf("DeepCopyObject did not return client.Object for %s", obj.GetName())
+		}
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(obj), fresh); err != nil {
+			return fmt.Errorf("re-fetching %s/%s for status sync-back: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err)
+		}
+		obj = fresh
+	}
+	return fmt.Errorf("status sync-back conflict after %d retries for %s/%s", maxRetries, obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
+}
+
+// desiredMirroredConditions filters the workload conditions down to the
+// allowlist and rewrites each condition's observedGeneration to the management
+// object's generation (the workload records it against its own, unrelated
+// generation). When the workload has not yet caught up to the intent we pushed,
+// every mirrored condition is reported as non-authoritative for the current
+// generation instead of the stale workload value: Ready=False/Progressing and
+// Resolved=Unknown/Progressing. Downgrading both keeps them consistent with the
+// generation gate — otherwise a previously mirrored Resolved=True (with an old
+// observedGeneration) would linger while Ready is Progressing for a newer
+// generation.
+func desiredMirroredConditions(remoteConds []metav1.Condition, caughtUp bool, mgmtGen int64) []metav1.Condition {
+	if !caughtUp {
+		const msg = "Workload cluster has not yet observed the latest synced spec"
+		return []metav1.Condition{
+			{
+				Type:               nc.ConditionTypeReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             "Progressing",
+				Message:            msg,
+				ObservedGeneration: mgmtGen,
+			},
+			{
+				Type:               nc.ConditionTypeResolved,
+				Status:             metav1.ConditionUnknown,
+				Reason:             "Progressing",
+				Message:            msg,
+				ObservedGeneration: mgmtGen,
+			},
+		}
+	}
+
+	var out []metav1.Condition
+	for i := range remoteConds {
+		c := remoteConds[i]
+		if !mirroredConditionTypes[c.Type] {
+			continue
+		}
+		c.ObservedGeneration = mgmtGen
+		out = append(out, c)
+	}
+	return out
+}
+
+// workloadCaughtUp reports whether the workload copy's status reflects the
+// current management intent. Both must hold:
+//   - the remote object carries the spec built from the current management
+//     generation (source-generation annotation), and
+//   - the workload compiler has observed the remote's current spec
+//     (status.observedGeneration == metadata.generation on the remote).
+//
+// Until both are true the remote status is stale relative to the intent and
+// must not be mirrored as authoritative.
+func workloadCaughtUp(remote client.Object, mgmtGen int64) bool {
+	if remote.GetAnnotations()[annotationSourceGeneration] != strconv.FormatInt(mgmtGen, 10) {
+		return false
+	}
+	observed, ok := statusObservedGeneration(remote)
+	if !ok {
+		return false
+	}
+	return observed == remote.GetGeneration()
+}
+
+// statusConditionsPtr returns a pointer to obj's status.Conditions slice via
+// reflection, or nil if the object has no such field. This keeps status
+// sync-back generic across every intent CRD without a per-type switch, mirroring
+// the reflection approach used by overlayBody and extractItems.
+func statusConditionsPtr(obj client.Object) *[]metav1.Condition {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return nil
+	}
+	status := v.Elem().FieldByName("Status")
+	if !status.IsValid() {
+		return nil
+	}
+	conds := status.FieldByName("Conditions")
+	if !conds.IsValid() || !conds.CanAddr() {
+		return nil
+	}
+	ptr, ok := conds.Addr().Interface().(*[]metav1.Condition)
+	if !ok {
+		return nil
+	}
+	return ptr
+}
+
+// statusObservedGeneration reads obj's status.ObservedGeneration via reflection.
+// The bool is false when the object has no such int64 field.
+func statusObservedGeneration(obj client.Object) (int64, bool) {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return 0, false
+	}
+	status := v.Elem().FieldByName("Status")
+	if !status.IsValid() {
+		return 0, false
+	}
+	og := status.FieldByName("ObservedGeneration")
+	if !og.IsValid() || og.Kind() != reflect.Int64 {
+		return 0, false
+	}
+	return og.Int(), true
+}
+
 // buildRemoteObject creates the desired remote object from the mgmt-side source.
 func (r *Controller) buildRemoteObject(src client.Object, sourceNamespace string) client.Object {
 	dst, ok := src.DeepCopyObject().(client.Object)
@@ -268,6 +513,9 @@ func (r *Controller) buildRemoteObject(src client.Object, sourceNamespace string
 
 	annotations := stripGitOpsKeys(dst.GetAnnotations())
 	annotations[annotationSourceNS] = sourceNamespace
+	// Record the management generation this spec was built from so status
+	// sync-back can tell whether the workload has caught up to the current intent.
+	annotations[annotationSourceGeneration] = strconv.FormatInt(src.GetGeneration(), 10)
 	// Remove system annotations.
 	delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
 	dst.SetAnnotations(annotations)

--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -17,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -68,6 +70,13 @@ var gitOpsKeyPrefixes = []string{
 
 const syncRequeueInterval = 10 * time.Second
 
+// errMultipleWorkloadClusters is returned by Reconcile (and surfaced on the
+// intent resources as a condition + event) when a namespace resolves to more
+// than one workload cluster, which is a misconfiguration for the
+// one-cluster-per-namespace design. Returning it lets the controller's rate
+// limiter apply exponential backoff while the misconfiguration persists.
+var errMultipleWorkloadClusters = errors.New("namespace maps to multiple workload clusters")
+
 // statusPollInterval is how often Reconcile requeues on success so that status
 // sync-back (workload → management) is refreshed. The controller only watches
 // management-cluster intent CRDs; workload-side status changes do not wake it,
@@ -95,6 +104,7 @@ type Controller struct {
 	Remotes         *RemoteClientManager
 	RemoteNamespace string
 	IPAMAllocator   *ipam.Allocator
+	Recorder        record.EventRecorder
 }
 
 // intentCRDTypes returns fresh instances of all intent CRD types to sync.
@@ -157,6 +167,27 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// ClusterController hasn't set up a client (yet) — wait and retry.
 		return ctrl.Result{RequeueAfter: syncRequeueInterval}, nil
 	}
+	if len(remoteClients) > 1 {
+		// A namespace maps to exactly one workload cluster by design. More than
+		// one CAPI Cluster in the same namespace is a misconfiguration: syncing
+		// the same intent to several clusters would be ambiguous (duplicate
+		// forward writes, no single authoritative status to mirror back), so we
+		// refuse to process the namespace until it is resolved rather than act on
+		// a guess. Surface the block on every intent resource (condition + event)
+		// so it is visible in `kubectl get`, not only in the controller log.
+		if err := r.blockOnMultipleRemotes(ctx, req.Namespace, len(remoteClients)); err != nil {
+			return ctrl.Result{}, err
+		}
+		// Return the error so the controller's rate limiter applies exponential
+		// backoff instead of a tight fixed-interval requeue: nothing can change
+		// until the namespace maps to a single cluster again, and the condition +
+		// event already inform the user, so we must not busy-loop LISTing intent
+		// CRDs. The backoff resets automatically once a reconcile succeeds (i.e.
+		// once the misconfiguration is resolved).
+		return ctrl.Result{}, fmt.Errorf("%w: namespace %q maps to %d clusters",
+			errMultipleWorkloadClusters, req.Namespace, len(remoteClients))
+	}
+	remoteClient := remoteClients[0]
 
 	// Run IPAM allocation for count-mode Inbound/Outbound before syncing,
 	// so that promoteIPAMAddresses can copy status→spec for the remote copy.
@@ -167,12 +198,6 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	// A single workload cluster per namespace is required for status sync-back:
-	// with several, one management object cannot carry a single authoritative
-	// status, so we mirror nothing back (forward sync below still fans out to
-	// every workload cluster).
-	singleRemote := len(remoteClients) == 1
-
 	// List and sync every intent CRD type in this namespace.
 	for _, list := range intentCRDLists() {
 		if err := r.Client.List(ctx, list, client.InNamespace(req.Namespace)); err != nil {
@@ -180,17 +205,15 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 		items := extractItems(list)
 		for i := range items {
-			for _, remoteClient := range remoteClients {
-				if err := r.syncObject(ctx, log, remoteClient, items[i]); err != nil {
-					return ctrl.Result{}, err
-				}
+			if err := r.syncObject(ctx, log, remoteClient, items[i]); err != nil {
+				return ctrl.Result{}, err
 			}
 			// Mirror Ready/Resolved conditions from the workload copy back onto
 			// the management object, reusing the object already listed above so
 			// status sync-back adds no extra LIST traffic. Objects mid-deletion
 			// are handled by the forward path and are not resurrected.
-			if singleRemote && items[i].GetDeletionTimestamp().IsZero() {
-				if err := r.syncObjectStatusBack(ctx, log, remoteClients[0], items[i]); err != nil {
+			if items[i].GetDeletionTimestamp().IsZero() {
+				if err := r.syncObjectStatusBack(ctx, log, remoteClient, items[i]); err != nil {
 					return ctrl.Result{}, err
 				}
 			}
@@ -200,22 +223,13 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Sync Secrets referenced by BGPPeering.spec.authSecretRef into the remote
 	// namespace so the workload-side intent compiler can resolve the password
 	// without any cross-cluster Secret access.
-	for _, remoteClient := range remoteClients {
-		if err := r.syncBGPSecrets(ctx, log, remoteClient, req.Namespace); err != nil {
-			return ctrl.Result{}, err
-		}
+	if err := r.syncBGPSecrets(ctx, log, remoteClient, req.Namespace); err != nil {
+		return ctrl.Result{}, err
 	}
 
-	// Requeue only when status sync-back is active, so workload status changes
-	// are pulled back periodically (the controller does not watch workload
-	// clusters). With multiple workload clusters there is nothing to poll back,
-	// so a change-driven reconcile is enough and we avoid needless full resyncs.
-	if singleRemote {
-		return ctrl.Result{RequeueAfter: statusPollInterval}, nil
-	}
-	log.V(1).Info("Multiple workload clusters in namespace; skipping status sync-back",
-		"count", len(remoteClients))
-	return ctrl.Result{}, nil
+	// Requeue so workload status changes are pulled back periodically; the
+	// controller does not watch the workload clusters.
+	return ctrl.Result{RequeueAfter: statusPollInterval}, nil
 }
 
 // drainFinalizersForLostRemote walks every intent CRD type in the namespace and
@@ -330,24 +344,26 @@ func (r *Controller) syncObjectStatusBack(ctx context.Context, log logr.Logger, 
 		return nil
 	}
 
-	if err := r.writeMirroredConditions(ctx, mgmtObj, desired); err != nil {
+	if _, err := r.writeStatusConditions(ctx, mgmtObj, desired); err != nil {
 		return err
 	}
 	log.V(1).Info("Mirrored workload status back to management", "kind", kind, "name", name, "caughtUp", caughtUp)
 	return nil
 }
 
-// writeMirroredConditions applies the desired conditions onto obj's status and
+// writeStatusConditions applies the desired conditions onto obj's status and
 // persists them via the status subresource, retrying on optimistic-lock
 // conflicts. Only the status subresource is written, so spec is never touched.
 // SetStatusCondition is a no-op when a condition is unchanged, so a stable
-// workload status produces no writes and no lastTransitionTime flapping.
-func (r *Controller) writeMirroredConditions(ctx context.Context, obj client.Object, desired []metav1.Condition) error {
+// status produces no writes and no lastTransitionTime flapping; the returned
+// bool reports whether any condition actually transitioned (so callers can gate
+// side effects such as events on real changes).
+func (r *Controller) writeStatusConditions(ctx context.Context, obj client.Object, desired []metav1.Condition) (bool, error) {
 	const maxRetries = 3
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		conds := statusConditionsPtr(obj)
 		if conds == nil {
-			return nil
+			return false, nil
 		}
 		changed := false
 		for i := range desired {
@@ -356,26 +372,65 @@ func (r *Controller) writeMirroredConditions(ctx context.Context, obj client.Obj
 			}
 		}
 		if !changed {
-			return nil
+			return false, nil
 		}
 		err := r.Client.Status().Update(ctx, obj)
 		if err == nil {
-			return nil
+			return true, nil
 		}
 		if !apierrors.IsConflict(err) {
-			return fmt.Errorf("updating status for %s/%s: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err)
+			return false, fmt.Errorf("updating status for %s/%s: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err)
 		}
 		// Conflict: re-fetch to pick up the current resourceVersion and retry.
 		fresh, ok := obj.DeepCopyObject().(client.Object)
 		if !ok {
-			return fmt.Errorf("DeepCopyObject did not return client.Object for %s", obj.GetName())
+			return false, fmt.Errorf("DeepCopyObject did not return client.Object for %s", obj.GetName())
 		}
 		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(obj), fresh); err != nil {
-			return fmt.Errorf("re-fetching %s/%s for status sync-back: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err)
+			return false, fmt.Errorf("re-fetching %s/%s for status update: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err)
 		}
 		obj = fresh
 	}
-	return fmt.Errorf("status sync-back conflict after %d retries for %s/%s", maxRetries, obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
+	return false, fmt.Errorf("status update conflict after %d retries for %s/%s", maxRetries, obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
+}
+
+// blockOnMultipleRemotes surfaces the multiple-workload-cluster misconfiguration
+// on every intent resource in the namespace: it sets Ready=False (reason
+// MultipleWorkloadClusters) and emits a Warning event, so the block is
+// discoverable via `kubectl get`/`describe`, not only in the controller log.
+// Events fire only when the condition actually transitions, so a namespace held
+// in this state across periodic requeues does not spam the event stream.
+func (r *Controller) blockOnMultipleRemotes(ctx context.Context, namespace string, count int) error {
+	const reason = "MultipleWorkloadClusters"
+	message := fmt.Sprintf("Namespace maps to %d workload clusters; refusing to sync until exactly one remains", count)
+
+	for _, list := range intentCRDLists() {
+		if err := r.Client.List(ctx, list, client.InNamespace(namespace)); err != nil {
+			return fmt.Errorf("listing %T while blocking namespace: %w", list, err)
+		}
+		items := extractItems(list)
+		for i := range items {
+			obj := items[i]
+			if !obj.GetDeletionTimestamp().IsZero() {
+				continue
+			}
+			cond := metav1.Condition{
+				Type:               nc.ConditionTypeReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             reason,
+				Message:            message,
+				ObservedGeneration: obj.GetGeneration(),
+			}
+			changed, err := r.writeStatusConditions(ctx, obj, []metav1.Condition{cond})
+			if err != nil {
+				return err
+			}
+			if changed && r.Recorder != nil {
+				r.Recorder.Event(obj, corev1.EventTypeWarning, reason, message)
+			}
+		}
+	}
+	return nil
 }
 
 // desiredMirroredConditions filters the workload conditions down to the

--- a/controllers/sync/sync_controller_test.go
+++ b/controllers/sync/sync_controller_test.go
@@ -858,8 +858,9 @@ func TestSyncRecordsManagedKeysOnCreate(t *testing.T) {
 		t.Errorf("managed-labels tracking annotation = %q, want %q",
 			got.Annotations[annotationManagedLabels], wantLabelKeys)
 	}
-	if got.Annotations[annotationManagedAnnotations] != annotationSourceNS {
+	wantAnnKeys := annotationSourceGeneration + "," + annotationSourceNS
+	if got.Annotations[annotationManagedAnnotations] != wantAnnKeys {
 		t.Errorf("managed-annotations tracking annotation = %q, want %q",
-			got.Annotations[annotationManagedAnnotations], annotationSourceNS)
+			got.Annotations[annotationManagedAnnotations], wantAnnKeys)
 	}
 }

--- a/e2e/sync/rbac.yaml
+++ b/e2e/sync/rbac.yaml
@@ -35,12 +35,29 @@ rules:
   - interfaceconfigs
   - nodeattachments
   verbs: ["get", "list", "watch", "update", "patch"]
-# Read intent CRD status (for IPAM promotion)
+# Read intent CRD status (for IPAM promotion) and write it back (status
+# sync-back mirrors workload Ready/Resolved conditions onto the mgmt objects,
+# and marks resources when a namespace maps to multiple workload clusters).
 - apiGroups: ["network-connector.sylvaproject.org"]
   resources:
+  - vrfs/status
+  - networks/status
+  - destinations/status
+  - layer2attachments/status
   - inbounds/status
   - outbounds/status
-  verbs: ["get"]
+  - podnetworks/status
+  - bgppeerings/status
+  - collectors/status
+  - trafficmirrors/status
+  - announcementpolicies/status
+  - interfaceconfigs/status
+  - nodeattachments/status
+  verbs: ["get", "update", "patch"]
+# Emit events on intent resources (e.g. multiple-workload-cluster block)
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## What

Makes the **management cluster reflect whether synced intent actually converged on the workload cluster**, by mirroring the `Ready`/`Resolved` status conditions back from workload → management. Today the cross-cluster sync is one-directional and spec-only (management → workload); nothing surfaces workload readiness on the management side even though the RBAC/CRD scaffolding for it already exists. This PR fills that gap safely, and hardens the one-cluster-per-namespace assumption.

## Commits

1. **`feat(sync): mirror Ready/Resolved conditions from workload to management`** — the status sync-back pass.
2. **`feat(sync): refuse namespaces with multiple workload clusters; surface on resources`** — reject the misconfiguration instead of fanning out ambiguously.
3. **`fix(e2e): grant network-sync RBAC for status sync-back and events`** — align the hand-maintained e2e RBAC with the controller's needs.

## Design

### Status sync-back (workload → management)
- **Selective, not full-object.** Only `Ready`/`Resolved` conditions are mirrored back. Management-owned or spec-feeding status fields (`status.addresses`, `interfaceName`, `workloadASNumber`, `observedGeneration`) are **never** copied. This is the key safety property: `status.addresses` on mgmt feeds `spec.addresses` on the workload via IPAM promotion, so a blind status copy from a lagging/empty workload would wipe the allocation and push an empty spec (“brick”). The allowlist makes that impossible.
- **Cross-cluster generation gating.** `buildRemoteObject` stamps `network-sync.telekom.com/source-generation = <mgmt generation>` on the remote object. A workload condition is authoritative only when the remote carries the current mgmt generation **and** the workload has observed its own spec (`observedGeneration == generation`). Otherwise both conditions are reported as non-authoritative for the current generation (`Ready=False/Progressing`, `Resolved=Unknown/Progressing`) rather than a stale value. Mirrored conditions have `observedGeneration` rewritten to the **mgmt** generation so `status.observedGeneration`/`metadata.generation` comparisons behave on the management cluster.
- **No extra LIST traffic.** Status sync-back is folded into the forward list loop and mirrors conditions per-item using the objects already listed. Written via the status subresource only (spec never touched); `SetStatusCondition` no-ops when unchanged, so a stable status produces no writes and no `lastTransitionTime` flapping.
- **Polling.** Reconcile requeues (30s) so workload status is pulled back; the controller does not watch workload clusters.

### Multiple-workload-cluster guard
- A namespace maps to exactly one workload cluster by design. If it resolves to more than one CAPI Cluster, Reconcile **refuses to process it** (no ambiguous duplicate forward writes, no single authoritative status to mirror back).
- The block is surfaced **on the resources**, not just the log: each intent CR is marked `Ready=False` (reason `MultipleWorkloadClusters`) and a **Warning event** is emitted (events fire only on condition transition, so requeues don't spam the event stream).
- Returns the error so the controller's rate limiter applies **exponential backoff** while the misconfiguration persists; it resets automatically once the namespace maps to a single cluster again (which also self-clears the condition via normal status sync-back).

## Scope
- Controller RBAC (kubebuilder markers) and the generated `config/network-sync/role.yaml` already grant status-write and events verbs. Only the hand-maintained `e2e/sync/rbac.yaml` had drifted (status `get`-only on inbounds/outbounds, no events) and is corrected here.
- `NodeNetworkStatus` (interfaces/routes) and any spec-feeding status field remain deliberately out of scope.

## Tests
- Allowlist enforcement + `observedGeneration` rewrite.
- Progressing downgrade for both Ready and Resolved when the workload has not caught up (never a stale `Ready=True`/`Resolved=True`).
- Both `workloadCaughtUp` gates (source-generation annotation + workload observedGeneration).
- Reflection helpers (`statusConditionsPtr`, `statusObservedGeneration`).
- Integration: mirroring a workload `Ready` back onto the mgmt object.
- **Brick regression**: an empty workload status does not wipe mgmt `status.addresses` or mutate spec.
- Multiple-workload-cluster namespace: no forward sync, `Ready=False/MultipleWorkloadClusters` condition, Warning event, and the block error returned (exponential backoff).

`go test ./controllers/sync/...` and `golangci-lint run ./controllers/sync/...` are clean; e2e sync green.