### PR TITLE
fix(healthcheck): detect Update conflicts with apierrors.IsConflict instead of string matching

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -95,9 +96,14 @@ func (hc *HealthChecker) TaintsRemoved() bool {
 }
 
 // RemoveTaints removes taint from the node.
-// If taint removal fails due to a conflict (node was modified by another process),
-// it logs a warning and returns nil - the taints will be removed on the next reconciliation.
-// This prevents transient conflicts from invalidating the NodeNetworkConfig.
+// If taint removal fails due to a conflict (the node was modified concurrently by
+// kubelet or another controller), it logs the event and returns nil - the taints will
+// be removed on the next reconciliation, which re-Gets the node and therefore starts
+// from a fresh resourceVersion. This prevents transient conflicts from invalidating the
+// NodeNetworkConfig. Deliberately not wrapped in retry.RetryOnConflict: the agents
+// already reconcile on a timer and the callers requeue, so an in-line retry loop would
+// only duplicate that at the cost of holding up the reconcile.
+// Any other error is returned to the caller.
 func (hc *HealthChecker) RemoveTaints(ctx context.Context) error {
 	node := &corev1.Node{}
 	err := hc.client.Get(ctx,
@@ -126,9 +132,10 @@ func (hc *HealthChecker) RemoveTaints(ctx context.Context) error {
 	}
 
 	if err := hc.client.Update(ctx, node, &client.UpdateOptions{}); err != nil {
-		// Conflict errors are transient - the node was modified by another process.
+		// Conflict errors are transient - the node was modified by another process
+		// (kubelet and other controllers write Node concurrently).
 		// Don't fail the healthcheck; taints will be removed on next reconciliation.
-		if strings.Contains(err.Error(), "the object has been modified") {
+		if apierrors.IsConflict(err) {
 			hc.Logger.Info("node object was modified by another process, will retry taint removal on next reconciliation")
 			return nil
 		}
@@ -190,6 +197,19 @@ func (hc *HealthChecker) UpdateReadinessCondition(ctx context.Context, status co
 		RecordNodeReadinessCondition(status == corev1.ConditionTrue, reason)
 	}
 	return nil
+}
+
+// ReportUnready sets the NetworkOperatorReady Node condition to False.
+//
+// It exists for the reconcilers' error paths, where the caller is already returning the
+// underlying failure to its own caller. Failing to publish the condition must not mask
+// that failure, so the error is logged rather than returned - but it is deliberately not
+// discarded silently, since a persistently unpublishable condition means the node's
+// readiness is not observable and is worth an operator's attention.
+func ReportUnready(ctx context.Context, hc HealthCheckerInterface, logger logr.Logger, reason, message string) {
+	if err := hc.UpdateReadinessCondition(ctx, corev1.ConditionFalse, reason, message); err != nil {
+		logger.Error(err, "failed to publish NetworkOperatorReady=False condition", "reason", reason)
+	}
 }
 
 // CheckInterfaces checks if all interfaces in the Interfaces slice are in UP state.

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/vishvananda/netlink"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -232,6 +234,42 @@ var _ = Describe("RemoveTaints()", func() {
 		err = c.Get(context.Background(), types.NamespacedName{Name: testHostname}, node)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(node.Spec.Taints).To(BeEmpty())
+	})
+	It("treats a typed Conflict error as transient and returns no error", func() {
+		c := &taintedNodeClient{updateErr: newConflictError(
+			"Operation cannot be fulfilled on nodes \"" + testHostname + "\": the object has been modified; " +
+				"please apply your changes to the latest version and try again")}
+		hc := newTaintHealthChecker(c)
+		err := hc.RemoveTaints(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		// Taints were not actually removed, so the next reconciliation must try again.
+		Expect(hc.TaintsRemoved()).To(BeFalse())
+	})
+	It("treats a Conflict error without the usual message as transient", func() {
+		// A Conflict StatusError whose message does not contain "the object has been
+		// modified" - the previous string match would have wrongly failed the healthcheck.
+		c := &taintedNodeClient{updateErr: newConflictError("some other conflict cause")}
+		hc := newTaintHealthChecker(c)
+		err := hc.RemoveTaints(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hc.TaintsRemoved()).To(BeFalse())
+	})
+	It("returns non-conflict errors even if the message mentions the object being modified", func() {
+		// A non-Conflict error that merely mentions the phrase - the previous string match
+		// would have wrongly swallowed it and reported success.
+		c := &taintedNodeClient{updateErr: errors.New("webhook denied the request: the object has been modified")}
+		hc := newTaintHealthChecker(c)
+		err := hc.RemoveTaints(context.Background())
+		Expect(err).To(HaveOccurred())
+		Expect(hc.TaintsRemoved()).To(BeFalse())
+	})
+	It("returns other API errors, e.g. Forbidden", func() {
+		c := &taintedNodeClient{updateErr: apierrors.NewForbidden(
+			schema.GroupResource{Resource: "nodes"}, testHostname, errors.New("not allowed"))}
+		hc := newTaintHealthChecker(c)
+		err := hc.RemoveTaints(context.Background())
+		Expect(err).To(HaveOccurred())
+		Expect(hc.TaintsRemoved()).To(BeFalse())
 	})
 })
 var _ = Describe("UpdateReadinessCondition()", func() {
@@ -760,6 +798,44 @@ func (*updateErrorClient) Get(_ context.Context, _ types.NamespacedName, o clien
 		Effect: corev1.TaintEffectNoSchedule,
 	})
 	return nil
+}
+
+// taintedNodeClient returns a node carrying both test taints and fails Update with a
+// configurable error, so RemoveTaints() always reaches the Update error handling.
+type taintedNodeClient struct {
+	client.Client
+	updateErr error
+}
+
+func (c *taintedNodeClient) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+	return c.updateErr
+}
+
+func (*taintedNodeClient) Get(_ context.Context, _ types.NamespacedName, o client.Object, _ ...client.GetOption) error {
+	node, ok := o.(*corev1.Node)
+	if !ok {
+		return fmt.Errorf("error casting object %v as corev1.Node", o)
+	}
+	node.Name = testHostname
+	node.Spec.Taints = append(node.Spec.Taints,
+		corev1.Taint{Key: testTaint, Effect: corev1.TaintEffectNoSchedule},
+		corev1.Taint{Key: testTaint2, Effect: corev1.TaintEffectNoSchedule})
+	return nil
+}
+
+// newConflictError builds a typed Conflict StatusError with an arbitrary message,
+// as the apiserver would return on a resourceVersion mismatch.
+func newConflictError(message string) error {
+	return apierrors.NewConflict(
+		schema.GroupResource{Resource: "nodes"}, testHostname, errors.New(message))
+}
+
+func newTaintHealthChecker(c client.Client) *HealthChecker {
+	hc, err := NewHealthChecker(c, nil, &NetHealthcheckConfig{Taints: []string{testTaint, testTaint2}})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(hc).ToNot(BeNil())
+	Expect(hc.TaintsRemoved()).To(BeFalse())
+	return hc
 }
 
 // statusUpdateErrorClient is a client that fails on Status().Update() calls.

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"
@@ -272,6 +273,37 @@ var _ = Describe("RemoveTaints()", func() {
 		Expect(hc.TaintsRemoved()).To(BeFalse())
 	})
 })
