### PR TITLE
feat(config): add MgmtInterfaceName with fallback to trunk interface

### DIFF
--- a/cmd/frr-cra/main.go
+++ b/cmd/frr-cra/main.go
@@ -272,7 +272,7 @@ func setRuleFamily(rule *netlink.Rule) {
 		rule.IifName = baseConfig.ClusterVRF.Name
 	} else {
 		rule.Family = unix.AF_INET
-		rule.IifName = baseConfig.TrunkInterfaceName
+		rule.IifName = baseConfig.MgmtInterface()
 	}
 }
 

--- a/pkg/config/baseconfig.go
+++ b/pkg/config/baseconfig.go
@@ -11,12 +11,22 @@ import (
 type BaseConfig struct {
 	VTEPLoopbackIP     string     `yaml:"vtepLoopbackIP"`
 	TrunkInterfaceName string     `yaml:"trunkInterfaceName"`
+	MgmtInterfaceName  string     `yaml:"mgmtInterfaceName"`
 	ExportCIDRs        []string   `yaml:"exportCIDRs"`
 	ManagementVRF      BaseVRF    `yaml:"managementVRF"`
 	ClusterVRF         BaseVRF    `yaml:"clusterVRF"`
 	LocalASN           int        `yaml:"localASN"`
 	UnderlayNeighbors  []Neighbor `yaml:"underlayNeighbors"`
 	ClusterNeighbors   []Neighbor `yaml:"clusterNeighbors"`
+}
+
+// MgmtInterface returns the management interface name, falling back to the
+// trunk interface when no dedicated management interface is configured.
+func (c *BaseConfig) MgmtInterface() string {
+	if c.MgmtInterfaceName != "" {
+		return c.MgmtInterfaceName
+	}
+	return c.TrunkInterfaceName
 }
 
 type BaseVRF struct {

--- a/pkg/cra-vsr/cra_vsr_test.go
+++ b/pkg/cra-vsr/cra_vsr_test.go
@@ -497,8 +497,9 @@ var _ = Describe("CRA-VSR", func() {
 
 		// Configure a dedicated management interface; PBR and node-IP static
 		// routes must use it instead of the trunk interface.
+		prevMgmtInterface := manager.baseConfig.MgmtInterfaceName
 		manager.baseConfig.MgmtInterfaceName = "oam0"
-		defer func() { manager.baseConfig.MgmtInterfaceName = "" }()
+		defer func() { manager.baseConfig.MgmtInterfaceName = prevMgmtInterface }()
 
 		generated, err := manager.makeVRouter(&nodeConfig.Spec)
 		Expect(err).ToNot(HaveOccurred())
@@ -526,7 +527,10 @@ var _ = Describe("CRA-VSR", func() {
 		Expect(nodeRoute.NextHops[0].NextHop).To(Equal("oam0"))
 	})
 	It("Falls back to the trunk interface when no management interface is set", func() {
-		Expect(manager.baseConfig.MgmtInterfaceName).To(BeEmpty())
+		prevMgmtInterface := manager.baseConfig.MgmtInterfaceName
+		manager.baseConfig.MgmtInterfaceName = ""
+		defer func() { manager.baseConfig.MgmtInterfaceName = prevMgmtInterface }()
+
 		Expect(manager.baseConfig.MgmtInterface()).To(Equal(manager.baseConfig.TrunkInterfaceName))
 	})
 })

--- a/pkg/cra-vsr/cra_vsr_test.go
+++ b/pkg/cra-vsr/cra_vsr_test.go
@@ -464,4 +464,96 @@ var _ = Describe("CRA-VSR", func() {
 
 		Expect(generatedXML).To(MatchXML(expectedXML))
 	})
+	It("Uses the management interface for PBR and node-IP static routes", func() {
+		scheme := runtime.NewScheme()
+		utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+		utilruntime.Must(v1alpha1.AddToScheme(scheme))
+
+		client := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		reconciler, err := operator.NewNodeConfigReconciler(
+			client, logr.Logger{}, 3, 3, 3, scheme, 3, operator.ImportModeImport)
+		Expect(err).ToNot(HaveOccurred())
+
+		node := &corev1.Node{}
+		node.Name = "server1"
+
+		nodeConfig, err := reconciler.CreateNodeNetworkConfig(context.Background(), node, revision)
+		Expect(err).ToNot(HaveOccurred())
+
+		nodeConfig.Spec.ClusterVRF.PolicyRoutes = []v1alpha1.PolicyRoute{
+			{
+				TrafficMatch: v1alpha1.TrafficMatch{
+					SrcPrefix: types.ToPtr("1.1.1.0/24"),
+					DstPrefix: types.ToPtr("2.2.2.3"),
+				},
+				NextHop: v1alpha1.NextHop{
+					Vrf: types.ToPtr("mgmt"),
+				},
+			},
+		}
+
+		// Configure a dedicated management interface; PBR and node-IP static
+		// routes must use it instead of the trunk interface.
+		manager.baseConfig.MgmtInterfaceName = "oam0"
+		defer func() { manager.baseConfig.MgmtInterfaceName = "" }()
+
+		generated, err := manager.makeVRouter(&nodeConfig.Spec)
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := findNamespace(generated, manager.WorkNSName)
+		Expect(ns).ToNot(BeNil())
+
+		// IPv4 PBR rule must match on the management interface.
+		Expect(ns.Routing).ToNot(BeNil())
+		Expect(ns.Routing.PBR).ToNot(BeNil())
+		Expect(ns.Routing.PBR.IPv4).ToNot(BeEmpty())
+		Expect(ns.Routing.PBR.IPv4[0].Match).ToNot(BeNil())
+		Expect(ns.Routing.PBR.IPv4[0].Match.Interface).ToNot(BeNil())
+		Expect(*ns.Routing.PBR.IPv4[0].Match.Interface).To(Equal("oam0"))
+
+		// Static route to the cluster node IP must egress via the mgmt interface.
+		clusterVRF := findVRFByName(ns, "cluster")
+		Expect(clusterVRF).ToNot(BeNil())
+		Expect(clusterVRF.Routing).ToNot(BeNil())
+		Expect(clusterVRF.Routing.Static).ToNot(BeNil())
+
+		nodeRoute := findStaticRoute(clusterVRF.Routing.Static.IPv4, "10.100.0.10/32")
+		Expect(nodeRoute).ToNot(BeNil())
+		Expect(nodeRoute.NextHops).ToNot(BeEmpty())
+		Expect(nodeRoute.NextHops[0].NextHop).To(Equal("oam0"))
+	})
+	It("Falls back to the trunk interface when no management interface is set", func() {
+		Expect(manager.baseConfig.MgmtInterfaceName).To(BeEmpty())
+		Expect(manager.baseConfig.MgmtInterface()).To(Equal(manager.baseConfig.TrunkInterfaceName))
+	})
 })
