### PR TITLE
fix(nl): apply GRO/GSO max size to the bridge-port veth

### DIFF
--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8.0.0
         with:
+          version: v2.8.0
           args: --timeout=10m
 
   test:

--- a/pkg/nl/layer2.go
+++ b/pkg/nl/layer2.go
@@ -170,6 +170,14 @@ func (n *Manager) setupVXLAN(info *Layer2Information, bridge *netlink.Bridge) er
 		return err
 	}
 
+	// The veth is the bridge port, so it is the device the bridge sets as
+	// skb->dev when forwarding a frame towards the pods. Only its GSO limit
+	// governs whether frames coalesced by GRO on the underlay get
+	// re-segmented on the way in.
+	if err := n.setGroGsoMaxSize(link, info.GroGsoMaxSize()); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -329,8 +337,17 @@ func (n *Manager) setMTU(current, desired *Layer2Information) error {
 			return fmt.Errorf("error setting veth macvlan side MTU: %w", err)
 		}
 	}
+	// Kept on the bridge because br_dev_xmit() runs with skb->dev set to the
+	// bridge for locally routed traffic (anycast gateway / IRB egress).
 	if err := n.setGroGsoMaxSize(current.bridge, desired.GroGsoMaxSize()); err != nil {
 		return fmt.Errorf("error setting GRO/GSO max size: %w", err)
+	}
+	// Bridged traffic towards the pods leaves through the veth, never through
+	// the bridge itself, so the veth needs the same limit.
+	if current.macvlanBridge != nil {
+		if err := n.setGroGsoMaxSize(current.macvlanBridge, desired.GroGsoMaxSize()); err != nil {
+			return fmt.Errorf("error setting GRO/GSO max size on veth bridge side: %w", err)
+		}
 	}
 	return nil
 }
@@ -431,6 +448,9 @@ func (n *Manager) setupMACVLANinterface(current, desired *Layer2Information) err
 			return fmt.Errorf("error creating MACVLAN interface: %w", err)
 		}
 		current.macvlanBridge = veth
+		if err := n.setGroGsoMaxSize(veth, desired.GroGsoMaxSize()); err != nil {
+			return fmt.Errorf("error setting GRO/GSO max size on veth bridge side: %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/nl/nl_test.go
+++ b/pkg/nl/nl_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	mock_nl "github.com/telekom/das-schiff-network-operator/pkg/nltoolkit/mock"
 	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sys/unix"
 )
@@ -540,7 +541,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return(nil, errors.New("error listing addresses"))
 
 		err := nm.ReconcileL2(current, desired)
@@ -562,7 +563,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.ParseIP("2001::"))}}, nil)
 
 		err := nm.ReconcileL2(current, desired)
@@ -584,7 +585,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(errors.New("unable to set link down"))
 