+var _ = Describe("ReportUnready()", func() {
+	It("publishes ConditionFalse with the given reason and message", func() {
+		ctrl := gomock.NewController(GinkgoT())
+		defer ctrl.Finish()
+		hc := mock_healthcheck.NewMockHealthCheckerInterface(ctrl)
+		ctx := context.Background()
+		hc.EXPECT().
+			UpdateReadinessCondition(ctx, corev1.ConditionFalse, "SomeReason", "some message").
+			Return(nil).
+			Times(1)
+
+		ReportUnready(ctx, hc, logr.Discard(), "SomeReason", "some message")
+	})
+	It("does not panic when the condition cannot be published", func() {
+		// The callers are already returning the underlying failure, so a failure to
+		// publish the condition must be logged and must not change control flow.
+		ctrl := gomock.NewController(GinkgoT())
+		defer ctrl.Finish()
+		hc := mock_healthcheck.NewMockHealthCheckerInterface(ctrl)
+		ctx := context.Background()
+		hc.EXPECT().
+			UpdateReadinessCondition(ctx, corev1.ConditionFalse, "SomeReason", "some message").
+			Return(errors.New("api server unreachable")).
+			Times(1)
+
+		Expect(func() {
+			ReportUnready(ctx, hc, logr.Discard(), "SomeReason", "some message")
+		}).ToNot(Panic())
+	})
+})
+
 var _ = Describe("UpdateReadinessCondition()", func() {
 	It("creates readiness condition when absent", func() {
 		node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: testHostname}}

--- a/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go
+++ b/pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go
@@ -466,25 +466,25 @@ func (reconciler *NodeNetplanConfigReconciler) Reconcile(ctx context.Context) er
 	}
 
 	if err := reconcileVLANs(cfg.Spec.DesiredState.Network.VLans); err != nil {
-		_ = reconciler.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionFalse, healthcheck.ReasonVLANReconcileFailed, err.Error())
+		healthcheck.ReportUnready(ctx, reconciler.healthChecker, reconciler.logger, healthcheck.ReasonVLANReconcileFailed, err.Error())
 		return fmt.Errorf("error reconciling VLANs: %w", err)
 	}
 	if err := reconcileLoopbacks(cfg.Spec.DesiredState.Network.Dummies); err != nil {
-		_ = reconciler.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionFalse, healthcheck.ReasonLoopbackReconcileFail, err.Error())
+		healthcheck.ReportUnready(ctx, reconciler.healthChecker, reconciler.logger, healthcheck.ReasonLoopbackReconcileFail, err.Error())
 		return fmt.Errorf("error reconciling loopbacks: %w", err)
 	}
 
 	// Perform health checks (interfaces / reachability / API server)
 	if err := reconciler.healthChecker.CheckInterfaces(); err != nil {
-		_ = reconciler.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionFalse, healthcheck.ReasonInterfaceCheckFailed, err.Error())
+		healthcheck.ReportUnready(ctx, reconciler.healthChecker, reconciler.logger, healthcheck.ReasonInterfaceCheckFailed, err.Error())
 		return fmt.Errorf("error checking network interfaces: %w", err)
 	}
 	if err := reconciler.healthChecker.CheckReachability(); err != nil {
-		_ = reconciler.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionFalse, healthcheck.ReasonReachabilityFailed, err.Error())
+		healthcheck.ReportUnready(ctx, reconciler.healthChecker, reconciler.logger, healthcheck.ReasonReachabilityFailed, err.Error())
 		return fmt.Errorf("error checking network reachability: %w", err)
 	}
 	if err := reconciler.healthChecker.CheckAPIServer(ctx); err != nil {
-		_ = reconciler.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionFalse, healthcheck.ReasonAPIServerFailed, err.Error())
+		healthcheck.ReportUnready(ctx, reconciler.healthChecker, reconciler.logger, healthcheck.ReasonAPIServerFailed, err.Error())
 		return fmt.Errorf("error checking API Server reachability: %w", err)
 	}
 	if err := reconciler.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionTrue, healthcheck.ReasonHealthChecksPassed, "All network operator health checks passed"); err != nil {

--- a/pkg/reconciler/agent-netplan/nodenetplanconfig_reconciler.go
+++ b/pkg/reconciler/agent-netplan/nodenetplanconfig_reconciler.go
@@ -107,21 +107,21 @@ func (reconciler *NodeNetplanConfigReconciler) Reconcile(ctx context.Context) er
 			reconciler.logger.Error(err, "failed to discard pending netplan configuration")
 		}
 	} else if err := netplanConfig.Apply(); err != nil {
-		_ = reconciler.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionFalse, healthcheck.ReasonNetplanApplyFailed, err.Error())
+		healthcheck.ReportUnready(ctx, reconciler.healthChecker, reconciler.logger, healthcheck.ReasonNetplanApplyFailed, err.Error())
 		return fmt.Errorf("error applying desired state: %w", err)
 	}
 
 	// Run basic health checks (interfaces/reachability + API) after applying netplan config
 	if err := reconciler.healthChecker.CheckInterfaces(); err != nil {
-		_ = reconciler.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionFalse, healthcheck.ReasonInterfaceCheckFailed, err.Error())
+		healthcheck.ReportUnready(ctx, reconciler.healthChecker, reconciler.logger, healthcheck.ReasonInterfaceCheckFailed, err.Error())
 		return fmt.Errorf("error checking network interfaces: %w", err)
 	}
 	if err := reconciler.healthChecker.CheckReachability(); err != nil {
-		_ = reconciler.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionFalse, healthcheck.ReasonReachabilityFailed, err.Error())
+		healthcheck.ReportUnready(ctx, reconciler.healthChecker, reconciler.logger, healthcheck.ReasonReachabilityFailed, err.Error())
 		return fmt.Errorf("error checking network reachability: %w", err)
 	}
 	if err := reconciler.healthChecker.CheckAPIServer(ctx); err != nil {
-		_ = reconciler.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionFalse, healthcheck.ReasonAPIServerFailed, err.Error())
+		healthcheck.ReportUnready(ctx, reconciler.healthChecker, reconciler.logger, healthcheck.ReasonAPIServerFailed, err.Error())
 		return fmt.Errorf("error checking API Server reachability: %w", err)
 	}
 	if err := reconciler.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionTrue, healthcheck.ReasonHealthChecksPassed, "All network operator health checks passed"); err != nil {

--- a/pkg/reconciler/common/nodenetworkconfig.go
+++ b/pkg/reconciler/common/nodenetworkconfig.go
@@ -269,17 +269,17 @@ func (r *NodeNetworkConfigReconciler) restoreNodeNetworkConfig(ctx context.Conte
 
 func (r *NodeNetworkConfigReconciler) checkHealth(ctx context.Context) (ctrl.Result, error) {
 	if err := r.healthChecker.CheckInterfaces(); err != nil {
-		_ = r.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionFalse, healthcheck.ReasonInterfaceCheckFailed, err.Error())
+		healthcheck.ReportUnready(ctx, r.healthChecker, r.logger, healthcheck.ReasonInterfaceCheckFailed, err.Error())
 		return ctrl.Result{}, fmt.Errorf("error checking network interfaces: %w", err)
 	}
 
 	if err := r.healthChecker.CheckReachability(); err != nil {
-		_ = r.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionFalse, healthcheck.ReasonReachabilityFailed, err.Error())
+		healthcheck.ReportUnready(ctx, r.healthChecker, r.logger, healthcheck.ReasonReachabilityFailed, err.Error())
 		return ctrl.Result{}, fmt.Errorf("error checking network reachability: %w", err)
 	}
 
 	if err := r.healthChecker.CheckAPIServer(ctx); err != nil {
-		_ = r.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionFalse, healthcheck.ReasonAPIServerFailed, err.Error())
+		healthcheck.ReportUnready(ctx, r.healthChecker, r.logger, healthcheck.ReasonAPIServerFailed, err.Error())
 		return ctrl.Result{}, fmt.Errorf("error checking API Server reachability: %w", err)
 	}
 