+
+func findNamespace(v *VRouter, name string) *Namespace {
+	for i := range v.Namespaces {
+		if v.Namespaces[i].Name == name {
+			return &v.Namespaces[i]
+		}
+	}
+	return nil
+}
+
+func findVRFByName(ns *Namespace, name string) *VRF {
+	for i := range ns.VRFs {
+		if ns.VRFs[i].Name == name {
+			return &ns.VRFs[i]
+		}
+	}
+	return nil
+}
+
+func findStaticRoute(routes []StaticRoute, destination string) *StaticRoute {
+	for i := range routes {
+		if routes[i].Destination == destination {
+			return &routes[i]
+		}
+	}
+	return nil
+}

--- a/pkg/cra-vsr/layerbgp.go
+++ b/pkg/cra-vsr/layerbgp.go
@@ -319,10 +319,11 @@ func (l *LayerBGP) setupPolicyRoute(i int, conf v1alpha1.PolicyRoute) error {
 	}
 
 	// Select the inbound (source) interface based on the rule's address family.
-	// For IPv4 the kernel's receive path matches on the trunk interface, while
-	// for IPv6 it sets flowi6_iif to the cluster VRF device; matching the trunk
-	// there would cause the subsequent table lookup to repeat the same lookup,
-	// resulting in circular routing.
+	// For IPv4 the kernel's receive path matches on the management interface
+	// (which falls back to the trunk interface when unset), while for IPv6 it
+	// sets flowi6_iif to the cluster VRF device; matching the management
+	// interface there would cause the subsequent table lookup to repeat the
+	// same lookup, resulting in circular routing.
 	match.Interface = types.ToPtr(l.mgr.baseConfig.MgmtInterface())
 	if match.ipVersion() == IPv6 {
 		match.Interface = &l.mgr.baseConfig.ClusterVRF.Name

--- a/pkg/cra-vsr/layerbgp.go
+++ b/pkg/cra-vsr/layerbgp.go
@@ -323,7 +323,7 @@ func (l *LayerBGP) setupPolicyRoute(i int, conf v1alpha1.PolicyRoute) error {
 	// for IPv6 it sets flowi6_iif to the cluster VRF device; matching the trunk
 	// there would cause the subsequent table lookup to repeat the same lookup,
 	// resulting in circular routing.
-	match.Interface = &l.mgr.baseConfig.TrunkInterfaceName
+	match.Interface = types.ToPtr(l.mgr.baseConfig.MgmtInterface())
 	if match.ipVersion() == IPv6 {
 		match.Interface = &l.mgr.baseConfig.ClusterVRF.Name
 	}
@@ -836,7 +836,7 @@ func (l *LayerBGP) setupClusterVRF() error {
 			Destination: *neigh.IP + mask,
 			NextHops: []NextHop{
 				{
-					NextHop: baseCfg.TrunkInterfaceName,
+					NextHop: baseCfg.MgmtInterface(),
 				},
 			},
 		})


### PR DESCRIPTION
## Summary
Introduces a dedicated management interface (`mgmtInterfaceName`) alongside the existing `trunkInterfaceName`. When it is unset, `MgmtInterface()` falls back to the trunk interface, preserving existing behaviour.

The management interface is now used for:
- IPv4 PBR inbound-interface matching (`setupPolicyRoute`)
- static routes to cluster node IPs (`setupClusterVRF`)
- frr-cra IPv4 policy rule `IifName` (`setRuleFamily`)

## Rationale
Management traffic previously rode the trunk interface (`hbn`), which was fine while both operated at 1500 MTU. Some VLANs, however, require a 9000 MTU, so `hbn` was raised to 9000. That would implicitly push management traffic to 9000 as well, which is not desired — management must stay at 1500 MTU.

To decouple the two, management now runs over a dedicated `oam0` interface pinned at 1500 MTU, while `hbn` remains at 9000 for the VLANs that need jumbo frames. `mgmtInterfaceName` selects this interface; when it is not configured, behaviour is unchanged (falls back to the trunk interface).

## Changes
- `pkg/config/baseconfig.go`: new `MgmtInterfaceName` field + `MgmtInterface()` fallback helper
- `pkg/cra-vsr/layerbgp.go`: PBR match and node-IP static route next-hop use `MgmtInterface()`
- `cmd/frr-cra/main.go`: IPv4 rule `IifName` uses `MgmtInterface()`

## Tests
- Added a cra-vsr spec configuring `mgmtInterfaceName: oam0` and asserting the IPv4 PBR interface and node-IP static route next-hop resolve to `oam0`, plus a fallback assertion.
- Existing golden-XML test still passes (config leaves mgmt unset -> falls back to the trunk interface).

## Verification
- `go test ./pkg/config/... ./pkg/cra-vsr/...` passes
- `golangci-lint run` on those packages reports 0 issues
- `cmd/frr-cra` is Linux-only (netlink/bpf/ethtool) and is validated by CI; the change there is a trivial string-method swap