@@ -607,7 +608,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(errors.New("unable to change MAC address"))
@@ -631,7 +632,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -656,7 +657,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -684,7 +685,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -713,7 +714,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -746,7 +747,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -775,7 +776,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -805,7 +806,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -836,7 +837,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -868,7 +869,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -901,7 +902,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -935,7 +936,7 @@ var _ = Describe("ReconcileL2()", func() {
 		}
 
 		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Any()).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.IPv4(0, 0, 0, 0))}}, nil)
 		netlinkMock.EXPECT().LinkSetDown(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetHardwareAddr(gomock.Any(), gomock.Any()).Return(nil)
@@ -1019,7 +1020,7 @@ var _ = Describe("ReconcileL2()", func() {
 		netlinkMock.EXPECT().LinkSetLearning(gomock.Any(), gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetUp(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkAdd(gomock.Any()).Return(nil)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrAdd(gomock.Any(), gomock.Any()).Return(errors.New("cannot add address"))
 
 		vlanName := fmt.Sprintf("%s%d", layer2Prefix, current.VlanID)
@@ -1089,7 +1090,7 @@ var _ = Describe("ReconcileL2()", func() {
 		netlinkMock.EXPECT().LinkSetLearning(gomock.Any(), gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetUp(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkAdd(gomock.Any()).Return(nil)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrAdd(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		netlinkMock.EXPECT().AddrDel(gomock.Any(), gomock.Any()).Return(errors.New("cannot delete address"))
 
@@ -1152,7 +1153,7 @@ var _ = Describe("ReconcileL2()", func() {
 		netlinkMock.EXPECT().LinkSetLearning(gomock.Any(), gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkSetUp(gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().LinkAdd(gomock.Any()).Return(nil)
-		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return([][]byte{}, nil).Times(2)
 		netlinkMock.EXPECT().AddrAdd(gomock.Any(), gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().AddrDel(gomock.Any(), gomock.Any()).Return(nil)
 		netlinkMock.EXPECT().AddrList(gomock.Any(), gomock.Eq(unix.AF_INET6)).Return([]netlink.Addr{{IPNet: netlink.NewIPNet(net.ParseIP("2a01::1")), Flags: unix.IFA_F_DADFAILED}}, nil)
@@ -1189,6 +1190,51 @@ var _ = Describe("ReconcileL2()", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		procSysNetPath = oldProcSysNetPath
+	})
+})
+
+var _ = Describe("setMTU()", func() {
+	It("caps GRO/GSO on both the bridge and the bridge-side veth", func() {
+		netlinkMock := mock_nl.NewMockToolkitInterface(mockctrl)
+		nm := NewManager(netlinkMock)
+		current := &Layer2Information{
+			bridge:        &netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Index: 11}},
+			vxlan:         &netlink.Vxlan{LinkAttrs: netlink.LinkAttrs{Index: 12}},
+			macvlanBridge: &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Index: 13}},
+			macvlanHost:   &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Index: 14}},
+		}
+		desired := &Layer2Information{
+			MTU:                 1399,
+			DisableSegmentation: true,
+		}
+
+		cappedIndexes := []int32{}
+		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(4)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(req *nl.NetlinkRequest, _ int, _ uint16) ([][]byte, error) {
+				msg, ok := req.Data[0].(*nl.IfInfomsg)
+				Expect(ok).To(BeTrue())
+				cappedIndexes = append(cappedIndexes, msg.Index)
+				return [][]byte{}, nil
+			}).Times(2)
+
+		Expect(nm.setMTU(current, desired)).To(Succeed())
+		Expect(cappedIndexes).To(ConsistOf(int32(11), int32(13)))
+	})
+	It("only caps the bridge if no veth exists yet", func() {
+		netlinkMock := mock_nl.NewMockToolkitInterface(mockctrl)
+		nm := NewManager(netlinkMock)
+		current := &Layer2Information{
+			bridge: &netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Index: 11}},
+			vxlan:  &netlink.Vxlan{LinkAttrs: netlink.LinkAttrs{Index: 12}},
+		}
+		desired := &Layer2Information{MTU: 1399}
+
+		netlinkMock.EXPECT().LinkSetMTU(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+		netlinkMock.EXPECT().ExecuteNetlinkRequest(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([][]byte{}, nil).Times(1)
+
+		Expect(nm.setMTU(current, desired)).To(Succeed())
 	})
 })
 


### PR DESCRIPTION
Refs #287

## Problem

`disableSegmentation` (#174) caps `IFLA_GRO_MAX_SIZE` / `IFLA_GSO_MAX_SIZE` to the MTU, but it only ever does so on **`l2.<vid>`** — the bridge netdev itself:

```go
// setupBridge()
n.setGroGsoMaxSize(bridge, info.GroGsoMaxSize())
// setMTU()
n.setGroGsoMaxSize(current.bridge, desired.GroGsoMaxSize())
```

For frames the bridge **forwards**, that device is never consulted:

- `net/bridge/br_forward.c:91-92` — `__br_forward()` assigns `skb->dev = to->dev` (the **egress port**) before `dev_queue_xmit()`
- `net/core/dev.c:3507` — `netif_skb_features()` starts with `struct net_device *dev = skb->dev;`
- `net/core/dev.c:3465-3503` — `gso_features_check()` compares `skb->len` against `netif_get_gso_max_size(dev, skb)` and strips `NETIF_F_GSO_MASK`, which is what makes `validate_xmit_skb()` call `skb_gso_segment()`

So for the pod-ingress direction the bridge's own limit is inert. The device that matters is the **bridge port**, which here is the veth **`l2v.<vid>`** — `createLink()` sets `MasterIndex` on the `l2v` side, and `Layer2Information.macvlanBridge` (confusingly named) holds exactly that link.

Net effect: the feature never did anything for the case it was written for — re-segmenting skbs that GRO coalesced on the underlay before they reach the macvlan pods.

## Fix

Apply the cap to `macvlanBridge` (`l2v.<vid>`) in all three places the veth can come into existence:

| location | why |
|---|---|
| `setupVXLAN()` | initial creation |
| `setupMACVLANinterface()` | late creation during reconcile |
| `setMTU()` | every reconcile — also **repairs already-running deployments** |

### The existing bridge-level cap is kept

`br_dev_xmit()` (`net/bridge/br_device.c`) is the bridge's own `ndo_start_xmit`. It is reached through `dev_queue_xmit()` with `skb->dev = bridge` for locally **routed** traffic — anycast gateway / IRB egress. There the bridge's limit *is* the effective one, so removing it would be a regression.

### No clobbering

`br_set_gso_limits()` (`net/bridge/br_if.c:528-540`) only writes `tso_max_size`, and `netif_set_tso_max_size()` (`net/core/dev.c:3022-3030`) only ever *lowers* `gso_max_size`. Adding or removing ports will not raise the limit back.

## Why not `vlan.<vid>`, as suggested in #287

`vlan.<vid>` is the **pod-facing** end of the veth pair. Its TX path only carries traffic **from** the pods towards the fabric, so:

- **GRO on `vlan.<vid>` is a placebo.** GRO already happened upstream (physical NIC NAPI, and a second `gro_cells` pass attributed to `vx.<vni>` after `vxlan_rcv()` sets `skb->dev = vxlan->dev`). The flag on this device is never consulted for those packets. For 8021q devices it is worse than useless: `vlan_dev_fix_features()` preserves whatever was requested (`features |= old_features & NETIF_F_SOFT_FEATURES`), so `ethtool -k` faithfully reports a setting that does nothing.
- **GSO/TSO on `vlan.<vid>` only affects egress**, i.e. pod → fabric. It cannot make packets arriving from the fabric smaller.

Note also that `ethtool -k vlan.XXXX` showing `gro/gso/tso: on` is expected and not evidence of a bug on `stable/0.2` — the operator caps `gso_max_size` there rather than clearing feature bits, and capping alone is sufficient (`gso_features_check()` above).

## Testing

`go test ./pkg/nl/...` passes. Added `Describe("setMTU()")` which decodes the emitted `RTM_SETLINK` requests and asserts that the caps land on **both** the bridge index and the veth index. Existing `ReconcileL2()` mocks updated for the additional netlink request.