### PR DESCRIPTION
## Why string-matching a Kubernetes error is wrong

`RemoveTaints` decided whether a failed Node `Update` was transient by substring-matching the
error text:

```go
if strings.Contains(err.Error(), "the object has been modified") {
    return nil // treat as transient
}
```

That phrase is a formatting detail of the message the apiserver's registry builds for a
`resourceVersion` mismatch. It is not API surface — nothing guarantees it, no compatibility
policy covers it, and it can be reworded. Kubernetes exposes the answer as typed data: a
`*metav1.StatusError` carrying `Reason: metav1.StatusReasonConflict`, which is exactly what
`apierrors.IsConflict` inspects.

The string match was wrong in **both** directions:

| Case | Old behaviour | New behaviour |
|---|---|---|
| Conflict, usual message | transient, `return nil` | transient, `return nil` (unchanged) |
| Conflict, **different** message | **hard error** — invalidates NodeNetworkConfig over a routine concurrent write | transient, `return nil` |
| **Non**-Conflict error that quotes the phrase (e.g. a validating webhook echoing it back) | **swallowed, reported as success** — taints silently never removed | error returned |
| Any other error (Forbidden, timeout, …) | error returned | error returned (unchanged) |

The second row is the availability bug; the third is the silent-failure bug — the exact class
the backwards-compat contract calls out as "accepted, inert, reported as success".

