### PR TITLE
fix(hbn-l2): honor Layer2Attachment interfaceName for the VLAN interface name

### DIFF
--- a/cmd/network-sync/main.go
+++ b/cmd/network-sync/main.go
@@ -101,7 +101,7 @@ func main() {
 		Remotes:         remotes,
 		RemoteNamespace: remoteNamespace,
 		IPAMAllocator:   ipam.NewAllocator(mgr.GetClient(), mgr.GetLogger()),
-		Recorder:        mgr.GetEventRecorderFor("network-sync"),
+		Recorder:        mgr.GetEventRecorder("network-sync"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Sync")
 		os.Exit(1)

--- a/controllers/sync/status_back_test.go
+++ b/controllers/sync/status_back_test.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -297,7 +297,7 @@ func TestReconcileBlocksNamespaceWithMultipleRemotes(t *testing.T) {
 	sc.Remotes.clients[types.NamespacedName{Namespace: "test-cluster", Name: "test-cluster"}] = remoteA
 	sc.Remotes.clients[types.NamespacedName{Namespace: "test-cluster", Name: "second"}] =
 		fake.NewClientBuilder().WithScheme(testScheme()).Build()
-	recorder := record.NewFakeRecorder(10)
+	recorder := events.NewFakeRecorder(10)
 	sc.Recorder = recorder
 
 	ctx := context.Background()

--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -104,7 +104,7 @@ type Controller struct {
 	Remotes         *RemoteClientManager
 	RemoteNamespace string
 	IPAMAllocator   *ipam.Allocator
-	Recorder        record.EventRecorder
+	Recorder        events.EventRecorder
 }
 
 // intentCRDTypes returns fresh instances of all intent CRD types to sync.
@@ -426,7 +426,9 @@ func (r *Controller) blockOnMultipleRemotes(ctx context.Context, namespace strin
 				return err
 			}
 			if changed && r.Recorder != nil {
-				r.Recorder.Event(obj, corev1.EventTypeWarning, reason, message)
+				// action "RefusingSync" describes the operation the reason relates
+				// to; note is passed as a literal to avoid interpreting stray %.
+				r.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, reason, "RefusingSync", "%s", message)
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/vishvananda/netlink v1.3.1
+	github.com/vishvananda/netns v0.0.5
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.51.0
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6
@@ -90,7 +91,6 @@ require (
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/rackn/gohai v0.6.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_netlink_test.go
+++ b/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_netlink_test.go
@@ -1,0 +1,145 @@
+//go:build linux
+
+package agent_hbn_l2
+
+import (
+	"encoding/json"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+
+	"github.com/telekom/das-schiff-network-operator/pkg/network/netplan"
+)
+
+// vlanDevice builds a minimal netplan VLAN device with the given id.
+func vlanDevice(t *testing.T, id int) netplan.Device {
+	t.Helper()
+	raw, err := json.Marshal(map[string]interface{}{"id": id, "mtu": 1500})
+	if err != nil {
+		t.Fatalf("marshalling vlan device: %v", err)
+	}
+	return netplan.Device{Raw: raw}
+}
+
+// withHBNNetns runs fn inside a fresh network namespace that already contains an
+// "hbn" master interface, so the netlink-driven VLAN reconciliation can be
+// exercised hermetically. It skips when not root (netlink/netns need CAP_NET_ADMIN).
+func withHBNNetns(t *testing.T, fn func(hbn netlink.Link)) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("requires root for netlink/netns operations")
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	orig, err := netns.Get()
+	if err != nil {
+		t.Fatalf("getting current netns: %v", err)
+	}
+	defer orig.Close()
+
+	ns, err := netns.New() // creates and switches into a fresh namespace
+	if err != nil {
+		t.Fatalf("creating netns: %v", err)
+	}
+	defer func() {
+		_ = netns.Set(orig)
+		_ = ns.Close()
+	}()
+
+	hbn := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: hbnMasterName}}
+	if err := netlink.LinkAdd(hbn); err != nil {
+		t.Fatalf("creating hbn master: %v", err)
+	}
+	if err := netlink.LinkSetUp(hbn); err != nil {
+		t.Fatalf("bringing hbn up: %v", err)
+	}
+	master, err := netlink.LinkByName(hbnMasterName)
+	if err != nil {
+		t.Fatalf("fetching hbn master: %v", err)
+	}
+	fn(master)
+}
+
+func assertVLAN(t *testing.T, name string, wantID int, wantAlias string) {
+	t.Helper()
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		t.Fatalf("expected interface %q to exist: %v", name, err)
+	}
+	vlan, ok := link.(*netlink.Vlan)
+	if !ok {
+		t.Fatalf("interface %q is %s, want vlan", name, link.Type())
+	}
+	if vlan.VlanId != wantID {
+		t.Errorf("interface %q vlan id = %d, want %d", name, vlan.VlanId, wantID)
+	}
+	if got := link.Attrs().Alias; got != wantAlias {
+		t.Errorf("interface %q alias = %q, want %q", name, got, wantAlias)
+	}
+}
+
+func assertNoInterface(t *testing.T, name string) {
+	t.Helper()
+	if _, err := netlink.LinkByName(name); err == nil {
+		t.Errorf("unexpected interface %q still present", name)
+	}
+}
+
+// TestReconcileVLANsHonorsInterfaceName verifies that the kernel interface is
+// named after the netplan map key (spec.interfaceName), not vlan.<id>.
+func TestReconcileVLANsHonorsInterfaceName(t *testing.T) {
+	withHBNNetns(t, func(_ netlink.Link) {
+		devices := map[string]netplan.Device{"mac-be": vlanDevice(t, 100)}
+		if err := reconcileVLANs(devices); err != nil {
+			t.Fatalf("reconcileVLANs: %v", err)
+		}
+		assertVLAN(t, "mac-be", 100, "hbn::vlan::mac-be")
+		assertNoInterface(t, "vlan.100")
+	})
+}
+
+// TestReconcileVLANsDefaultName verifies that the default "vlan.<id>" key still
+// yields a vlan.<id> interface (backward compatibility).
+func TestReconcileVLANsDefaultName(t *testing.T) {
+	withHBNNetns(t, func(_ netlink.Link) {
+		devices := map[string]netplan.Device{"vlan.100": vlanDevice(t, 100)}
+		if err := reconcileVLANs(devices); err != nil {
+			t.Fatalf("reconcileVLANs: %v", err)
+		}
+		assertVLAN(t, "vlan.100", 100, "hbn::vlan::vlan.100")
+	})
+}
+
+// TestReconcileVLANsRenamesStaleInterface verifies convergence: an interface
+// created before interfaceName was honored (named vlan.<id> but carrying the
+// desired-name alias) is renamed to the desired name.
+func TestReconcileVLANsRenamesStaleInterface(t *testing.T) {
+	withHBNNetns(t, func(master netlink.Link) {
+		stale := &netlink.Vlan{
+			LinkAttrs: netlink.LinkAttrs{Name: "vlan.100", ParentIndex: master.Attrs().Index},
+			VlanId:    100,
+		}
+		if err := netlink.LinkAdd(stale); err != nil {
+			t.Fatalf("creating stale vlan: %v", err)
+		}
+		if err := netlink.LinkSetAlias(stale, "hbn::vlan::mac-be"); err != nil {
+			t.Fatalf("setting stale alias: %v", err)
+		}
+		if err := netlink.LinkSetUp(stale); err != nil {
+			t.Fatalf("bringing stale vlan up: %v", err)
+		}
+
+		devices := map[string]netplan.Device{"mac-be": vlanDevice(t, 100)}
+		if err := reconcileVLANs(devices); err != nil {
+			t.Fatalf("reconcileVLANs: %v", err)
+		}
+
+		assertVLAN(t, "mac-be", 100, "hbn::vlan::mac-be")
+		assertNoInterface(t, "vlan.100")
+	})
+}

