### PR TITLE
fix(nl): use kernel feature names for segmentation offload

### DIFF
--- a/pkg/nl/layer2.go
+++ b/pkg/nl/layer2.go
@@ -34,10 +34,23 @@ func sanitizeIntfName(name string) (string, error) {
 	return s, nil
 }
 
+// segmentationFeatureCandidates lists the offload features to toggle, keyed by
+// the names the kernel exposes through ETH_SS_FEATURES. Those are the raw
+// netdev_features_strings[] entries, not the aliases ethtool(8) prints
+// ("gro", "generic-receive-offload", "tso", ...) - the aliases are a userspace
+// display convenience and never appear in the netlink/ioctl API, so matching on
+// them silently matched nothing.
+//
+// Each group is a fallback chain: segmentationSettings() takes the first name
+// that the interface actually reports, so distinct features must stay in
+// distinct groups.
 var segmentationFeatureCandidates = [][]string{
-	{"generic-receive-offload", "gro"},
-	{"generic-segmentation-offload", "gso"},
-	{"tcp-segmentation-offload", "tx-tcp-segmentation", "tso"},
+	{"rx-gro"},
+	{"tx-generic-segmentation"},
+	// TSO is per-address-family; clearing only the IPv4 bit still lets IPv6
+	// TCP frames traverse the interface unsegmented.
+	{"tx-tcp-segmentation"},
+	{"tx-tcp6-segmentation"},
 }
 
 type Layer2Information struct {

--- a/pkg/nl/layer2.go
+++ b/pkg/nl/layer2.go
@@ -47,8 +47,11 @@ func sanitizeIntfName(name string) (string, error) {
 var segmentationFeatureCandidates = [][]string{
 	{"rx-gro"},
 	{"tx-generic-segmentation"},
-	// TSO is per-address-family; clearing only the IPv4 bit still lets IPv6
-	// TCP frames traverse the interface unsegmented.
+	// TSO is per-address-family: net_gso_ok() consults NETIF_F_TSO6 for IPv6
+	// TCP. Clearing only the IPv4 bit leaves netif_needs_gso() false for IPv6,
+	// so the stack hands the aggregate GSO skb on as-is. This path is 8021q
+	// over a veth, where no hardware segmentation can take over, so the pod
+	// ends up receiving one oversized frame.
 	{"tx-tcp-segmentation"},
 	{"tx-tcp6-segmentation"},
 }

--- a/pkg/nl/mock_ethtool_test.go
+++ b/pkg/nl/mock_ethtool_test.go
@@ -12,9 +12,10 @@ func (m *MockEthtool) Features(intf string) (map[string]bool, error) {
 		return m.FeaturesFunc(intf)
 	}
 	return map[string]bool{
-		"generic-receive-offload":      true,
-		"generic-segmentation-offload": true,
-		"tcp-segmentation-offload":     true,
+		"rx-gro":                  true,
+		"tx-generic-segmentation": true,
+		"tx-tcp-segmentation":     true,
+		"tx-tcp6-segmentation":    true,
 	}, nil
 }
 

--- a/pkg/nl/nl_test.go
+++ b/pkg/nl/nl_test.go
@@ -1419,9 +1419,10 @@ var _ = Describe("setSegmentation()", func() {
 		mockEth := &MockEthtool{
 			FeaturesFunc: func(_ string) (map[string]bool, error) {
 				return map[string]bool{
-					"generic-receive-offload":      true,
-					"generic-segmentation-offload": true,
-					"tcp-segmentation-offload":     true,
+					"rx-gro":                  true,
+					"tx-generic-segmentation": true,
+					"tx-tcp-segmentation":     true,
+					"tx-tcp6-segmentation":    true,
 				}, nil
 			},
 			ChangeFunc: func(intf string, config map[string]bool) error {
@@ -1439,9 +1440,10 @@ var _ = Describe("setSegmentation()", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(capturedIntf).To(Equal("vlan100"))
 		Expect(capturedConfig).To(Equal(map[string]bool{
-			"generic-receive-offload":      false,
-			"generic-segmentation-offload": false,
-			"tcp-segmentation-offload":     false,
+			"rx-gro":                  false,
+			"tx-generic-segmentation": false,
+			"tx-tcp-segmentation":     false,
+			"tx-tcp6-segmentation":    false,
 		}))
 		Expect(mockEth.Closed).To(BeTrue())
 	})
@@ -1452,9 +1454,10 @@ var _ = Describe("setSegmentation()", func() {
 		mockEth := &MockEthtool{
 			FeaturesFunc: func(_ string) (map[string]bool, error) {
 				return map[string]bool{
-					"generic-receive-offload":      false,
-					"generic-segmentation-offload": false,
-					"tcp-segmentation-offload":     false,
+					"rx-gro":                  false,
+					"tx-generic-segmentation": false,
+					"tx-tcp-segmentation":     false,
+					"tx-tcp6-segmentation":    false,
 				}, nil
 			},
 			ChangeFunc: func(intf string, config map[string]bool) error {
@@ -1472,9 +1475,10 @@ var _ = Describe("setSegmentation()", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(capturedIntf).To(Equal("vlan200"))
 		Expect(capturedConfig).To(Equal(map[string]bool{
-			"generic-receive-offload":      true,
-			"generic-segmentation-offload": true,
-			"tcp-segmentation-offload":     true,
+			"rx-gro":                  true,
+			"tx-generic-segmentation": true,
+			"tx-tcp-segmentation":     true,
+			"tx-tcp6-segmentation":    true,
 		}))
 		Expect(mockEth.Closed).To(BeTrue())
 	})
@@ -1483,9 +1487,10 @@ var _ = Describe("setSegmentation()", func() {
 		mockEth := &MockEthtool{
 			FeaturesFunc: func(_ string) (map[string]bool, error) {
 				return map[string]bool{
-					"generic-receive-offload":      false,
-					"generic-segmentation-offload": false,
-					"tcp-segmentation-offload":     false,
+					"rx-gro":                  false,
+					"tx-generic-segmentation": false,
+					"tx-tcp-segmentation":     false,
+					"tx-tcp6-segmentation":    false,
 				}, nil
 			},
 		}


### PR DESCRIPTION
## Problem

`segmentationFeatureCandidates` in `pkg/nl/layer2.go` matched against the **display aliases** printed by `ethtool(8)`:

```go
{"generic-receive-offload", "gro"},
{"generic-segmentation-offload", "gso"},
{"tcp-segmentation-offload", "tx-tcp-segmentation", "tso"},
```

Those aliases exist **only in the `ethtool(8)` userspace binary** (`off_flag_def[]`). They never cross the kernel boundary.

The kernel returns the raw `netdev_features_strings[]` entries over `ETH_SS_FEATURES`:
- `net/ethtool/ioctl.c:165,197` → `net/ethtool/strset.c:25` — copied verbatim, no aliasing
- `safchain/ethtool@v0.7.0` `ethtool.go:1006-1037` — passes them through unchanged

So the interface reports `rx-gro`, `tx-generic-segmentation`, `tx-tcp-segmentation`, … and **two of the three groups matched nothing at all**. Only the third group matched, and only via its middle entry.

Since `segmentationSettings()` skips names the interface does not report, `disableSegmentation: true` was silently degraded to "clear IPv4 TSO only" — GRO and GSO were never touched.

## Fix

Use the names the kernel actually reports:

| name | kernel source |
|---|---|
| `rx-gro` | `net/ethtool/common.c:29` |
| `tx-generic-segmentation` | `net/ethtool/common.c:26` |
| `tx-tcp-segmentation` | `net/ethtool/common.c:33` |
| `tx-tcp6-segmentation` | `net/ethtool/common.c:37` |

### `tx-tcp6-segmentation` is newly added

TSO is **per address family**. `net_gso_ok()` (`include/linux/netdevice.h:5060-5086`) selects `NETIF_F_TSO6` for `SKB_GSO_TCPV6`, so clearing only the IPv4 bit left IPv6 TCP traversing the interface unsegmented.

This matches `ethtool(8)`'s own behaviour: its `tso` alias expands to the **wildcard** `tx-tcp*-segmentation`, which is why the documented manual workaround (`ethtool -K … tso off`) clears both bits while the operator only cleared one.

### One name per group

`segmentationSettings()` `break`s after the first hit within a group — groups are **fallback chains for alternative spellings of the same feature**, not sets of distinct features. Now that each name is unambiguous and always reported, each gets its own group so all four are actually applied.

## Notes

- `pkg/reconciler/agent-hbn-l2/nodenetplanconfig_reconciler.go:56` also uses `generic-receive-offload`, but that is a **netplan schema key**, not an ethtool feature name. Correctly left untouched.
- Likely textual conflicts with the open PRs #344 and #306, which both still carry the old alias list.

## Testing

`go test ./pkg/nl/...` passes (executed in a `golang:1.25` linux container — the package cannot run natively on darwin). Test fixtures in `nl_test.go` and `mock_ethtool_test.go` updated to the kernel names, including the new IPv6 entry.
