### PR TITLE
fix(status): mirror explicit spec.addresses to status for Inbound and Outbound

### DIFF
--- a/pkg/reconciler/intent/ipam/ipam.go
+++ b/pkg/reconciler/intent/ipam/ipam.go
@@ -118,7 +118,10 @@ func (a *Allocator) reconcileInboundAllocations(ctx context.Context, fetched *re
 		if inb.Spec.Count == nil || inb.Spec.Addresses != nil {
 			continue
 		}
-		if inb.Status.Addresses != nil && len(inb.Status.Addresses.IPv4)+len(inb.Status.Addresses.IPv6) > 0 {
+		// Skip only when status contains a valid IPAM allocation: each non-empty
+		// family has the requested count of bare IPs. CIDRs indicate stale explicit
+		// addresses after an addresses→count mode switch and must be reallocated.
+		if inb.Status.Addresses != nil && ipamAllocatedCorrectly(inb.Status.Addresses, int(*inb.Spec.Count)) {
 			continue
 		}
 		addrs, err := a.allocate(inb.Spec.NetworkRef, int(*inb.Spec.Count), networks, pools, true, nil)
@@ -147,7 +150,8 @@ func (a *Allocator) reconcileOutboundAllocations(ctx context.Context, fetched *r
 		if outb.Spec.Count == nil || outb.Spec.Addresses != nil {
 			continue
 		}
-		if outb.Status.Addresses != nil && len(outb.Status.Addresses.IPv4)+len(outb.Status.Addresses.IPv6) > 0 {
+		// Same stale-address guard as for Inbounds.
+		if outb.Status.Addresses != nil && ipamAllocatedCorrectly(outb.Status.Addresses, int(*outb.Spec.Count)) {
 			continue
 		}
 		addrs, err := a.allocate(outb.Spec.NetworkRef, int(*outb.Spec.Count), networks, pools, true, nil)
@@ -168,6 +172,38 @@ func (a *Allocator) reconcileOutboundAllocations(ctx context.Context, fetched *r
 		a.logger.Info("allocated addresses for Outbound", "outbound", outb.Name, "addresses", addrs)
 	}
 	return nil
+}
+
+// ipamAllocatedCorrectly reports whether addrs looks like a correct IPAM
+// allocation for wantPerFamily IPs. Each non-empty family must have exactly
+// wantPerFamily bare IP addresses of the expected family. This distinguishes
+// IPAM output from stale explicit CIDRs left in status after switching from
+// addresses→count mode.
+func ipamAllocatedCorrectly(addrs *nc.AddressAllocation, wantPerFamily int) bool {
+	if addrs == nil {
+		return false
+	}
+	haveV4, haveV6 := len(addrs.IPv4), len(addrs.IPv6)
+	if haveV4+haveV6 == 0 {
+		return false
+	}
+	if (haveV4 != 0 && haveV4 != wantPerFamily) ||
+		(haveV6 != 0 && haveV6 != wantPerFamily) {
+		return false
+	}
+	for _, address := range addrs.IPv4 {
+		ip := net.ParseIP(address)
+		if ip == nil || ip.To4() == nil {
+			return false
+		}
+	}
+	for _, address := range addrs.IPv6 {
+		ip := net.ParseIP(address)
+		if ip == nil || ip.To4() != nil {
+			return false
+		}
+	}
+	return true
 }
 
 // seedExistingAllocations scans resources with existing status.addresses and
@@ -191,10 +227,22 @@ func (*Allocator) seedExistingAllocations(fetched *resolver.FetchedResources, po
 	// Seed L3 routing pools (Inbound/Outbound) first so a Network shared with an
 	// L2 attachment keeps routed semantics for its already-allocated addresses.
 	for i := range fetched.Inbounds {
-		collectAddresses(fetched.Inbounds[i].Spec.NetworkRef, fetched.Inbounds[i].Status.Addresses, true)
+		inb := &fetched.Inbounds[i]
+		// Skip seeding stale explicit addresses: if we're in count mode but
+		// status.addresses is not valid IPAM output (e.g. CIDRs after an
+		// addresses→count mode switch), it must not advance the pool cursor or
+		// the allocator may report CIDR exhausted when it tries to reallocate.
+		if inb.Spec.Count != nil && inb.Spec.Addresses == nil && !ipamAllocatedCorrectly(inb.Status.Addresses, int(*inb.Spec.Count)) {
+			continue
+		}
+		collectAddresses(inb.Spec.NetworkRef, inb.Status.Addresses, true)
 	}
 	for i := range fetched.Outbounds {
-		collectAddresses(fetched.Outbounds[i].Spec.NetworkRef, fetched.Outbounds[i].Status.Addresses, true)
+		outb := &fetched.Outbounds[i]
+		if outb.Spec.Count != nil && outb.Spec.Addresses == nil && !ipamAllocatedCorrectly(outb.Status.Addresses, int(*outb.Spec.Count)) {
+			continue
+		}
+		collectAddresses(outb.Spec.NetworkRef, outb.Status.Addresses, true)
 	}
 	// Seed from L2A per-node allocations (L2 subnet semantics).
 	for i := range fetched.Layer2Attachments {

--- a/pkg/reconciler/intent/ipam/ipam_test.go
+++ b/pkg/reconciler/intent/ipam/ipam_test.go
@@ -319,3 +319,139 @@ func TestAllocateDualStack(t *testing.T) {
 		assert.Nil(t, alloc)
 	})
 }
+
+func TestSeedExistingAllocationsSkipsStaleExplicitCIDRs(t *testing.T) {
+	count := int32(1)
+	stale := &nc.AddressAllocation{IPv4: []string{"10.0.0.0/32"}}
+	networks := map[string]*resolver.ResolvedNetwork{
+		"net": {
+			Name: "net",
+			Spec: nc.NetworkSpec{IPv4: &nc.IPNetwork{CIDR: "10.0.0.0/30"}},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		fetched *resolver.FetchedResources
+	}{
+		{
+			name: "Inbound",
+			fetched: &resolver.FetchedResources{
+				Inbounds: []nc.Inbound{{
+					Spec:   nc.InboundSpec{NetworkRef: "net", Count: &count},
+					Status: nc.InboundStatus{Addresses: stale.DeepCopy()},
+				}},
+			},
+		},
+		{
+			name: "Outbound",
+			fetched: &resolver.FetchedResources{
+				Outbounds: []nc.Outbound{{
+					Spec:   nc.OutboundSpec{NetworkRef: "net", Count: &count},
+					Status: nc.OutboundStatus{Addresses: stale.DeepCopy()},
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pools := make(map[string]*networkPool)
+			allocator := &Allocator{}
+
+			allocator.seedExistingAllocations(tt.fetched, pools, networks)
+			assert.Empty(t, pools, "stale explicit CIDRs must not seed an IPAM pool")
+
+			allocated, err := allocator.allocate("net", int(count), networks, pools, true, nil)
+			require.NoError(t, err)
+			assert.Equal(t, []string{"10.0.0.0"}, allocated.IPv4)
+		})
+	}
+}
+
+func TestIPAMAllocatedCorrectly(t *testing.T) {
+	tests := []struct {
+		name          string
+		addrs         *nc.AddressAllocation
+		wantPerFamily int
+		expect        bool
+	}{
+		{
+			name:          "nil addrs",
+			addrs:         nil,
+			wantPerFamily: 2,
+			expect:        false,
+		},
+		{
+			name:          "empty both families",
+			addrs:         &nc.AddressAllocation{},
+			wantPerFamily: 2,
+			expect:        false,
+		},
+		{
+			name:          "IPv4-only correct count",
+			addrs:         &nc.AddressAllocation{IPv4: []string{"10.0.0.1", "10.0.0.2"}},
+			wantPerFamily: 2,
+			expect:        true,
+		},
+		{
+			name:          "dual-stack correct count",
+			addrs:         &nc.AddressAllocation{IPv4: []string{"10.0.0.1", "10.0.0.2"}, IPv6: []string{"fd00::1", "fd00::2"}},
+			wantPerFamily: 2,
+			expect:        true,
+		},
+		{
+			name:          "IPv4 count mismatch (stale explicit addresses)",
+			addrs:         &nc.AddressAllocation{IPv4: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}},
+			wantPerFamily: 2,
+			expect:        false,
+		},
+		{
+			name:          "dual-stack IPv6 count mismatch",
+			addrs:         &nc.AddressAllocation{IPv4: []string{"10.0.0.1", "10.0.0.2"}, IPv6: []string{"fd00::1"}},
+			wantPerFamily: 2,
+			expect:        false,
+		},
+		{
+			name:          "explicit IPv4 CIDRs with matching count",
+			addrs:         &nc.AddressAllocation{IPv4: []string{"10.0.0.1/32", "10.0.0.2/32"}},
+			wantPerFamily: 2,
+			expect:        false,
+		},
+		{
+			name:          "explicit IPv6 CIDRs with matching count",
+			addrs:         &nc.AddressAllocation{IPv6: []string{"fd00::1/128", "fd00::2/128"}},
+			wantPerFamily: 2,
+			expect:        false,
+		},
+		{
+			name:          "invalid bare address",
+			addrs:         &nc.AddressAllocation{IPv4: []string{"not-an-ip"}},
+			wantPerFamily: 1,
+			expect:        false,
+		},
+		{
+			name:          "IPv6 address in IPv4 family",
+			addrs:         &nc.AddressAllocation{IPv4: []string{"fd00::1"}},
+			wantPerFamily: 1,
+			expect:        false,
+		},
+		{
+			name:          "IPv4 address in IPv6 family",
+			addrs:         &nc.AddressAllocation{IPv6: []string{"10.0.0.1"}},
+			wantPerFamily: 1,
+			expect:        false,
+		},
+		{
+			name:          "count=1 IPv4-only",
+			addrs:         &nc.AddressAllocation{IPv4: []string{"10.0.0.1"}},
+			wantPerFamily: 1,
+			expect:        true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, ipamAllocatedCorrectly(tt.addrs, tt.wantPerFamily))
+		})
+	}
+}

--- a/pkg/reconciler/intent/status/status.go
+++ b/pkg/reconciler/intent/status/status.go
@@ -241,8 +241,9 @@ func (u *Updater) updateInboundConditions(ctx context.Context, fetched *resolver
 			// Mirror explicit spec.addresses to status so consumers (e.g. kubectl wide
 			// columns, MetalLB controller) can read addresses from a single source.
 			// The IPAM path handles the count-based case separately.
+			// DeepCopy to avoid aliasing the spec and status pointers in-memory.
 			if in.Spec.Addresses != nil {
-				in.Status.Addresses = in.Spec.Addresses
+				in.Status.Addresses = in.Spec.Addresses.DeepCopy()
 			}
 		}); err != nil {
 			return fmt.Errorf("updating Inbound %q status: %w", inb.Name, err)
@@ -272,6 +273,9 @@ func (u *Updater) updateOutboundConditions(ctx context.Context, fetched *resolve
 			setCondition(&o.Status.Conditions, nc.ConditionTypeReady, readyStatus, readyReason, readyMsg, o.Generation)
 			o.Status.VRFs = vrfs
 			o.Status.ObservedGeneration = o.Generation
+			if o.Spec.Addresses != nil {
+				o.Status.Addresses = o.Spec.Addresses.DeepCopy()
+			}
 		}); err != nil {
 			return fmt.Errorf("updating Outbound %q status: %w", outb.Name, err)
 		}

--- a/pkg/reconciler/intent/status/status.go
+++ b/pkg/reconciler/intent/status/status.go
@@ -238,6 +238,12 @@ func (u *Updater) updateInboundConditions(ctx context.Context, fetched *resolver
 			setCondition(&in.Status.Conditions, nc.ConditionTypeReady, readyStatus, readyReason, readyMsg, in.Generation)
 			in.Status.VRFs = vrfs
 			in.Status.ObservedGeneration = in.Generation
+			// Mirror explicit spec.addresses to status so consumers (e.g. kubectl wide
+			// columns, MetalLB controller) can read addresses from a single source.
+			// The IPAM path handles the count-based case separately.
+			if in.Spec.Addresses != nil {
+				in.Status.Addresses = in.Spec.Addresses
+			}
 		}); err != nil {
 			return fmt.Errorf("updating Inbound %q status: %w", inb.Name, err)
 		}


### PR DESCRIPTION
## Problem

When an `Inbound` or `Outbound` uses explicit `spec.addresses`, `status.addresses` was never populated. This left the IPv4/IPv6 columns empty in `kubectl get inbound/outbound -o wide` on workload clusters.

## Flow

```
Management: count -> IPAM -> status.addresses (bare IPs)
Sync ->:    status.addresses -> workload spec.addresses (host CIDRs)
Workload:  spec.addresses -> platform resources
           spec.addresses -> status.addresses  <- this fix
Sync <-:    addresses remain excluded from status sync-back
```

## Fix

1. Mirror explicit `spec.addresses` into `status.addresses` with `DeepCopy()` for both Inbound and Outbound.
2. Keep addresses-to-count mode switches Flux-friendly: count-mode status is considered reusable only when each non-empty family has exactly `spec.count` **bare IPs of the correct family**. Mirrored explicit CIDRs are therefore detected as stale even when their entry count matches.
3. Exclude stale explicit CIDRs from pool seeding so they cannot move the cursor or cause false exhaustion. Reallocation overwrites status only after success; failed allocation preserves the previous status.

## Tests

Added focused coverage for nil/empty allocations, count mismatches, dual stack, CIDR-form explicit addresses, invalid/wrong-family values, and Inbound/Outbound pool seeding after a mode switch.