## Every error-string-match site found

I grepped the whole repo for `strings.Contains(err.Error(`, `"already exists"`, `"not found"`,
`"has been modified"` and `"conflict"`.

**Fixed (1 — the only Kubernetes-error string match in the repo):**
- `pkg/healthcheck/healthcheck.go:131` → `apierrors.IsConflict(err)`

**Found and deliberately left alone (not Kubernetes errors):**
- `pkg/healthcheck/healthcheck.go:284,340` — `strings.Contains(err.Error(), "refused")` on a
  `net.Dial` result. These are Go net errors, not API errors. Matching on `"refused"` is still
  fragile (`syscall.ECONNREFUSED` via `errors.Is` would be better) but it is an unrelated
  concern in unrelated code, so it is out of scope for this PR. Noted as a follow-up below.
- Test-only assertions on message text (`cluster_controller_test.go:151`,
  `routes_test.go:76,82`, `ipam_test.go:120,302`, `bgp_announcement_test.go:600`) — asserting on
  your own error strings in your own tests is fine.

Everywhere else in the repo already uses the typed helpers correctly (`apierrors.IsNotFound`,
`IsAlreadyExists`, `IsConflict`) — 40+ call sites across `controllers/`, `pkg/reconciler/` and
`e2etests/`. This was the lone outlier.