--- a/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_netlink_test.go
+++ b/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_netlink_test.go
@@ -85,8 +85,14 @@ func assertVLAN(t *testing.T, name string, wantID int, wantAlias string) {
 
 func assertNoInterface(t *testing.T, name string) {
 	t.Helper()
-	if _, err := netlink.LinkByName(name); err == nil {
-		t.Errorf("unexpected interface %q still present", name)
+	links, err := netlink.LinkList()
+	if err != nil {
+		t.Fatalf("listing links: %v", err)
+	}
+	for _, link := range links {
+		if link.Attrs().Name == name {
+			t.Errorf("unexpected interface %q still present", name)
+		}
 	}
 }
 

--- a/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go
+++ b/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go
@@ -364,22 +364,36 @@ func reconcileExistingInterface(existingInterface netlink.Link, interfaceType, d
 
 // ensureInterfaceName renames link to desiredName when they differ, returning a
 // freshly fetched handle for the (possibly renamed) link. A rename requires the
-// link to be down, so it is brought down, renamed, and brought back up; the
-// caller then reconciles addresses and routes, restoring anything the flap
-// dropped. When the name already matches, the link is returned unchanged.
+// link to be down, so the link's original admin state is captured and restored
+// afterwards: an interface that was up is brought back up, and one that was
+// administratively down stays down. On rename failure the original up state is
+// restored too, so a failed rename does not leave a previously-up interface down
+// (and cause an outage). When the name already matches, the link is returned
+// unchanged.
 func ensureInterfaceName(link netlink.Link, desiredName string) (netlink.Link, error) {
 	if link.Attrs().Name == desiredName {
 		return link, nil
 	}
 	oldName := link.Attrs().Name
+	wasUp := link.Attrs().Flags&net.FlagUp != 0
+
 	if err := netlink.LinkSetDown(link); err != nil {
 		return nil, fmt.Errorf("error bringing %s down for rename: %w", oldName, err)
 	}
 	if err := netlink.LinkSetName(link, desiredName); err != nil {
+		// Restore the prior admin state so a failed rename does not leave a
+		// previously-up interface down.
+		if wasUp {
+			if upErr := netlink.LinkSetUp(link); upErr != nil {
+				return nil, fmt.Errorf("error renaming %s to %s: %w (and restoring up state failed: %w)", oldName, desiredName, err, upErr)
+			}
+		}
 		return nil, fmt.Errorf("error renaming %s to %s: %w", oldName, desiredName, err)
 	}
-	if err := netlink.LinkSetUp(link); err != nil {
-		return nil, fmt.Errorf("error bringing %s up after rename: %w", desiredName, err)
+	if wasUp {
+		if err := netlink.LinkSetUp(link); err != nil {
+			return nil, fmt.Errorf("error bringing %s up after rename: %w", desiredName, err)
+		}
 	}
 	refreshed, err := netlink.LinkByName(desiredName)
 	if err != nil {

--- a/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go
+++ b/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go
@@ -119,7 +119,13 @@ nmstate or netplan. This just creates VLAN and dummy interfaces and nothing else
 func createVLAN(masterInterface netlink.Link, vlanConfig *netplanVlan, name string, vlan netplan.Device, bridge *netlink.Bridge) error {
 	link := netlink.Vlan{
 		LinkAttrs: netlink.LinkAttrs{
-			Name:        fmt.Sprintf("%s.%d", vlanNamePrefix, vlanConfig.ID),
+			// The netplan map key (name) is the desired interface name: it is
+			// spec.interfaceName when set, otherwise the default "vlan.<id>".
+			// This mirrors the non-HBN netplan path and the dummy/loopback path
+			// below, and matches what Layer2Attachment.Status.InterfaceName
+			// reports. Naming the link "vlan.<id>" unconditionally would ignore
+			// a configured interfaceName.
+			Name:        name,
 			ParentIndex: masterInterface.Attrs().Index,
 			MTU:         vlanConfig.Mtu,
 		},
@@ -311,7 +317,7 @@ func reconcileExisting(prefix, interfaceType string, devices map[string]netplan.
 							return fmt.Errorf("error deleting vlan %s from bridge %s: %w", existingInterface.Attrs().Name, (*bridge).Attrs().Name, err)
 						}
 					}
-				} else if err := reconcileExistingInterface(existingInterface, interfaceType, devices[name]); err != nil {
+				} else if err := reconcileExistingInterface(existingInterface, interfaceType, name, devices[name]); err != nil {
 					return fmt.Errorf("error reconciling existing %s: %w", existingInterface.Attrs().Name, err)
 				}
 			}
@@ -321,7 +327,18 @@ func reconcileExisting(prefix, interfaceType string, devices map[string]netplan.
 	return nil
 }
 
-func reconcileExistingInterface(existingInterface netlink.Link, interfaceType string, device netplan.Device) error {
+func reconcileExistingInterface(existingInterface netlink.Link, interfaceType, desiredName string, device netplan.Device) error {
+	// Converge the kernel interface name with the desired name (the netplan map
+	// key). Interfaces created before interfaceName was honored carry the old
+	// "vlan.<id>" name while their alias already encodes the desired name, so a
+	// pure create-path fix would never rename them; this makes live nodes
+	// converge. The rename is a no-op once names match.
+	renamed, err := ensureInterfaceName(existingInterface, desiredName)
+	if err != nil {
+		return err
+	}
+	existingInterface = renamed
+
 	if err := reconcileExistingAddresses(existingInterface, device); err != nil {
 		return err
 	}
@@ -343,6 +360,32 @@ func reconcileExistingInterface(existingInterface netlink.Link, interfaceType st
 		return fmt.Errorf("error disabling segmentation offload: %w", err)
 	}
 	return nil
+}
+
+// ensureInterfaceName renames link to desiredName when they differ, returning a
+// freshly fetched handle for the (possibly renamed) link. A rename requires the
+// link to be down, so it is brought down, renamed, and brought back up; the
+// caller then reconciles addresses and routes, restoring anything the flap
+// dropped. When the name already matches, the link is returned unchanged.
+func ensureInterfaceName(link netlink.Link, desiredName string) (netlink.Link, error) {
+	if link.Attrs().Name == desiredName {
+		return link, nil
+	}
+	oldName := link.Attrs().Name
+	if err := netlink.LinkSetDown(link); err != nil {
+		return nil, fmt.Errorf("error bringing %s down for rename: %w", oldName, err)
+	}
+	if err := netlink.LinkSetName(link, desiredName); err != nil {
+		return nil, fmt.Errorf("error renaming %s to %s: %w", oldName, desiredName, err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		return nil, fmt.Errorf("error bringing %s up after rename: %w", desiredName, err)
+	}
+	refreshed, err := netlink.LinkByName(desiredName)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching renamed interface %s: %w", desiredName, err)
+	}
+	return refreshed, nil
 }
 
 func reconcileLoopbacks(devices map[string]netplan.Device) error {


### PR DESCRIPTION
## Problem

The HBN-L2 agent created every VLAN link as `vlan.<id>` and stored the desired name (the netplan map key — `Layer2Attachment.spec.interfaceName` when set, otherwise `vlan.<id>`) **only in the interface alias**. So a configured `interfaceName: mac-be` never reached the kernel interface:

```
25: vlan.1000@hbn: <...> mtu 1500 ...
    alias hbn::vlan::mac-be
```

The netplan `NodeNetplanConfig` already carried the right key (`vlans: { mac-be: { id: 1000, link: hbn, ... } }`), but `createVLAN` ignored it for naming.

This is inconsistent with everything else that treats the key as the interface name:
- the **non-HBN netplan path** (netplan uses the map key as the interface name),
- the **dummy/loopback path** in the same file (`Name: name`),
- `Layer2Attachment.Status.InterfaceName` (reported to the user).

## Fix

- `createVLAN` names the VLAN link after the netplan map key. The default case (`vlan.<id>` key) is byte-for-byte unchanged; a configured `interfaceName` now actually names the interface.
- `ensureInterfaceName` (wired into `reconcileExistingInterface`) renames interfaces created before `interfaceName` was honored — they carry the old `vlan.<id>` name but already have the correct alias — so **live nodes converge**, not just newly created interfaces. It is a no-op once names match, so the default path never flaps.

## Validation

Added `nodenetplanconfig_netlink_test.go` (`//go:build linux`, skips when not root) exercising **real netlink in a fresh network namespace**:
- `interfaceName` override → interface named `mac-be`, alias `hbn::vlan::mac-be`, no `vlan.100`.
- default key → `vlan.100` (backward compatible).
- stale `vlan.100` (with `hbn::vlan::mac-be` alias) → renamed to `mac-be`.

All pass. Package tests, `go vet`, `gofmt`, and `golangci-lint v2.8.0` (`--new-from-rev=origin/main` → 0 new issues) all clean (run in Linux containers).

## Scope / compatibility

- **No e2e regression:** no e2e `Layer2Attachment` sets `interfaceName`, so every netplan key is `vlan.<vlanid>` and the produced names are identical to today (the connectivity NADs use `master: vlan.501`/`vlan.502`, which still hold).
- **No interaction with frr-cra:** the `vlan.<id>` that `cmd/frr-cra` looks up for neighbor-suppression eBPF is the CRA/VSR-side interface, a different interface from the HBN-agent-managed VLAN renamed here.
- `go.mod`: promotes `vishvananda/netns` from indirect → direct (test dependency; already in `go.sum`).