### PR TITLE
feat(platform-coil): provision Calico IPPools for PodNetwork

### DIFF
--- a/api/v1alpha1/network-connector/podnetwork_types.go
+++ b/api/v1alpha1/network-connector/podnetwork_types.go
@@ -53,6 +53,14 @@ type PodNetworkStatus struct {
 	// +optional
 	VRFs []string `json:"vrfs,omitempty"`
 
+	// IPPools lists the names of the Calico IPPools created for this PodNetwork
+	// (one per address family, natOutgoing=false). Reference these names from a
+	// pod's cni.projectcalico.org/ipv4pools / ipv6pools annotation to allocate
+	// pod addresses from this network. Sorted. Empty until the platform-coil
+	// controller has provisioned the pools.
+	// +optional
+	IPPools []string `json:"ipPools,omitempty"`
+
 	// Conditions represent the latest available observations of the
 	// PodNetwork's current state.
 	// +optional
@@ -70,6 +78,7 @@ type PodNetworkStatus struct {
 //+kubebuilder:printcolumn:name="IPv4",type=string,JSONPath=`.status.networkIPv4`
 //+kubebuilder:printcolumn:name="IPv6",type=string,JSONPath=`.status.networkIPv6`,priority=10
 //+kubebuilder:printcolumn:name="VRFs",type=string,JSONPath=`.status.vrfs`
+//+kubebuilder:printcolumn:name="IPPools",type=string,JSONPath=`.status.ipPools`,priority=10
 //+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 //+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/api/v1alpha1/network-connector/zz_generated.deepcopy.go
+++ b/api/v1alpha1/network-connector/zz_generated.deepcopy.go
@@ -2007,6 +2007,11 @@ func (in *PodNetworkStatus) DeepCopyInto(out *PodNetworkStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.IPPools != nil {
+		in, out := &in.IPPools, &out.IPPools
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]v1.Condition, len(*in))

--- a/cmd/platform-coil/main.go
+++ b/cmd/platform-coil/main.go
@@ -97,6 +97,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&platform.PodNetworkReconciler{
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Scheme:    mgr.GetScheme(),
+		Log:       mgr.GetLogger().WithName("PodNetworkReconciler"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "PodNetwork")
+		os.Exit(1)
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)

--- a/config/crd/bases/network-connector.sylvaproject.org_podnetworks.yaml
+++ b/config/crd/bases/network-connector.sylvaproject.org_podnetworks.yaml
@@ -30,6 +30,10 @@ spec:
     - jsonPath: .status.vrfs
       name: VRFs
       type: string
+    - jsonPath: .status.ipPools
+      name: IPPools
+      priority: 10
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -186,6 +190,16 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              ipPools:
+                description: |-
+                  IPPools lists the names of the Calico IPPools created for this PodNetwork
+                  (one per address family, natOutgoing=false). Reference these names from a
+                  pod's cni.projectcalico.org/ipv4pools / ipv6pools annotation to allocate
+                  pod addresses from this network. Sorted. Empty until the platform-coil
+                  controller has provisioned the pools.
+                items:
+                  type: string
+                type: array
               networkIPv4:
                 description: |-
                   NetworkIPv4 is the IPv4 CIDR of the referenced Network (spec.ipv4.cidr).

--- a/config/platform-coil/rbac.yaml
+++ b/config/platform-coil/rbac.yaml
@@ -24,7 +24,20 @@ rules:
 - apiGroups:
   - network-connector.sylvaproject.org
   resources:
+  - podnetworks
+  - podnetworks/status
+  - podnetworks/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - network-connector.sylvaproject.org
+  resources:
   - destinations
+  - networks
   verbs:
   - get
   - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -102,6 +102,7 @@ rules:
   - interfaceconfigs/finalizers
   - networks/finalizers
   - outbounds/finalizers
+  - podnetworks/finalizers
   - vrfs/finalizers
   verbs:
   - update

--- a/controllers/platform/podnetwork_controller.go
+++ b/controllers/platform/podnetwork_controller.go
@@ -93,8 +93,8 @@ func (r *PodNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// Wait for the Calico IPPool CRD before adding a finalizer or creating pools.
-	if ready, result := r.checkCalicoCRD(ctx, logger); !ready {
-		return result, nil
+	if ready, result, err := r.checkCalicoCRD(ctx, logger); !ready {
+		return result, err
 	}
 
 	if !controllerutil.ContainsFinalizer(pn, podNetworkFinalizer) {
@@ -366,17 +366,22 @@ func (r *PodNetworkReconciler) mapNetworkToPodNetworks(ctx context.Context, obj 
 }
 
 // checkCalicoCRD verifies that the Calico IPPool CRD is registered. Returns
-// (true, _) if ready, or (false, requeueResult) if not.
-func (r *PodNetworkReconciler) checkCalicoCRD(ctx context.Context, logger logr.Logger) (bool, ctrl.Result) {
+// (true, _, nil) if ready, (false, requeueResult, nil) if the CRD is not yet
+// registered (a benign, expected state during bootstrap), or (false, _, err)
+// for any other List failure (e.g. RBAC Forbidden or a transient API error) so
+// the controller requeues and surfaces the failure here rather than proceeding
+// to create IPPools and failing later.
+func (r *PodNetworkReconciler) checkCalicoCRD(ctx context.Context, logger logr.Logger) (bool, ctrl.Result, error) {
 	list := &unstructured.UnstructuredList{}
 	list.SetGroupVersionKind(calicoIPPoolGVK)
 	if err := r.List(ctx, list, client.Limit(1)); err != nil {
 		if apimeta.IsNoMatchError(err) {
 			logger.Info("Calico IPPool CRD not yet available, will retry", "gvk", calicoIPPoolGVK.String())
-			return false, ctrl.Result{RequeueAfter: crdRequeueInterval}
+			return false, ctrl.Result{RequeueAfter: crdRequeueInterval}, nil
 		}
+		return false, ctrl.Result{}, fmt.Errorf("error checking Calico IPPool CRD: %w", err)
 	}
-	return true, ctrl.Result{}
+	return true, ctrl.Result{}, nil
 }
 
 // SetupWithManager registers the PodNetwork controller.

--- a/controllers/platform/podnetwork_controller.go
+++ b/controllers/platform/podnetwork_controller.go
@@ -1,0 +1,404 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"sort"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
+)
+
+const (
+	podNetworkFinalizer = "network-connector.sylvaproject.org/podnetwork-coil-cleanup"
+
+	// Calico's default IPAM block sizes. A block is the per-node slice a node
+	// claims out of the pool; the network pools we create are large enough that
+	// these defaults give sensible per-node distribution. blockSize must be
+	// numerically >= the pool CIDR prefix length, so for pools smaller than the
+	// default block we fall back to the pool prefix (see poolBlockSize).
+	defaultIPv4BlockSize = int64(26)
+	defaultIPv6BlockSize = int64(122)
+)
+
+// PodNetworkReconciler watches PodNetwork resources and reconciles the Calico
+// IPPools that back them. Unlike the Outbound flow (which allocates specific
+// egress source addresses and creates a /32 or /128 host pool per address), a
+// PodNetwork represents a whole pod network: one IPPool is created per address
+// family covering the referenced Network's full CIDR, with natOutgoing=false so
+// the fabric (not Calico) owns SNAT. Pods opt in to the pool via the
+// cni.projectcalico.org/ipv4pools / ipv6pools annotation; the pool names are
+// surfaced in PodNetwork.status.ipPools.
+//
+// This controller lives in the platform-coil binary alongside CoilReconciler
+// because it shares the Calico IPPool ownership model, even though it is driven
+// by a different CRD.
+type PodNetworkReconciler struct {
+	client.Client
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
+	Log       logr.Logger
+}
+
+//+kubebuilder:rbac:groups=network-connector.sylvaproject.org,resources=podnetworks,verbs=get;list;watch
+//+kubebuilder:rbac:groups=network-connector.sylvaproject.org,resources=podnetworks/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=network-connector.sylvaproject.org,resources=podnetworks/finalizers,verbs=update
+//+kubebuilder:rbac:groups=network-connector.sylvaproject.org,resources=networks,verbs=get;list;watch
+
+// Reconcile handles PodNetwork create/update/delete events.
+func (r *PodNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	pn := &nc.PodNetwork{}
+	if err := r.Get(ctx, req.NamespacedName, pn); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("error fetching PodNetwork: %w", err)
+	}
+
+	if !pn.DeletionTimestamp.IsZero() {
+		return r.handlePodNetworkDeletion(ctx, pn, logger)
+	}
+
+	// Wait for the Calico IPPool CRD before adding a finalizer or creating pools.
+	if ready, result := r.checkCalicoCRD(ctx, logger); !ready {
+		return result, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(pn, podNetworkFinalizer) {
+		controllerutil.AddFinalizer(pn, podNetworkFinalizer)
+		if err := r.Update(ctx, pn); err != nil {
+			return ctrl.Result{}, fmt.Errorf("error adding finalizer: %w", err)
+		}
+	}
+
+	// Resolve the referenced Network's CIDRs (same namespace).
+	ipv4CIDR, ipv6CIDR, err := r.resolveNetworkCIDRs(ctx, pn)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("error resolving Network %q: %w", pn.Spec.NetworkRef, err)
+	}
+
+	// Build the desired pools (one per family the Network provides).
+	desired := map[string]calicoPoolSpec{}
+	if ipv4CIDR != "" {
+		name := podNetworkPoolName(pn.Namespace, pn.Name, "v4", ipv4CIDR)
+		desired[name] = calicoPoolSpec{cidr: ipv4CIDR, family: "v4", blockSize: poolBlockSize(ipv4CIDR, defaultIPv4BlockSize)}
+	}
+	if ipv6CIDR != "" {
+		name := podNetworkPoolName(pn.Namespace, pn.Name, "v6", ipv6CIDR)
+		desired[name] = calicoPoolSpec{cidr: ipv6CIDR, family: "v6", blockSize: poolBlockSize(ipv6CIDR, defaultIPv6BlockSize)}
+	}
+
+	poolNames := make([]string, 0, len(desired))
+	for name, spec := range desired {
+		if err := r.upsertPodNetworkPool(ctx, pn, name, spec, logger); err != nil {
+			return ctrl.Result{}, err
+		}
+		poolNames = append(poolNames, name)
+	}
+	sort.Strings(poolNames)
+
+	if err := r.prunePodNetworkPools(ctx, pn, desired, logger); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if err := r.updateIPPoolStatus(ctx, pn, poolNames); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// calicoPoolSpec captures the derived properties of a desired IPPool.
+type calicoPoolSpec struct {
+	cidr      string
+	family    string
+	blockSize int64
+}
+
+// resolveNetworkCIDRs looks up the Network referenced by the PodNetwork (in the
+// same namespace) and returns its IPv4 and IPv6 CIDRs. A missing Network is not
+// an error: pools cannot be created yet, so empty CIDRs are returned and the
+// existing pools (if any) are pruned. The Network watch re-triggers this
+// reconcile once the Network appears.
+func (r *PodNetworkReconciler) resolveNetworkCIDRs(ctx context.Context, pn *nc.PodNetwork) (ipv4, ipv6 string, err error) {
+	network := &nc.Network{}
+	getErr := r.Get(ctx, types.NamespacedName{Name: pn.Spec.NetworkRef, Namespace: pn.Namespace}, network)
+	if apierrors.IsNotFound(getErr) {
+		return "", "", nil
+	}
+	if getErr != nil {
+		return "", "", fmt.Errorf("error getting Network: %w", getErr)
+	}
+	if network.Spec.IPv4 != nil {
+		ipv4 = network.Spec.IPv4.CIDR
+	}
+	if network.Spec.IPv6 != nil {
+		ipv6 = network.Spec.IPv6.CIDR
+	}
+	return ipv4, ipv6, nil
+}
+
+// podNetworkPoolName derives a stable, DNS-safe, cluster-unique IPPool name from
+// the PodNetwork's namespace/name, address family and CIDR. IPPools are
+// cluster-scoped, so the namespace is folded into the hash to avoid collisions
+// between equally named PodNetworks in different namespaces.
+func podNetworkPoolName(namespace, name, family, cidr string) string {
+	sum := sha256.Sum256([]byte(namespace + "/" + name + "/" + cidr))
+	return fmt.Sprintf("pn-%s-%s-%s", name, family, hex.EncodeToString(sum[:4]))
+}
+
+// poolBlockSize returns a valid Calico blockSize for a pool: the default block
+// size, unless the pool CIDR is smaller than a single default block, in which
+// case the pool prefix length is used (blockSize must be >= the pool prefix).
+func poolBlockSize(cidr string, defaultBlock int64) int64 {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return defaultBlock
+	}
+	ones, _ := ipNet.Mask.Size()
+	if int64(ones) > defaultBlock {
+		return int64(ones)
+	}
+	return defaultBlock
+}
+
+func (r *PodNetworkReconciler) upsertPodNetworkPool(ctx context.Context, pn *nc.PodNetwork, poolName string, spec calicoPoolSpec, logger logr.Logger) error {
+	desired := &unstructured.Unstructured{}
+	desired.SetGroupVersionKind(calicoIPPoolGVK)
+	desired.SetName(poolName)
+	desired.SetLabels(map[string]string{
+		"app.kubernetes.io/managed-by":                  managedByValue,
+		"network-connector.sylvaproject.org/podnetwork": pn.Name,
+		"network-connector.sylvaproject.org/namespace":  pn.Namespace,
+		"network-connector.sylvaproject.org/family":     spec.family,
+	})
+	if err := unstructured.SetNestedField(desired.Object, spec.cidr, "spec", "cidr"); err != nil {
+		return fmt.Errorf("error setting cidr: %w", err)
+	}
+	// natOutgoing=false: the fabric performs SNAT, not Calico. This is the whole
+	// point of the pool -- it makes the pod network's addresses routable rather
+	// than masqueraded behind the node IP.
+	if err := unstructured.SetNestedField(desired.Object, false, "spec", "natOutgoing"); err != nil {
+		return fmt.Errorf("error setting natOutgoing: %w", err)
+	}
+	if err := unstructured.SetNestedField(desired.Object, spec.blockSize, "spec", "blockSize"); err != nil {
+		return fmt.Errorf("error setting blockSize: %w", err)
+	}
+	// !all() keeps the pool from being auto-selected for ordinary pods; pods opt
+	// in explicitly via the cni.projectcalico.org/ipv4pools / ipv6pools
+	// annotation. Without this the pool could steal addresses from the default
+	// pod network.
+	if err := unstructured.SetNestedField(desired.Object, "!all()", "spec", "nodeSelector"); err != nil {
+		return fmt.Errorf("error setting nodeSelector: %w", err)
+	}
+	if err := unstructured.SetNestedStringSlice(desired.Object, []string{"Workload"}, "spec", "allowedUses"); err != nil {
+		return fmt.Errorf("error setting allowedUses: %w", err)
+	}
+
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(calicoIPPoolGVK)
+	err := r.Get(ctx, types.NamespacedName{Name: poolName}, existing)
+	if apierrors.IsNotFound(err) {
+		logger.Info("creating Calico IPPool for PodNetwork", "name", poolName, "cidr", spec.cidr, "podnetwork", pn.Name)
+		if err := r.Create(ctx, desired); err != nil {
+			return fmt.Errorf("error creating Calico IPPool %s: %w", poolName, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error getting IPPool: %w", err)
+	}
+
+	// blockSize is immutable in Calico once the pool has blocks; the Network CIDR
+	// is itself immutable, so we never need to change it. Preserve the existing
+	// blockSize to avoid a rejected update, and reconcile the remaining fields.
+	if bs, found, _ := unstructured.NestedInt64(existing.Object, "spec", "blockSize"); found {
+		if err := unstructured.SetNestedField(desired.Object, bs, "spec", "blockSize"); err != nil {
+			return fmt.Errorf("error preserving blockSize: %w", err)
+		}
+	}
+	existing.Object["spec"] = desired.Object["spec"]
+	existing.SetLabels(desired.GetLabels())
+	if err := r.Update(ctx, existing); err != nil {
+		return fmt.Errorf("error updating Calico IPPool %s: %w", poolName, err)
+	}
+	return nil
+}
+
+// prunePodNetworkPools deletes IPPools owned by this PodNetwork that are no
+// longer desired (e.g. after a Network lost an address family, or the Network
+// was removed).
+func (r *PodNetworkReconciler) prunePodNetworkPools(ctx context.Context, pn *nc.PodNetwork, desired map[string]calicoPoolSpec, logger logr.Logger) error {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(calicoIPPoolGVK)
+	if err := r.List(ctx, list, client.MatchingLabels{
+		"network-connector.sylvaproject.org/podnetwork": pn.Name,
+		"network-connector.sylvaproject.org/namespace":  pn.Namespace,
+	}); err != nil {
+		return fmt.Errorf("error listing Calico IPPools for prune: %w", err)
+	}
+	for i := range list.Items {
+		name := list.Items[i].GetName()
+		if _, keep := desired[name]; keep {
+			continue
+		}
+		if err := r.Delete(ctx, &list.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("error deleting stale Calico IPPool %s: %w", name, err)
+		}
+		logger.Info("deleted stale Calico IPPool for PodNetwork", "name", name, "podnetwork", pn.Name)
+	}
+	return nil
+}
+
+// updateIPPoolStatus writes the desired pool names into status.ipPools using
+// optimistic concurrency. Only the ipPools field is touched so it never clobbers
+// the fields owned by the intent status updater (conditions, networkIPv4/6, vrfs).
+func (r *PodNetworkReconciler) updateIPPoolStatus(ctx context.Context, pn *nc.PodNetwork, poolNames []string) error {
+	if stringSlicesEqual(pn.Status.IPPools, poolNames) {
+		return nil
+	}
+	const maxRetries = 3
+	key := types.NamespacedName{Name: pn.Name, Namespace: pn.Namespace}
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		fresh := &nc.PodNetwork{}
+		if err := r.Get(ctx, key, fresh); err != nil {
+			return fmt.Errorf("error re-fetching PodNetwork for status update: %w", err)
+		}
+		if stringSlicesEqual(fresh.Status.IPPools, poolNames) {
+			return nil
+		}
+		fresh.Status.IPPools = poolNames
+		err := r.Status().Update(ctx, fresh)
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsConflict(err) {
+			return fmt.Errorf("error updating PodNetwork status: %w", err)
+		}
+	}
+	return fmt.Errorf("status update conflict after %d retries for PodNetwork %s", maxRetries, key)
+}
+
+func (r *PodNetworkReconciler) handlePodNetworkDeletion(ctx context.Context, pn *nc.PodNetwork, logger logr.Logger) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(pn, podNetworkFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	pools := &unstructured.UnstructuredList{}
+	pools.SetGroupVersionKind(calicoIPPoolGVK)
+	if err := r.List(ctx, pools, client.MatchingLabels{
+		"network-connector.sylvaproject.org/podnetwork": pn.Name,
+		"network-connector.sylvaproject.org/namespace":  pn.Namespace,
+	}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("error listing Calico IPPools for deletion: %w", err)
+	}
+	for i := range pools.Items {
+		if err := r.Delete(ctx, &pools.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("error deleting Calico IPPool %s: %w", pools.Items[i].GetName(), err)
+		}
+		logger.Info("deleted Calico IPPool for PodNetwork", "name", pools.Items[i].GetName(), "podnetwork", pn.Name)
+	}
+
+	controllerutil.RemoveFinalizer(pn, podNetworkFinalizer)
+	if err := r.Update(ctx, pn); err != nil {
+		return ctrl.Result{}, fmt.Errorf("error removing finalizer: %w", err)
+	}
+	return ctrl.Result{}, nil
+}
+
+// mapNetworkToPodNetworks maps a Network change to the PodNetworks (in the same
+// namespace) that reference it, so pools are (re)created once the Network exists.
+func (r *PodNetworkReconciler) mapNetworkToPodNetworks(ctx context.Context, obj client.Object) []ctrlreconcile.Request {
+	logger := log.FromContext(ctx)
+
+	var pnList nc.PodNetworkList
+	if err := r.List(ctx, &pnList, client.InNamespace(obj.GetNamespace())); err != nil {
+		logger.Error(err, "error listing podnetworks for network mapping")
+		return nil
+	}
+
+	var requests []ctrlreconcile.Request
+	for i := range pnList.Items {
+		if pnList.Items[i].Spec.NetworkRef != obj.GetName() {
+			continue
+		}
+		requests = append(requests, ctrlreconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      pnList.Items[i].Name,
+				Namespace: pnList.Items[i].Namespace,
+			},
+		})
+	}
+	return requests
+}
+
+// checkCalicoCRD verifies that the Calico IPPool CRD is registered. Returns
+// (true, _) if ready, or (false, requeueResult) if not.
+func (r *PodNetworkReconciler) checkCalicoCRD(ctx context.Context, logger logr.Logger) (bool, ctrl.Result) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(calicoIPPoolGVK)
+	if err := r.List(ctx, list, client.Limit(1)); err != nil {
+		if apimeta.IsNoMatchError(err) {
+			logger.Info("Calico IPPool CRD not yet available, will retry", "gvk", calicoIPPoolGVK.String())
+			return false, ctrl.Result{RequeueAfter: crdRequeueInterval}
+		}
+	}
+	return true, ctrl.Result{}
+}
+
+// SetupWithManager registers the PodNetwork controller.
+func (r *PodNetworkReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named("podnetwork-coil-reconciler").
+		For(&nc.PodNetwork{}).
+		Watches(&nc.Network{}, handler.EnqueueRequestsFromMapFunc(r.mapNetworkToPodNetworks)).
+		Complete(r); err != nil {
+		return fmt.Errorf("error setting up podnetwork controller: %w", err)
+	}
+	return nil
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/controllers/platform/podnetwork_controller.go
+++ b/controllers/platform/podnetwork_controller.go
@@ -79,6 +79,7 @@ type PodNetworkReconciler struct {
 //+kubebuilder:rbac:groups=network-connector.sylvaproject.org,resources=podnetworks/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=network-connector.sylvaproject.org,resources=podnetworks/finalizers,verbs=update
 //+kubebuilder:rbac:groups=network-connector.sylvaproject.org,resources=networks,verbs=get;list;watch
+// crd.projectcalico.org/ippools RBAC (create/update/delete) is in config/platform-coil/rbac.yaml.
 
 // Reconcile handles PodNetwork create/update/delete events.
 func (r *PodNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -337,7 +338,13 @@ func (r *PodNetworkReconciler) handlePodNetworkDeletion(ctx context.Context, pn 
 		"network-connector.sylvaproject.org/podnetwork": pn.Name,
 		"network-connector.sylvaproject.org/namespace":  pn.Namespace,
 	}); err != nil {
-		return ctrl.Result{}, fmt.Errorf("error listing Calico IPPools for deletion: %w", err)
+		// If the Calico IPPool CRD has been uninstalled there is nothing left to
+		// clean up; treat it as benign so the finalizer can still be removed and
+		// the PodNetwork is not stuck terminating.
+		if !apimeta.IsNoMatchError(err) {
+			return ctrl.Result{}, fmt.Errorf("error listing Calico IPPools for deletion: %w", err)
+		}
+		logger.Info("Calico IPPool CRD not present during deletion, nothing to clean up", "podnetwork", pn.Name)
 	}
 	for i := range pools.Items {
 		if err := r.Delete(ctx, &pools.Items[i]); err != nil && !apierrors.IsNotFound(err) {

--- a/controllers/platform/podnetwork_controller.go
+++ b/controllers/platform/podnetwork_controller.go
@@ -50,6 +50,10 @@ const (
 	// default block we fall back to the pool prefix (see poolBlockSize).
 	defaultIPv4BlockSize = int64(26)
 	defaultIPv6BlockSize = int64(122)
+
+	// dns1123SubdomainMaxLen is the maximum length of a Kubernetes object name
+	// (RFC 1123 subdomain). Calico IPPool names must satisfy it.
+	dns1123SubdomainMaxLen = 253
 )
 
 // PodNetworkReconciler watches PodNetwork resources and reconciles the Calico
@@ -174,10 +178,17 @@ func (r *PodNetworkReconciler) resolveNetworkCIDRs(ctx context.Context, pn *nc.P
 // podNetworkPoolName derives a stable, DNS-safe, cluster-unique IPPool name from
 // the PodNetwork's namespace/name, address family and CIDR. IPPools are
 // cluster-scoped, so the namespace is folded into the hash to avoid collisions
-// between equally named PodNetworks in different namespaces.
+// between equally named PodNetworks in different namespaces. The readable name
+// portion is truncated so the full name stays within the DNS-1123 subdomain
+// limit even for near-max-length PodNetwork names; the hash preserves uniqueness.
 func podNetworkPoolName(namespace, name, family, cidr string) string {
 	sum := sha256.Sum256([]byte(namespace + "/" + name + "/" + cidr))
-	return fmt.Sprintf("pn-%s-%s-%s", name, family, hex.EncodeToString(sum[:4]))
+	const prefix = "pn-"
+	suffix := fmt.Sprintf("-%s-%s", family, hex.EncodeToString(sum[:4]))
+	if budget := dns1123SubdomainMaxLen - len(prefix) - len(suffix); len(name) > budget {
+		name = name[:budget]
+	}
+	return prefix + name + suffix
 }
 
 // poolBlockSize returns a valid Calico blockSize for a pool: the default block
@@ -286,6 +297,9 @@ func (r *PodNetworkReconciler) prunePodNetworkPools(ctx context.Context, pn *nc.
 // updateIPPoolStatus writes the desired pool names into status.ipPools using
 // optimistic concurrency. Only the ipPools field is touched so it never clobbers
 // the fields owned by the intent status updater (conditions, networkIPv4/6, vrfs).
+// Re-fetches use the uncached APIReader: because the PodNetwork status is also
+// written by the intent controller, the cache may be stale after a conflict, and
+// retrying against it would just keep conflicting.
 func (r *PodNetworkReconciler) updateIPPoolStatus(ctx context.Context, pn *nc.PodNetwork, poolNames []string) error {
 	if stringSlicesEqual(pn.Status.IPPools, poolNames) {
 		return nil
@@ -294,7 +308,7 @@ func (r *PodNetworkReconciler) updateIPPoolStatus(ctx context.Context, pn *nc.Po
 	key := types.NamespacedName{Name: pn.Name, Namespace: pn.Namespace}
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		fresh := &nc.PodNetwork{}
-		if err := r.Get(ctx, key, fresh); err != nil {
+		if err := r.APIReader.Get(ctx, key, fresh); err != nil {
 			return fmt.Errorf("error re-fetching PodNetwork for status update: %w", err)
 		}
 		if stringSlicesEqual(fresh.Status.IPPools, poolNames) {

--- a/controllers/platform/podnetwork_controller_test.go
+++ b/controllers/platform/podnetwork_controller_test.go
@@ -111,8 +111,8 @@ func TestPodNetworkReconciler_CreatesDualStackPools(t *testing.T) {
 	if cidr, _, _ := unstructured.NestedString(poolV4.Object, "spec", "cidr"); cidr != "10.244.0.0/16" {
 		t.Errorf("expected cidr 10.244.0.0/16, got %s", cidr)
 	}
-	if nat, _, _ := unstructured.NestedBool(poolV4.Object, "spec", "natOutgoing"); nat {
-		t.Error("expected natOutgoing false")
+	if nat, found, _ := unstructured.NestedBool(poolV4.Object, "spec", "natOutgoing"); !found || nat {
+		t.Errorf("expected natOutgoing to be explicitly false, got value=%v found=%v", nat, found)
 	}
 	if bs, _, _ := unstructured.NestedInt64(poolV4.Object, "spec", "blockSize"); bs != defaultIPv4BlockSize {
 		t.Errorf("expected blockSize %d, got %d", defaultIPv4BlockSize, bs)

--- a/controllers/platform/podnetwork_controller_test.go
+++ b/controllers/platform/podnetwork_controller_test.go
@@ -257,7 +257,8 @@ func TestPodNetworkReconciler_DeletionCleanup(t *testing.T) {
 	reconcilePodNetworkOnce(t, r, "del-pods")
 	reconcilePodNetworkOnce(t, r, "del-pods")
 
-	if pools := listPodNetworkPools(t, r, "del-pods", ""); len(pools) == 0 {
+	existingPools := listPodNetworkPools(t, r, "del-pods", "")
+	if len(existingPools) == 0 {
 		t.Fatal("expected pools to exist before deletion")
 	}
 
@@ -269,10 +270,21 @@ func TestPodNetworkReconciler_DeletionCleanup(t *testing.T) {
 	fresh.DeletionTimestamp = &now
 	// The fake client does not allow setting DeletionTimestamp via Update, so
 	// rebuild the client with the modified object (mirrors coil_controller_test).
+	// Carry the already-created IPPools into the new client so the deletion path
+	// has real objects to remove -- otherwise the post-deletion assertion would
+	// pass vacuously.
 	scheme := newScheme()
-	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(fresh, network).Build()
+	seed := []client.Object{fresh, network}
+	for i := range existingPools {
+		seed = append(seed, &existingPools[i])
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(seed...).Build()
 	r.Client = cli
 	r.APIReader = cli
+
+	if pools := listPodNetworkPools(t, r, "del-pods", ""); len(pools) != len(existingPools) {
+		t.Fatalf("expected %d pools carried into rebuilt client, got %d", len(existingPools), len(pools))
+	}
 
 	reconcilePodNetworkOnce(t, r, "del-pods")
 
@@ -300,6 +312,18 @@ func TestPodNetworkPoolName(t *testing.T) {
 	}
 	if strings.ContainsAny(n1, "./:") {
 		t.Errorf("name %q contains invalid characters", n1)
+	}
+
+	// A near-max-length PodNetwork name must still yield a valid (<=253 char)
+	// pool name; the hash keeps distinct long names distinct after truncation.
+	longName := strings.Repeat("a", 253)
+	long1 := podNetworkPoolName("default", longName, "v4", "10.0.0.0/16")
+	long2 := podNetworkPoolName("default", longName, "v4", "10.1.0.0/16")
+	if len(long1) > dns1123SubdomainMaxLen {
+		t.Errorf("pool name exceeds DNS-1123 limit: len=%d", len(long1))
+	}
+	if long1 == long2 {
+		t.Errorf("expected distinct pool names for distinct CIDRs even when truncated")
 	}
 }
 

--- a/controllers/platform/podnetwork_controller_test.go
+++ b/controllers/platform/podnetwork_controller_test.go
@@ -274,7 +274,8 @@ func TestPodNetworkReconciler_DeletionCleanup(t *testing.T) {
 	// has real objects to remove -- otherwise the post-deletion assertion would
 	// pass vacuously.
 	scheme := newScheme()
-	seed := []client.Object{fresh, network}
+	seed := make([]client.Object, 0, 2+len(existingPools))
+	seed = append(seed, fresh, network)
 	for i := range existingPools {
 		seed = append(seed, &existingPools[i])
 	}

--- a/controllers/platform/podnetwork_controller_test.go
+++ b/controllers/platform/podnetwork_controller_test.go
@@ -1,0 +1,345 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
+)
+
+func reconcilePodNetworkOnce(t *testing.T, r *PodNetworkReconciler, name string) {
+	t.Helper()
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+}
+
+func getPodNetworkPool(t *testing.T, r *PodNetworkReconciler, name string) *unstructured.Unstructured {
+	t.Helper()
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(calicoIPPoolGVK)
+	if err := r.Get(context.Background(), types.NamespacedName{Name: name}, obj); err != nil {
+		return nil
+	}
+	return obj
+}
+
+func listPodNetworkPools(t *testing.T, r *PodNetworkReconciler, podnetwork, family string) []unstructured.Unstructured {
+	t.Helper()
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(calicoIPPoolGVK)
+	sel := client.MatchingLabels{"network-connector.sylvaproject.org/podnetwork": podnetwork}
+	if family != "" {
+		sel["network-connector.sylvaproject.org/family"] = family
+	}
+	if err := r.List(context.Background(), list, sel); err != nil {
+		t.Fatalf("error listing IPPools: %v", err)
+	}
+	return list.Items
+}
+
+func newPodNetworkReconciler(objs ...client.Object) *PodNetworkReconciler {
+	scheme := newScheme()
+	pnObjs := make([]client.Object, 0, len(objs))
+	statusObjs := make([]client.Object, 0)
+	for _, o := range objs {
+		pnObjs = append(pnObjs, o)
+		if _, ok := o.(*nc.PodNetwork); ok {
+			statusObjs = append(statusObjs, o)
+		}
+	}
+	builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pnObjs...)
+	if len(statusObjs) > 0 {
+		builder = builder.WithStatusSubresource(statusObjs...)
+	}
+	cli := builder.Build()
+	return &PodNetworkReconciler{Client: cli, APIReader: cli, Scheme: scheme}
+}
+
+func TestPodNetworkReconciler_CreatesDualStackPools(t *testing.T) {
+	network := &nc.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "net-pods", Namespace: "default"},
+		Spec: nc.NetworkSpec{
+			IPv4: &nc.IPNetwork{CIDR: "10.244.0.0/16"},
+			IPv6: &nc.IPNetwork{CIDR: "fd00:10:244::/48"},
+		},
+	}
+	pn := &nc.PodNetwork{
+		ObjectMeta: metav1.ObjectMeta{Name: "tenant-pods", Namespace: "default"},
+		Spec:       nc.PodNetworkSpec{NetworkRef: "net-pods"},
+	}
+
+	r := newPodNetworkReconciler(pn, network)
+
+	// First reconcile adds finalizer, second creates pools.
+	reconcilePodNetworkOnce(t, r, "tenant-pods")
+	reconcilePodNetworkOnce(t, r, "tenant-pods")
+
+	v4Name := podNetworkPoolName("default", "tenant-pods", "v4", "10.244.0.0/16")
+	poolV4 := getPodNetworkPool(t, r, v4Name)
+	if poolV4 == nil {
+		t.Fatal("expected IPv4 IPPool to exist")
+	}
+	if cidr, _, _ := unstructured.NestedString(poolV4.Object, "spec", "cidr"); cidr != "10.244.0.0/16" {
+		t.Errorf("expected cidr 10.244.0.0/16, got %s", cidr)
+	}
+	if nat, _, _ := unstructured.NestedBool(poolV4.Object, "spec", "natOutgoing"); nat {
+		t.Error("expected natOutgoing false")
+	}
+	if bs, _, _ := unstructured.NestedInt64(poolV4.Object, "spec", "blockSize"); bs != defaultIPv4BlockSize {
+		t.Errorf("expected blockSize %d, got %d", defaultIPv4BlockSize, bs)
+	}
+	if ns, _, _ := unstructured.NestedString(poolV4.Object, "spec", "nodeSelector"); ns != "!all()" {
+		t.Errorf("expected nodeSelector '!all()', got %s", ns)
+	}
+	if uses, _, _ := unstructured.NestedStringSlice(poolV4.Object, "spec", "allowedUses"); len(uses) != 1 || uses[0] != "Workload" {
+		t.Errorf("expected allowedUses [Workload], got %v", uses)
+	}
+	lbls := poolV4.GetLabels()
+	if lbls["app.kubernetes.io/managed-by"] != managedByValue {
+		t.Errorf("expected managed-by label, got %v", lbls)
+	}
+	if lbls["network-connector.sylvaproject.org/podnetwork"] != "tenant-pods" {
+		t.Errorf("expected podnetwork label, got %v", lbls)
+	}
+
+	v6Name := podNetworkPoolName("default", "tenant-pods", "v6", "fd00:10:244::/48")
+	poolV6 := getPodNetworkPool(t, r, v6Name)
+	if poolV6 == nil {
+		t.Fatal("expected IPv6 IPPool to exist")
+	}
+	if bs, _, _ := unstructured.NestedInt64(poolV6.Object, "spec", "blockSize"); bs != defaultIPv6BlockSize {
+		t.Errorf("expected blockSize %d, got %d", defaultIPv6BlockSize, bs)
+	}
+
+	// Status must list both pool names, sorted.
+	updated := &nc.PodNetwork{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "tenant-pods", Namespace: "default"}, updated); err != nil {
+		t.Fatalf("error fetching podnetwork: %v", err)
+	}
+	if len(updated.Status.IPPools) != 2 {
+		t.Fatalf("expected 2 ipPools in status, got %v", updated.Status.IPPools)
+	}
+	want := []string{v4Name, v6Name}
+	// podNetworkPoolName produces deterministic values; ensure both present.
+	got := map[string]bool{updated.Status.IPPools[0]: true, updated.Status.IPPools[1]: true}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("expected status.ipPools to contain %s, got %v", w, updated.Status.IPPools)
+		}
+	}
+}
+
+func TestPodNetworkReconciler_IPv4Only(t *testing.T) {
+	network := &nc.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "net-v4", Namespace: "default"},
+		Spec:       nc.NetworkSpec{IPv4: &nc.IPNetwork{CIDR: "10.10.0.0/24"}},
+	}
+	pn := &nc.PodNetwork{
+		ObjectMeta: metav1.ObjectMeta{Name: "v4-pods", Namespace: "default"},
+		Spec:       nc.PodNetworkSpec{NetworkRef: "net-v4"},
+	}
+
+	r := newPodNetworkReconciler(pn, network)
+	reconcilePodNetworkOnce(t, r, "v4-pods")
+	reconcilePodNetworkOnce(t, r, "v4-pods")
+
+	if pools := listPodNetworkPools(t, r, "v4-pods", "v4"); len(pools) != 1 {
+		t.Errorf("expected 1 IPv4 pool, got %d", len(pools))
+	}
+	if pools := listPodNetworkPools(t, r, "v4-pods", "v6"); len(pools) != 0 {
+		t.Errorf("expected no IPv6 pool, got %d", len(pools))
+	}
+}
+
+func TestPodNetworkReconciler_MissingNetwork(t *testing.T) {
+	pn := &nc.PodNetwork{
+		ObjectMeta: metav1.ObjectMeta{Name: "orphan", Namespace: "default"},
+		Spec:       nc.PodNetworkSpec{NetworkRef: "does-not-exist"},
+	}
+
+	r := newPodNetworkReconciler(pn)
+	reconcilePodNetworkOnce(t, r, "orphan")
+	reconcilePodNetworkOnce(t, r, "orphan")
+
+	if pools := listPodNetworkPools(t, r, "orphan", ""); len(pools) != 0 {
+		t.Errorf("expected no pools when Network is missing, got %d", len(pools))
+	}
+	updated := &nc.PodNetwork{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "orphan", Namespace: "default"}, updated); err != nil {
+		t.Fatalf("error fetching podnetwork: %v", err)
+	}
+	if len(updated.Status.IPPools) != 0 {
+		t.Errorf("expected empty status.ipPools, got %v", updated.Status.IPPools)
+	}
+}
+
+func TestPodNetworkReconciler_PrunesRemovedFamily(t *testing.T) {
+	network := &nc.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "net-shrink", Namespace: "default"},
+		Spec: nc.NetworkSpec{
+			IPv4: &nc.IPNetwork{CIDR: "10.20.0.0/16"},
+			IPv6: &nc.IPNetwork{CIDR: "fd00:20::/48"},
+		},
+	}
+	pn := &nc.PodNetwork{
+		ObjectMeta: metav1.ObjectMeta{Name: "shrink-pods", Namespace: "default"},
+		Spec:       nc.PodNetworkSpec{NetworkRef: "net-shrink"},
+	}
+
+	r := newPodNetworkReconciler(pn, network)
+	reconcilePodNetworkOnce(t, r, "shrink-pods")
+	reconcilePodNetworkOnce(t, r, "shrink-pods")
+
+	if pools := listPodNetworkPools(t, r, "shrink-pods", ""); len(pools) != 2 {
+		t.Fatalf("expected 2 pools, got %d", len(pools))
+	}
+
+	// Remove the IPv6 family from the Network.
+	fresh := &nc.Network{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "net-shrink", Namespace: "default"}, fresh); err != nil {
+		t.Fatalf("error fetching network: %v", err)
+	}
+	fresh.Spec.IPv6 = nil
+	if err := r.Update(context.Background(), fresh); err != nil {
+		t.Fatalf("error updating network: %v", err)
+	}
+
+	reconcilePodNetworkOnce(t, r, "shrink-pods")
+
+	if pools := listPodNetworkPools(t, r, "shrink-pods", "v6"); len(pools) != 0 {
+		t.Errorf("expected IPv6 pool pruned, got %d", len(pools))
+	}
+	if pools := listPodNetworkPools(t, r, "shrink-pods", "v4"); len(pools) != 1 {
+		t.Errorf("expected IPv4 pool retained, got %d", len(pools))
+	}
+}
+
+func TestPodNetworkReconciler_DeletionCleanup(t *testing.T) {
+	network := &nc.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "net-del", Namespace: "default"},
+		Spec:       nc.NetworkSpec{IPv4: &nc.IPNetwork{CIDR: "10.30.0.0/16"}},
+	}
+	pn := &nc.PodNetwork{
+		ObjectMeta: metav1.ObjectMeta{Name: "del-pods", Namespace: "default"},
+		Spec:       nc.PodNetworkSpec{NetworkRef: "net-del"},
+	}
+
+	r := newPodNetworkReconciler(pn, network)
+	reconcilePodNetworkOnce(t, r, "del-pods")
+	reconcilePodNetworkOnce(t, r, "del-pods")
+
+	if pools := listPodNetworkPools(t, r, "del-pods", ""); len(pools) == 0 {
+		t.Fatal("expected pools to exist before deletion")
+	}
+
+	fresh := &nc.PodNetwork{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "del-pods", Namespace: "default"}, fresh); err != nil {
+		t.Fatalf("error fetching podnetwork: %v", err)
+	}
+	now := metav1.NewTime(time.Now())
+	fresh.DeletionTimestamp = &now
+	// The fake client does not allow setting DeletionTimestamp via Update, so
+	// rebuild the client with the modified object (mirrors coil_controller_test).
+	scheme := newScheme()
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(fresh, network).Build()
+	r.Client = cli
+	r.APIReader = cli
+
+	reconcilePodNetworkOnce(t, r, "del-pods")
+
+	if pools := listPodNetworkPools(t, r, "del-pods", ""); len(pools) != 0 {
+		t.Errorf("expected pools to be deleted, got %d", len(pools))
+	}
+}
+
+func TestPodNetworkPoolName(t *testing.T) {
+	n1 := podNetworkPoolName("default", "pn-a", "v4", "10.0.0.0/16")
+	n2 := podNetworkPoolName("default", "pn-a", "v4", "10.0.0.0/16")
+	n3 := podNetworkPoolName("default", "pn-a", "v4", "10.1.0.0/16")
+	n4 := podNetworkPoolName("other", "pn-a", "v4", "10.0.0.0/16")
+	if n1 != n2 {
+		t.Errorf("expected stable name, got %q and %q", n1, n2)
+	}
+	if n1 == n3 {
+		t.Errorf("expected distinct names for distinct CIDRs")
+	}
+	if n1 == n4 {
+		t.Errorf("expected namespace to disambiguate cluster-scoped pool names")
+	}
+	if !strings.HasPrefix(n1, "pn-pn-a-v4-") {
+		t.Errorf("unexpected name %q", n1)
+	}
+	if strings.ContainsAny(n1, "./:") {
+		t.Errorf("name %q contains invalid characters", n1)
+	}
+}
+
+func TestPoolBlockSize(t *testing.T) {
+	// Large pool -> default block size.
+	if bs := poolBlockSize("10.0.0.0/16", defaultIPv4BlockSize); bs != defaultIPv4BlockSize {
+		t.Errorf("expected %d, got %d", defaultIPv4BlockSize, bs)
+	}
+	// Pool smaller than a default block -> pool prefix.
+	if bs := poolBlockSize("10.0.0.0/28", defaultIPv4BlockSize); bs != 28 {
+		t.Errorf("expected 28, got %d", bs)
+	}
+	// IPv6 large pool -> default.
+	if bs := poolBlockSize("fd00::/48", defaultIPv6BlockSize); bs != defaultIPv6BlockSize {
+		t.Errorf("expected %d, got %d", defaultIPv6BlockSize, bs)
+	}
+	// Invalid CIDR -> default fallback.
+	if bs := poolBlockSize("not-a-cidr", defaultIPv4BlockSize); bs != defaultIPv4BlockSize {
+		t.Errorf("expected default fallback %d, got %d", defaultIPv4BlockSize, bs)
+	}
+}
+
+func TestPodNetworkReconciler_MapNetworkToPodNetworks(t *testing.T) {
+	pnMatch := &nc.PodNetwork{
+		ObjectMeta: metav1.ObjectMeta{Name: "pn-match", Namespace: "default"},
+		Spec:       nc.PodNetworkSpec{NetworkRef: "net-x"},
+	}
+	pnOther := &nc.PodNetwork{
+		ObjectMeta: metav1.ObjectMeta{Name: "pn-other", Namespace: "default"},
+		Spec:       nc.PodNetworkSpec{NetworkRef: "net-y"},
+	}
+	network := &nc.Network{ObjectMeta: metav1.ObjectMeta{Name: "net-x", Namespace: "default"}}
+
+	r := newPodNetworkReconciler(pnMatch, pnOther, network)
+
+	reqs := r.mapNetworkToPodNetworks(context.Background(), network)
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(reqs))
+	}
+	if reqs[0].Name != "pn-match" {
+		t.Errorf("expected pn-match, got %s", reqs[0].Name)
+	}
+}

--- a/docs/guides/pod-network.md
+++ b/docs/guides/pod-network.md
@@ -72,7 +72,7 @@ workload) in with the
 First read the provisioned pool names:
 
 ```bash
-kubectl get podnetwork tenant-pods -o jsonpath='{.status.ipPools}'
+kubectl get podnetwork tenant-pods -o json | jq -c '.status.ipPools'
 # e.g. ["pn-tenant-pods-v4-1a2b3c4d","pn-tenant-pods-v6-9f8e7d6c"]
 ```
 
@@ -188,7 +188,7 @@ the resolved VRF names in `status.vrfs`, and a `Ready` condition with status
 
 ```bash
 kubectl get ippools.crd.projectcalico.org \
-  -l network-connector.sylvaproject.org/podnetwork=tenant-pods
+  -l network-connector.sylvaproject.org/podnetwork=tenant-pods,network-connector.sylvaproject.org/namespace=default
 ```
 
 ## Troubleshooting

--- a/docs/guides/pod-network.md
+++ b/docs/guides/pod-network.md
@@ -1,33 +1,48 @@
 ---
 title: PodNetwork
 description: >-
-  Redistribute a pod Network's CIDR into a VRF (BGP-EVPN) so an additional pod
-  network is reachable across the fabric.
+  Provision a Calico IPPool (natOutgoing=false) for a pod Network and redistribute
+  its CIDR into a VRF (BGP-EVPN) so pods can use it and it is reachable across the
+  fabric.
 ---
 
 # PodNetwork
 
-A `PodNetwork` makes an additional pod network **reachable across the fabric** by
-redistributing the referenced
-[`Network`](../getting-started/concepts.md#foundation-vrf-and-network)'s CIDR into
-a VRF. It surfaces the Network's IPv4/IPv6 CIDRs in status and, via a
-`destinations` selector, plumbs the network into the matched VRFs so pod traffic
-on this network is routed there.
+A `PodNetwork` makes an additional pod network **usable by pods and reachable
+across the fabric**. It provisions a
+[Calico](https://docs.tigera.io/calico/latest/reference/) `IPPool` (with
+`natOutgoing: false`) for the referenced
+[`Network`](../getting-started/concepts.md#foundation-vrf-and-network)'s CIDR so
+pods can be allocated addresses from it, and — via a `destinations` selector —
+redistributes that CIDR into the matched VRFs so the pod traffic is routed across
+the BGP-EVPN backbone.
 
-Use a `PodNetwork` when pods have a **secondary / additional network** (assigned
-by your CNI) that must be advertised through a specific VRF backbone — for
-example a tenant overlay reachable via the fabric. `PodNetwork` handles only the
-L3 fabric side (route redistribution); your CNI/IPAM owns the pod addresses.
+Use a `PodNetwork` when pods need a **secondary / additional network** that is
+routable through a specific VRF backbone — for example a tenant overlay reachable
+via the fabric. The operator provisions the Calico `IPPool` and the L3 fabric
+routing; you opt pods into the pool via a Calico annotation (see
+[Using the pool on pods](#using-the-pool-on-pods)).
 
 ## How it works
 
-A `PodNetwork` does two things on the operator side:
+A `PodNetwork` does three things on the operator side:
 
 1. **Resolves the Network** referenced by `spec.networkRef` and surfaces its
    CIDRs in status as `networkIPv4` (`Network.spec.ipv4.cidr`) and `networkIPv6`
    (`Network.spec.ipv6.cidr`). These are empty when the Network has no pool for
    that family or cannot be resolved.
-2. **Redistributes the network into VRFs.** When `spec.destinations` is set, the
+2. **Provisions a Calico `IPPool` per address family** covering the Network's
+   full CIDR, with:
+      - `natOutgoing: false` — the **fabric** performs SNAT (via the VRF), so pod
+        addresses stay routable instead of being masqueraded behind the node IP;
+      - `nodeSelector: "!all()"` — the pool is **not** auto-assigned to ordinary
+        pods, so it never steals addresses from your default pod network; pods
+        opt in explicitly (see below);
+      - `allowedUses: [Workload]` — usable for pod (workload) addressing.
+
+    The generated pool names are reported in `status.ipPools` (sorted). This is
+    handled by the **`platform-coil`** controller.
+3. **Redistributes the network into VRFs.** When `spec.destinations` is set, the
    matched [`Destination`](../getting-started/concepts.md#routing-destination)
    CRDs resolve to a VRF (`Destination.spec.vrfRef`). The operator adds a
    **redistribute-connected** filter for the Network's CIDR into that FabricVRF
@@ -36,29 +51,63 @@ A `PodNetwork` does two things on the operator side:
    `status.vrfs` (sorted, de-duplicated). If `destinations` is omitted, no VRF
    plumbing is performed.
 
-!!! note "PodNetwork does not allocate IPs or attach pods"
-    Unlike [`Inbound`](inbound.md) / [`Outbound`](outbound.md), a `PodNetwork`
-    allocates **no** addresses and creates **no** MetalLB pools, Calico
-    `IPPool`s or Coil `Egress` — there is no platform controller behind it. It
-    only contributes L3 routing (redistribute + aggregate) to the per-node
-    `NodeNetworkConfig`. Pod **IP address management** and **interface
-    attachment** are handled entirely by your **CNI** (for example the primary
-    CNI, or Multus via a `NetworkAttachmentDefinition`) — those resources are
-    external to this operator.
+!!! note "PodNetwork provisions the IPPool, not IPAM or attachment"
+    A `PodNetwork` creates the Calico `IPPool` and the L3 routing, but it does
+    **not** run IPAM or attach interfaces itself: **address allocation** from the
+    pool and **interface attachment** are still performed by **Calico** (the CNI)
+    at pod-creation time, driven by the pod annotation below. It allocates no
+    MetalLB pools and no Coil `Egress`.
 
-`PodNetwork` has no `nodeSelector`; the contribution applies to **all nodes**,
-and pod placement is the scheduler's job.
+`PodNetwork` has no `nodeSelector`; the routing contribution applies to **all
+nodes**, and pod placement is the scheduler's job.
+
+## Using the pool on pods
+
+Because the generated `IPPool` uses `nodeSelector: "!all()"`, Calico will **not**
+hand out its addresses to pods automatically — you opt a pod (or its namespace /
+workload) in with the
+[`cni.projectcalico.org/ipv4pools`](https://docs.tigera.io/calico/latest/networking/ipam/use-specific-ip)
+/ `ipv6pools` annotation, referencing the pool names from `status.ipPools`.
+
+First read the provisioned pool names:
+
+```bash
+kubectl get podnetwork tenant-pods -o jsonpath='{.status.ipPools}'
+# e.g. ["pn-tenant-pods-v4-1a2b3c4d","pn-tenant-pods-v6-9f8e7d6c"]
+```
+
+Then reference them on the pod template (values are JSON arrays of pool names):
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app
+  annotations:
+    cni.projectcalico.org/ipv4pools: '["pn-tenant-pods-v4-1a2b3c4d"]'
+    cni.projectcalico.org/ipv6pools: '["pn-tenant-pods-v6-9f8e7d6c"]'
+spec:
+  containers:
+    - name: app
+      image: nginx
+```
+
+The pod then receives its address(es) from the PodNetwork's pool and — provided a
+`destinations` selector plumbs the network into a VRF — is reachable across the
+fabric with the fabric handling SNAT (`natOutgoing: false`).
 
 ## Prerequisites
 
 Before creating a `PodNetwork` you need:
 
 - A **`Network`** referenced by `spec.networkRef`, in the same namespace, with an
-  `ipv4` and/or `ipv6` CIDR. The `PodNetwork` surfaces these CIDRs in its status.
+  `ipv4` and/or `ipv6` CIDR. The `PodNetwork` surfaces these CIDRs in its status
+  and provisions a Calico `IPPool` for each.
 - For **VRF routing**, one or more **`Destination`** CRDs carrying labels your
   `spec.destinations` selector matches, each bound to a **VRF** via `vrfRef`.
-- A **CNI** capable of consuming an additional network (e.g. the primary CNI, or
-  Multus). This is external to the operator.
+- **Calico** as the (or a) CNI, and the **`platform-coil`** controller running in
+  the cluster (it provisions the `IPPool`s). Pods opt into the pool via the
+  `cni.projectcalico.org/ipv4pools` / `ipv6pools` annotation.
 
 ## Minimal example
 
@@ -121,19 +170,26 @@ kubectl get podnetwork
 kubectl get pnet
 ```
 
-The print columns show `NetworkRef`, `IPv4`, `VRFs` and `Ready` (with `IPv6`
-available at higher verbosity). Inspect the resolved status:
+The print columns show `NetworkRef`, `IPv4`, `VRFs` and `Ready` (with `IPv6` and
+`IPPools` available at higher verbosity). Inspect the resolved status:
 
 ```bash
 kubectl get podnetwork tenant-pods -o jsonpath='{.status.networkIPv4}'
 kubectl get podnetwork tenant-pods -o jsonpath='{.status.networkIPv6}'
+kubectl get podnetwork tenant-pods -o jsonpath='{.status.ipPools}'
 kubectl get podnetwork tenant-pods -o jsonpath='{.status.vrfs}'
 kubectl get podnetwork tenant-pods -o jsonpath='{.status.conditions}' | jq
 ```
 
 A healthy `PodNetwork` reports the Network's CIDRs in `status.networkIPv4` /
-`status.networkIPv6`, the resolved VRF names in `status.vrfs`, and a `Ready`
-condition with status `True`.
+`status.networkIPv6`, the provisioned Calico `IPPool` names in `status.ipPools`,
+the resolved VRF names in `status.vrfs`, and a `Ready` condition with status
+`True`. You can confirm the pools directly:
+
+```bash
+kubectl get ippools.crd.projectcalico.org \
+  -l network-connector.sylvaproject.org/podnetwork=tenant-pods
+```
 
 ## Troubleshooting
 
@@ -150,9 +206,16 @@ condition with status `True`.
 
 !!! note "No `destinations` means no VRF plumbing"
     Omitting `spec.destinations` is valid: the `PodNetwork` still surfaces the
-    Network's CIDRs, but `status.vrfs` stays empty and no VRF routing is
-    programmed. Add a `destinations` selector matching a VRF-bound `Destination`
-    if you need the network plumbed into a VRF.
+    Network's CIDRs and provisions the Calico `IPPool`(s), but `status.vrfs` stays
+    empty and no VRF routing is programmed. Add a `destinations` selector matching
+    a VRF-bound `Destination` if you need the network plumbed into a VRF.
+
+!!! warning "`status.ipPools` stays empty"
+    The `IPPool`s are provisioned by the **`platform-coil`** controller. If
+    `status.ipPools` is empty while the Network resolves, check that
+    `platform-coil` is running and that the Calico `IPPool` CRD
+    (`ippools.crd.projectcalico.org`) is installed — the controller waits for the
+    CRD before creating pools.
 
 ## Related
 

--- a/docs/reference/crd-reference.md
+++ b/docs/reference/crd-reference.md
@@ -1211,6 +1211,7 @@ _Appears in:_
 | `networkIPv4` _string_ | NetworkIPv4 is the IPv4 CIDR of the referenced Network (spec.ipv4.cidr).<br />Empty when the Network has no IPv4 pool or cannot be resolved. |  | Optional: \{\} <br /> |
 | `networkIPv6` _string_ | NetworkIPv6 is the IPv6 CIDR of the referenced Network (spec.ipv6.cidr).<br />Empty when the Network has no IPv6 pool or cannot be resolved. |  | Optional: \{\} <br /> |
 | `vrfs` _string array_ | VRFs lists the VRF names this PodNetwork is plumbed into, derived from the<br />matched Destinations (spec.destinations → Destination.spec.vrfRef). Sorted<br />and de-duplicated. |  | Optional: \{\} <br /> |
+| `ipPools` _string array_ | IPPools lists the names of the Calico IPPools created for this PodNetwork<br />(one per address family, natOutgoing=false). Reference these names from a<br />pod's cni.projectcalico.org/ipv4pools / ipv6pools annotation to allocate<br />pod addresses from this network. Sorted. Empty until the platform-coil<br />controller has provisioned the pools. |  | Optional: \{\} <br /> |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#condition-v1-meta) array_ | Conditions represent the latest available observations of the<br />PodNetwork's current state. |  | Optional: \{\} <br /> |
 
 


### PR DESCRIPTION
## Summary

`PodNetwork` previously only redistributed a `Network`'s CIDR into a VRF and created **no** Calico networks, so pods could not actually be addressed on it. This PR makes PodNetworks usable by pods.

A new `PodNetworkReconciler` in the **platform-coil** binary provisions one Calico `IPPool` per address family covering the referenced Network's full CIDR:

- `natOutgoing: false` — the fabric performs SNAT (via the VRF), so pod addresses stay routable instead of being masqueraded behind the node IP.
- `nodeSelector: "!all()"` — opt-in only; the pool is never auto-assigned to ordinary pods, so it can't hijack the default pod network.
- `allowedUses: [Workload]` — pod (workload) addressing.
- a computed `blockSize` (Calico defaults 26/122, falling back to the pool prefix for small pools).

The generated pool names are surfaced in the new `PodNetwork.status.ipPools` field. Pods opt in via the `cni.projectcalico.org/ipv4pools` / `ipv6pools` annotation referencing those names.

This lives in the coil platform controller package/binary since it shares the Calico `IPPool` ownership model (even though it is driven by a different CRD).

## Changes

- **New controller** `controllers/platform/podnetwork_controller.go`: resolves the Network, creates/updates/prunes IPPools, finalizer-based cleanup, a `Network` watch to (re)create pools once the Network exists, and an optimistic status update that only touches `ipPools` (never clobbers the intent reconciler's status fields).
- **Status**: added `IPPools []string` to `PodNetworkStatus` (+ priority-10 print column); regenerated deepcopy, CRD manifest, and `crd-reference.md`.
- **Wiring**: registered the reconciler in `cmd/platform-coil/main.go`.
- **RBAC**: added `podnetworks`, `podnetworks/status`, `podnetworks/finalizers`, and `networks` read access to `config/platform-coil/rbac.yaml` (and regenerated `manager-role`).
- **Docs**: rewrote `docs/guides/pod-network.md` — corrected the old "creates no IPPool" note and added a "Using the pool on pods" section, verification, and troubleshooting.
- **Tests**: `podnetwork_controller_test.go` covering dual-stack pool creation (asserts `natOutgoing: false`, `!all()`, `allowedUses`, blockSize, labels, status), IPv4-only, missing-Network, family pruning, deletion cleanup, name stability/uniqueness, blockSize helper, and the Network→PodNetwork mapper.

## Notes

- `nodeSelector: "!all()"` makes the pool **opt-in** (via annotation) rather than the default for all pods — matching the existing Outbound pattern and avoiding breaking the primary pod network.
- The status update uses optimistic concurrency and only writes `ipPools`, so the platform-coil controller and the intent status updater don't fight over the PodNetwork status subresource.

## Testing

- `go build ./controllers/platform/... ./api/... ./cmd/platform-coil/...`
- `go vet ./controllers/platform/...`
- `go test ./controllers/platform/... ./api/v1alpha1/network-connector/...`

(`golangci-lint` and the `api/v1alpha1` envtest fail locally due to pre-existing environment issues — a Go 1.26 toolchain mismatch and a missing `etcd` binary — unrelated to these changes.)