## The retry/patch decision

**Decision: keep Get + full Update, return `nil` on conflict, and let the next reconcile retry.
No `retry.RetryOnConflict`, no merge patch.** The previous behaviour was defensible but
implicit; it is now stated in the function's doc comment rather than left to be inferred.

Justification:

- **The work is already idempotent and already retried.** Each agent reconciles on a timer, and
  the callers requeue (`pkg/reconciler/common/nodenetworkconfig.go:147,279` return
  `RequeueAfter: TaintRemovalRequeueTime`). `taintsRemoved` stays `false`, so the next pass
  re-`Get`s the node — from a fresh `resourceVersion` — and tries again. An in-line
  `RetryOnConflict` would duplicate that loop while holding up the reconcile, and it would still
  need this same "give up eventually" branch.
- **Taint removal is not latency-critical.** It happens once per node at startup. Trading a few
  seconds of extra delay for a simpler, non-blocking code path is the right side of that trade.
- **A merge patch would be wrong here.** Removing an element from `spec.taints` is a
  read-modify-write on a list; a JSON merge patch on `taints` replaces the whole list, which
  would clobber taints added concurrently by another actor — reintroducing the lost-update
  problem that the conflict check exists to prevent. A conflict-detected optimistic update is
  the correct primitive for this operation. (JSON *patch* with a test-and-remove on an index
  would work but is more fragile than the current retry-next-time approach.)

So the only real defect was the detection, which is what this PR fixes.

## Error-swallowing assessment (callers)

I checked all 12 sites across the four agents. **The control flow is correct and I did not
change it.** In every case the caller is already returning the underlying failure:

```go
if err := reconciler.healthChecker.CheckInterfaces(); err != nil {
    _ = reconciler.healthChecker.UpdateReadinessCondition(ctx, corev1.ConditionFalse, ...)
    return fmt.Errorf("error checking network interfaces: %w", err) // <- real error propagates
}
```

Letting a condition-publish error override that would replace the actual diagnosis
("interface eth0 is down") with a much less useful one ("couldn't update node status"). So
discarding is deliberate and right.

What was wrong is that it was *invisible*: a bare `_ =` at twelve sites, with the reasoning
written down nowhere, and a persistently failing status write producing no signal at all — a
node whose readiness condition cannot be published is not observable. Second commit introduces
`healthcheck.ReportUnready`, which keeps the control flow byte-for-byte identical, logs instead
of dropping, and states the rationale once on the helper. No call site's return value or
ordering changes.

`RemoveTaints` errors at the caller are **not** swallowed — `agent-netplan` and `agent-hbn-l2`
return them, `common` logs and requeues. Left as-is.

## NodeCondition logic — verified, not changed

As requested I only audited `UpdateReadinessCondition` (`healthcheck.go:32-44`, `148-193`). The
manual loop over `node.Status.Conditions` is **correct**:

- `LastTransitionTime` is updated only inside `if c.Status != status`, which is the documented
  semantic. `LastHeartbeatTime` is updated unconditionally. Correct.
- Takes `&node.Status.Conditions[i]`, so it mutates in place rather than a copy. Correct.
- Appends with both timestamps set when the condition is absent. Correct.
- Writes via `Status().Update()`, the right subresource.

