### PR TITLE
fix(monitoring): resolve nil pointer dereference in updateBGPNeighborAFs

### DIFF
--- a/pkg/monitoring/vsr.go
+++ b/pkg/monitoring/vsr.go
@@ -330,10 +330,11 @@ func (c *VSRCollector) updateBGPNeighborAFs(
 	}
 
 	if groupName != nil {
-		neighConfig := c.findBGPNeighborGroup(*groupName, bgp)
-		if neighConfig == nil {
+		group := c.findBGPNeighborGroup(*groupName, bgp)
+		if group == nil {
 			return
 		}
+		neighConfig = &group.BGPNeighbor
 	} else {
 		neighConfig = neighState
 	}


### PR DESCRIPTION
## Summary

Fix a nil pointer dereference panic in \`VSRCollector.updateBGPNeighborAFs\` that caused the \`cra-vsr\` agent to crash after NETCONF provisioning on nodes where BGP neighbors belong to a peer-group.

## Problem

In \`pkg/monitoring/vsr.go\`, the variable \`neighConfig\` was re-declared with \`:=\` inside the \`groupName != nil\` branch, shadowing the outer \`var neighConfig *cra.BGPNeighbor\` (line 300). The result of \`findBGPNeighborGroup\` was stored in a block-scoped local that was discarded when the \`if\` block ended, leaving the outer \`neighConfig\` as \`nil\`.

On the subsequent access at \`neighConfig.RemoteAS\`, the nil dereference caused a panic:

\`\`\`
panic: runtime error: invalid memory address or nil pointer dereference
  pkg/monitoring.(*VSRCollector).updateBGPNeighborAFs
    pkg/monitoring/vsr.go:341
\`\`\`

The existing \`if neighConfig == nil { return }\` guard only protected the inner (shadowed) variable — it did not prevent the outer \`neighConfig\` from being nil when the \`if\` block was exited.

## Solution

Use a dedicated \`group\` local variable for the \`*cra.BGPNeighborGroup\` result and then assign \`&group.BGPNeighbor\` to the outer \`neighConfig\`. Since \`BGPNeighborGroup\` embeds \`BGPNeighbor\`, this correctly propagates the peer-group config into the remainder of the function.

\`\`\`go
// Before
neighConfig := c.findBGPNeighborGroup(*groupName, bgp)  // shadows outer neighConfig
if neighConfig == nil {
    return
}
// outer neighConfig still nil here → panic at line 341

// After
group := c.findBGPNeighborGroup(*groupName, bgp)
if group == nil {
    return
}
neighConfig = &group.BGPNeighbor  // outer neighConfig now correctly set
\`\`\`

## Test scope

Manually verified: the fix compiles and the affected code path (\`groupName != nil\`) now correctly sets \`neighConfig\` before use. Unit test coverage for this specific path does not currently exist; a follow-up can add one.

Fixes: SCHIFF-3217