### PR TITLE
feat: render listen-range BGP peers for management VRF

### DIFF
--- a/config/agent-cra-frr/frr.conf.tpl
+++ b/config/agent-cra-frr/frr.conf.tpl
@@ -411,6 +411,12 @@ router bgp {{ $.Config.LocalASN }} vrf {{ $.Config.ManagementVRF.Name }}
   bgp router-id {{ $.Config.VTEPLoopbackIP }}
   no bgp suppress-duplicates
   no bgp default ipv4-unicast
+  {{ if containsKey $.NodeConfig.FabricVRFs $.Config.ManagementVRF.Name }}
+  {{ $mgmtVRF := index $.NodeConfig.FabricVRFs $.Config.ManagementVRF.Name }}
+  {{ range $peer := $mgmtVRF.BGPPeers }}
+  {{ template "bgpNeighbor" $peer }}
+  {{ end }}
+  {{ end }}
 
   address-family ipv4 unicast
     redistribute connected

--- a/pkg/cra-vsr/cra_vsr_test.go
+++ b/pkg/cra-vsr/cra_vsr_test.go
@@ -533,6 +533,52 @@ var _ = Describe("CRA-VSR", func() {
 
 		Expect(manager.baseConfig.MgmtInterface()).To(Equal(manager.baseConfig.TrunkInterfaceName))
 	})
+	It("Renders listen-range peers for the management VRF", func() {
+		listenRange := "192.168.100.0/24"
+		remoteASN := uint32(65099)
+		maxPfx := uint32(10)
+
+		nodeSpec := &v1alpha1.NodeNetworkConfigSpec{
+			FabricVRFs: map[string]v1alpha1.FabricVRF{
+				manager.baseConfig.ManagementVRF.Name: {
+					VNI: uint32(manager.baseConfig.ManagementVRF.VNI),
+					VRF: v1alpha1.VRF{
+						BGPPeers: []v1alpha1.BGPPeer{
+							{
+								ListenRange: &listenRange,
+								RemoteASN:   remoteASN,
+								IPv4: &v1alpha1.AddressFamily{
+									MaxPrefixes: &maxPfx,
+									ImportFilter: &v1alpha1.Filter{
+										DefaultAction: v1alpha1.Action{Type: v1alpha1.Reject},
+									},
+									ExportFilter: &v1alpha1.Filter{
+										DefaultAction: v1alpha1.Action{Type: v1alpha1.Accept},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		generated, err := manager.makeVRouter(nodeSpec)
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := findNamespace(generated, manager.WorkNSName)
+		Expect(ns).ToNot(BeNil())
+
+		mgmtVRF := findVRFByName(ns, manager.baseConfig.ManagementVRF.Name)
+		Expect(mgmtVRF).ToNot(BeNil())
+		Expect(mgmtVRF.Routing).ToNot(BeNil())
+		Expect(mgmtVRF.Routing.BGP).ToNot(BeNil())
+
+		bgp := mgmtVRF.Routing.BGP
+		Expect(bgp.Listen).ToNot(BeNil(), "management VRF BGP should have a listen block")
+		Expect(bgp.Listen.Ranges).ToNot(BeEmpty(), "management VRF BGP should have a listen-range entry")
+		Expect(bgp.Listen.Ranges[0].Range).To(Equal(listenRange))
+	})
 })
 
 func findNamespace(v *VRouter, name string) *Namespace {

--- a/pkg/cra-vsr/layerbgp.go
+++ b/pkg/cra-vsr/layerbgp.go
@@ -941,6 +941,9 @@ func (l *LayerBGP) setupManagementVRF() error {
 		for i, imprt := range conf.VRFImports {
 			l.setupVRFImport(vrf, i, imprt)
 		}
+		for i := range conf.BGPPeers {
+			l.setupNeighbor(bgp, &conf.BGPPeers[i])
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Problem

BGP peers (including `listen-range`) configured on the management VRF were silently dropped by both agents.

**Root cause** — two independent gaps:

### cra-frr (`config/agent-cra-frr/frr.conf.tpl`)
The `FabricVRFs` loop that calls `bgpNeighbor` explicitly skips the management VRF name. The dedicated `router bgp ... vrf <mgmt>` section looked into `FabricVRFs[mgmtName]` for VRF imports but never rendered BGP peers.

### cra-vsr (`pkg/cra-vsr/layerbgp.go`)
`setupManagementVRF()` read static routes and VRF imports from `FabricVRFs[mgmtName]` but had no `BGPPeers` loop, unlike `setupFabricVRF` / `setupLocalVRF`.

The input/builder layer (both new intent and legacy operator path) was unaffected — it placed the peer into `FabricVRFs[mgmtName]` correctly; only the agents discarded it.

## Fix

- **cra-frr**: add a conditional block inside the management VRF `router bgp` section that iterates `FabricVRFs[managementVRFName].BGPPeers` and calls `bgpNeighbor`.
- **cra-vsr**: add the missing `BGPPeers` loop inside the `conf` guard in `setupManagementVRF()`.

## Tests

New cra-vsr unit test: wires a `listen-range` peer into the management VRF's `FabricVRF` entry and asserts the generated VRouter XML contains a listen block with the expected CIDR.