And to be explicit about the tempting non-fix: `meta.SetStatusCondition` operates on
`[]metav1.Condition`, whereas `Node.Status.Conditions` is `[]corev1.NodeCondition` — a distinct
type with `LastHeartbeatTime` and no `ObservedGeneration`. There is no upstream helper for
NodeConditions; the manual loop is the only option and it is right. **Not touched.**

## Test evidence — both branches

Four specs added to `RemoveTaints()`, covering both directions of the fix. Full suite:

```
Ran 60 of 60 Specs in 0.084 seconds
SUCCESS! -- 60 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestHealthCheck (0.09s)
ok  github.com/telekom/das-schiff-network-operator/pkg/healthcheck  4.760s
```

(56 specs before, 60 after.)

**Proof the tests actually pin the bug.** I reverted just the one-line predicate back to
`strings.Contains(err.Error(), "the object has been modified")`, keeping the new tests, and
re-ran:

```
Summarizing 2 Failures:
  healthcheck_test.go:254   <- Conflict whose message differs: old code returned an error
  healthcheck_test.go:263   <- non-Conflict quoting the phrase: old code swallowed it
FAIL! -- 58 Passed | 2 Failed | 0 Pending | 0 Skipped
```

Exactly the two discriminating cases fail against the old implementation and pass against the
new one. The two rows the string match got right (usual-message conflict, Forbidden) pass under
both, which is the no-regression evidence.

Also run: `pkg/reconciler/common` `ok ... 6.665s` (exercises the `ReportUnready` call sites).

## Backwards compatibility

Per `BACKWARDS-COMPAT-CONTRACT.md`: **low risk, correctness-only, no version gate involved.**

- `apierrors.IsConflict` has been stable in `apimachinery` for the project's entire history and
  reads `Status().Reason`, which the apiserver has set on 409s since long before any version
  this operator could run against. There is no version floor to check and nothing to
  feature-detect — it is strictly *more* reliable than the string match, since it does not
  depend on message wording that varies across apiserver versions.
- No CRD change, no new field, no RBAC change, no API-surface change.
- Behaviour is byte-identical for the two cases the old code got right; the two it got wrong now
  behave per the table above. The same conflict cases are still transient, and a genuinely
  different error is still returned as an error — proven by the revert experiment.

## Verification run

| Gate | Result |
|---|---|
| `make manifests` + deepcopy gen, then `git status` | clean — only my 5 files, no generated drift (the `validate-generated` gate) |
| `make fmt` | clean, no reformatting |
| `golangci-lint run` (v2.10.1, `GOOS=linux`) on all changed packages | **no new findings.** One pre-existing `gosec G703` in `LoadConfig` (untouched code); confirmed identical on a stashed baseline — only its line number moved, 380 → 400 |
| `go test ./pkg/healthcheck/... ./pkg/reconciler/common/...` | pass, output above |
| `GOOS=linux GOARCH=amd64 go build` on changed packages | clean |

Two notes on the local environment, both pre-existing and unrelated:
- `make generate` cannot complete here — `bpf-generate` needs `llvm-strip`, which is not
  installed on this machine. I ran the `controller-gen` deepcopy step directly instead and
  confirmed no drift. CI has the toolchain.
- `go vet ./...` / lint fail on **darwin** inside `github.com/safchain/ethtool` and
  `netlink.BridgeVlanAdd` — Linux-only dependencies. Verified identical on a stashed baseline
  and clean under `GOOS=linux`, which is what CI runs.

## Follow-ups deliberately out of scope

Kept out to keep this reviewable; each is independent:

- Conditions / `observedGeneration` on the 6 CRDs (4 have empty `Status` structs) — larger.
- Server-Side Apply / field owners for Node writes — would change the concurrency story here,
  worth its own discussion.
- Scoping the agents' caches with field selectors — larger.
- `configrevision_reconciler.go:547` TODO about using the `node.kubernetes.io/not-ready` taint.
- `"refused"` string matching in `CheckReachability` / `checkReachabilityItemWithRetry`
  (`healthcheck.go:284,340`) — should be `errors.Is(err, syscall.ECONNREFUSED)`. Same *category*
  of fragility as this fix but in Go net errors rather than API errors, and it needs its own
  tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
