### PR TITLE
feat(cra-vsr): realize workload ports through NETCONF

### DIFF
--- a/cmd/agent-cra-vsr/main.go
+++ b/cmd/agent-cra-vsr/main.go
@@ -45,10 +45,12 @@ import (
 	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
 	controllervsr "github.com/telekom/das-schiff-network-operator/controllers/agent-cra-vsr"
 	"github.com/telekom/das-schiff-network-operator/pkg/cra-vsr"
+	"github.com/telekom/das-schiff-network-operator/pkg/healthcheck"
 	"github.com/telekom/das-schiff-network-operator/pkg/monitoring"
 	reconcilervsr "github.com/telekom/das-schiff-network-operator/pkg/reconciler/agent-cra-vsr"
 	"github.com/telekom/das-schiff-network-operator/pkg/reconciler/common"
 	"github.com/telekom/das-schiff-network-operator/pkg/version"
+	"github.com/telekom/das-schiff-network-operator/pkg/workloadcni"
 )
 
 var (
@@ -279,9 +281,35 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Start the node-local workload-cni gRPC server so the workload CNI plugin can
+	// hand VSR attachments to this agent (which renders them via NETCONF).
+	if err := startWorkloadCNIServer(mgr); err != nil {
+		setupLog.Error(err, "unable to start workload-cni server")
+		os.Exit(1)
+	}
+
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+// startWorkloadCNIServer registers the node-local workload-cni gRPC server as a
+// manager runnable so it shares the manager's lifecycle and client.
+func startWorkloadCNIServer(mgr manager.Manager) error {
+	nodeName := os.Getenv(healthcheck.NodenameEnv)
+	if nodeName == "" {
+		// Without it the server would write NodeWorkloadPorts objects with an empty
+		// name, failing every CNI ADD with an opaque API error.
+		return fmt.Errorf("%s must be set to run the workload-cni server", healthcheck.NodenameEnv)
+	}
+	socketPath := os.Getenv("ROUTED_CNI_SOCKET")
+	srv := workloadcni.NewServer(mgr.GetClient(), nodeName, mgr.GetLogger())
+	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		return srv.Serve(ctx, socketPath)
+	})); err != nil {
+		return fmt.Errorf("unable to add workload-cni server to manager: %w", err)
+	}
+	return nil
 }

--- a/cmd/agent-cra-vsr/main.go
+++ b/cmd/agent-cra-vsr/main.go
@@ -234,6 +234,7 @@ func main() {
 	var nodeNetworkConfigPath string
 	var metricsAddr string
 	var healthAddr string
+	var intentNamespace string
 	var opts zap.Options
 
 	version.Get().Print(os.Args[0])
@@ -246,6 +247,8 @@ func main() {
 	flag.StringVar(&nodeNetworkConfigPath, "nodenetworkconfig-path",
 		common.DefaultNodeNetworkConfigPath,
 		"Path to store working node configuration.")
+	flag.StringVar(&intentNamespace, "intent-namespace", workloadcni.DefaultLayer2Namespace,
+		"namespace the intent CRDs live in; workload CNI Layer2Attachment references are resolved in it")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
@@ -283,7 +286,7 @@ func main() {
 
 	// Start the node-local workload-cni gRPC server so the workload CNI plugin can
 	// hand VSR attachments to this agent (which renders them via NETCONF).
-	if err := startWorkloadCNIServer(mgr); err != nil {
+	if err := startWorkloadCNIServer(mgr, intentNamespace); err != nil {
 		setupLog.Error(err, "unable to start workload-cni server")
 		os.Exit(1)
 	}
@@ -297,15 +300,23 @@ func main() {
 
 // startWorkloadCNIServer registers the node-local workload-cni gRPC server as a
 // manager runnable so it shares the manager's lifecycle and client.
-func startWorkloadCNIServer(mgr manager.Manager) error {
+func startWorkloadCNIServer(mgr manager.Manager, intentNamespace string) error {
 	nodeName := os.Getenv(healthcheck.NodenameEnv)
 	if nodeName == "" {
 		// Without it the server would write NodeWorkloadPorts objects with an empty
 		// name, failing every CNI ADD with an opaque API error.
 		return fmt.Errorf("%s must be set to run the workload-cni server", healthcheck.NodenameEnv)
 	}
+	// The operator reads "" as "all namespaces", but a bare Layer2Attachment name
+	// on the CNI wire is only unambiguous within one namespace: cluster-wide, two
+	// tenants could each own an attachment of that name and the agent would have
+	// to guess which domain to bridge the workload into.
+	if intentNamespace == "" {
+		return fmt.Errorf("--intent-namespace must name a single namespace to run the workload-cni server")
+	}
 	socketPath := os.Getenv("ROUTED_CNI_SOCKET")
-	srv := workloadcni.NewServer(mgr.GetClient(), nodeName, mgr.GetLogger())
+	srv := workloadcni.NewServer(mgr.GetClient(), nodeName, mgr.GetLogger(),
+		workloadcni.WithLayer2Namespace(intentNamespace))
 	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		return srv.Serve(ctx, socketPath)
 	})); err != nil {

--- a/config/agent-cra-vsr/agent.yaml
+++ b/config/agent-cra-vsr/agent.yaml
@@ -91,6 +91,8 @@ spec:
               name: base-config
             - mountPath: /opt/healthcheck/
               name: healthcheck-config
+            - mountPath: /run/das-schiff
+              name: workload-cni-socket
       terminationGracePeriodSeconds: 10
       serviceAccountName: controller-manager
       volumes:
@@ -101,3 +103,10 @@ spec:
         - configMap:
             name: healthcheck-config
           name: healthcheck-config
+        # Shared with the workload CNI plugin (which runs in the host mount
+        # namespace): the agent serves the workload-cni gRPC socket here so the
+        # plugin can hand VSR attachments over on CNI ADD/DEL.
+        - hostPath:
+            path: /run/das-schiff
+            type: DirectoryOrCreate
+          name: workload-cni-socket

--- a/controllers/agent-cra-vsr/nodenetworkconfig_controller.go
+++ b/controllers/agent-cra-vsr/nodenetworkconfig_controller.go
@@ -22,10 +22,13 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
 	"github.com/telekom/das-schiff-network-operator/controllers/shared"
@@ -45,6 +48,7 @@ type NodeNetworkConfigReconciler struct {
 //+kubebuilder:rbac:groups=network.t-caas.telekom.com,resources=nodenetworkconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=network.t-caas.telekom.com,resources=nodenetworkconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=network.t-caas.telekom.com,resources=nodenetworkconfigs/finalizers,verbs=update
+//+kubebuilder:rbac:groups=network.t-caas.telekom.com,resources=nodeworkloadports,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups=core,resources=nodes/status,verbs=get;update;patch
 
@@ -77,9 +81,24 @@ func (r *NodeNetworkConfigReconciler) Reconcile(ctx context.Context, _ ctrl.Requ
 func (r *NodeNetworkConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&networkv1alpha1.NodeNetworkConfig{}, builder.WithPredicates(shared.BuildNamePredicates())).
+		// Re-render when this node's workload CNI attachments change: they arrive
+		// via the aggregate per-node NodeWorkloadPorts object (out-of-band from the
+		// NodeNetworkConfig revision), so a change there must trigger a reconcile.
+		Watches(&networkv1alpha1.NodeWorkloadPorts{},
+			handler.EnqueueRequestsFromMapFunc(r.mapNodeWorkloadPorts),
+			builder.WithPredicates(shared.BuildNamePredicates())).
 		Complete(r)
 	if err != nil {
 		return fmt.Errorf("error creating controller: %w", err)
 	}
 	return nil
+}
+
+// mapNodeWorkloadPorts enqueues a reconcile for the node's NodeNetworkConfig when
+// its NodeWorkloadPorts object changes. NodeWorkloadPorts and NodeNetworkConfig
+// share the node name, so the request maps by name.
+func (*NodeNetworkConfigReconciler) mapNodeWorkloadPorts(_ context.Context, obj client.Object) []reconcile.Request {
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Name: obj.GetName()},
+	}}
 }

--- a/pkg/cni/README.md
+++ b/pkg/cni/README.md
@@ -271,8 +271,17 @@ agent records the attachment on `NodeWorkloadPorts` and merges it into the
   `<deviceID>` is the device plugin's socket directory
   `/run/vsr-vhost-user/<deviceID>/` that the VSR auto-discovers as network-port
   `fpvhost-<deviceID>`; the socket path is implicit) + `interface fpvhost
-  <ifname> port fpvhost-<deviceID>`. See
+  <ifname> port fpvhost-<deviceID>`. Attached ports of either transport are
+  declared in the namespace's own `interface` set and only *enslaved* from the
+  Layer2 bridge: a bridge in an IRB VRF must not declare its slaves under
+  `l3vrf <vrf> interface`, the VSR accepts that but never creates the netdev
+  (a port cannot be a VRF slave and a bridge slave at once). See
   `pkg/cra-vsr/workloadports.go` / `layer2.go` and `pkg/workloadcni` (transport).
+  The agent rebuilds the candidate from the VSR **startup** configuration on
+  every reconcile, so anything committed on the device out of band (an online
+  licence activation, hand edits) must be saved with `copy running startup` or
+  it is lost on the next reconcile. The cra-vsr DaemonSet needs the same
+  `/run/das-schiff` hostPath as cra-frr (`config/agent-cra-vsr/agent.yaml`).
 
 ### Transport
 

--- a/pkg/cra-vsr/layer2.go
+++ b/pkg/cra-vsr/layer2.go
@@ -23,34 +23,44 @@ import (
 
 	"github.com/telekom/das-schiff-network-operator/api/v1alpha1"
 	"github.com/telekom/das-schiff-network-operator/pkg/helpers/types"
+	"github.com/telekom/das-schiff-network-operator/pkg/workloadcni"
 )
+
+// maxVSRInterfaceNameLen is the Linux interface-name limit (IFNAMSIZ-1) the
+// fast path materialises VSR interfaces under, which bounds the
+// <port>.<vlan> name of a trunk member.
+const maxVSRInterfaceNameLen = 15
 
 type Layer2 struct {
 	nodeCfg *v1alpha1.NodeNetworkConfigSpec
 	ns      *Namespace
+	vrouter *VRouter
 	mgr     *Manager
 	infos   []InfoL2
 }
 
 type InfoL2 struct {
-	vlanID int
-	mtu    int
-	vni    int
-	vrf    string
-	mac    string
-	ips    []string
-	acls   []v1alpha1.MirrorACL
+	vlanID        int
+	mtu           int
+	vni           int
+	vrf           string
+	mac           string
+	ips           []string
+	acls          []v1alpha1.MirrorACL
+	attachedPorts []v1alpha1.AttachedPort
 }
 
 func NewLayer2(
 	nodeCfg *v1alpha1.NodeNetworkConfigSpec,
 	ns *Namespace,
+	vrouter *VRouter,
 	mgr *Manager,
 ) *Layer2 {
 	return &Layer2{
 		nodeCfg: nodeCfg,
 		mgr:     mgr,
 		ns:      ns,
+		vrouter: vrouter,
 		infos:   []InfoL2{},
 	}
 }
@@ -58,10 +68,11 @@ func NewLayer2(
 func (l *Layer2) setupInformations() {
 	for _, l2 := range l.nodeCfg.Layer2s {
 		info := InfoL2{
-			vlanID: int(l2.VLAN),
-			mtu:    int(l2.MTU),
-			vni:    int(l2.VNI),
-			acls:   l2.MirrorACLs,
+			vlanID:        int(l2.VLAN),
+			mtu:           int(l2.MTU),
+			vni:           int(l2.VNI),
+			acls:          l2.MirrorACLs,
+			attachedPorts: l2.AttachedPorts,
 		}
 
 		if l2.IRB != nil {
@@ -154,6 +165,10 @@ func (l *Layer2) setup() error {
 		l.setupVXLAN(&info, br, l.ns.Interfaces)
 		vlan := l.mgr.createVLAN(info.vlanID, info.mtu, br, l.ns.Interfaces)
 
+		if err := l.attachPorts(&info, br); err != nil {
+			return err
+		}
+
 		// Mirror the Layer2 access port (vlan.<id>), not the bridge master, so
 		// port-to-port (east-west) traffic between the workload side and the L2VNI
 		// overlay is captured. The port faces the workload, so the workload-
@@ -166,4 +181,126 @@ func (l *Layer2) setup() error {
 	}
 
 	return nil
+}
+
+// attachPorts attaches the workload-CNI L2-attached ports (moved into the CRA
+// netns) to the Layer2 bridge: each port becomes a bridge link-interface with no
+// L3 addressing. veth-transport ports render as infrastructure interfaces
+// (port infra-<ifname>); vhostuser-transport ports render as fpvhost interfaces
+// (port fpvhost-<deviceID>, derived from the socket path) plus a global
+// fast-path fpvhost virtual-port.
+//
+// An access port (VLAN 0) is slaved directly and is therefore an untagged
+// member of exactly one domain. A trunk member (VLAN set) is reached
+// through a `vlan <ifname>.<vlan>` interface which is slaved in its place, so
+// one port can carry several domains and the workload-side id may differ from
+// the domain's fabric-side VLAN id. All of these interfaces are declared in the
+// namespace's own interface set — like the vxlan and fabric vlan interfaces —
+// because a bridge slave cannot also be an l3vrf slave, and because a trunked
+// port is shared by Layer2s that may live in different IRB
+// VRFs and so must be declared exactly once.
+func (l *Layer2) attachPorts(info *InfoL2, br *Bridge) error {
+	for i := range info.attachedPorts {
+		p := &info.attachedPorts[i]
+		if p.Interface == "" {
+			return fmt.Errorf("layer2 vni %d: attached port %d has no interface", info.vni, i)
+		}
+
+		slave := p.Interface
+		if p.VLAN != 0 {
+			slave = fmt.Sprintf("%s.%d", p.Interface, p.VLAN)
+			if len(slave) > maxVSRInterfaceNameLen {
+				return fmt.Errorf("layer2 vni %d: trunk sub-interface %q exceeds %d characters",
+					info.vni, slave, maxVSRInterfaceNameLen)
+			}
+		}
+
+		// The port is always declared in the namespace's own interface set,
+		// never in the IRB l3vrf's: a netdev has a single master, and the
+		// port's master is the bridge. Declaring it under `l3vrf <irb>
+		// interface` asks the VSR to make it a VRF slave as well, which vSR
+		// 3.12.2 accepts at commit time but never realises - the interface
+		// does not exist afterwards and the bridge link-interface is dead.
+		// The bridge itself lives in the l3vrf (like vlan.<id> / vx.<vni>,
+		// which are declared here too and enslaved from there).
+		if err := l.declarePort(l.ns.Interfaces, p, info.vni); err != nil {
+			return err
+		}
+		if p.VLAN != 0 {
+			l.declareTrunkVLAN(l.ns.Interfaces, slave, p)
+		}
+
+		br.Slaves = append(br.Slaves, BridgeSlave{Name: slave})
+	}
+	return nil
+}
+
+// declarePort declares the workload port itself (the moved veth or the
+// vhost-user virtual-port). It is idempotent: a trunked port is attached to
+// several Layer2s but must only be declared once.
+func (l *Layer2) declarePort(intfs *Interfaces, p *v1alpha1.AttachedPort, vni int) error {
+	if p.Transport == v1alpha1.PortTransportVhostUser {
+		if p.SocketPath == "" {
+			return fmt.Errorf("layer2 vni %d: attached port %s: vhostuser transport requires a socket path",
+				vni, p.Interface)
+		}
+		for i := range intfs.Fpvhosts {
+			if intfs.Fpvhosts[i].Name == p.Interface {
+				return nil
+			}
+		}
+		intfs.Fpvhosts = append(intfs.Fpvhosts, Fpvhost{
+			Name: p.Interface,
+			Port: types.ToPtr(fpvhostPortName(p.SocketPath)),
+		})
+		registerFpvhostVirtualPorts(l.vrouter, []FpvhostVirtualPort{
+			newFpvhostVirtualPort(p.SocketPath, p.SocketMode),
+		})
+		return nil
+	}
+
+	for i := range intfs.Infras {
+		if intfs.Infras[i].Name == p.Interface {
+			return nil
+		}
+	}
+	intfs.Infras = append(intfs.Infras, Infrastructure{
+		Name: p.Interface,
+		Port: types.ToPtr(infraPortPrefix + p.Interface),
+	})
+	return nil
+}
+
+// declareTrunkVLAN declares the `vlan` interface carrying one tagged member of a
+// trunk port. Its vlan-id is the workload-side id, so pairing it with the
+// bridge of the domain whose fabric-side id differs is what implements VLAN
+// translation. Its name matches the netdev the FRR flavor creates for the same
+// member, so both flavors expose the same datapath naming.
+//
+// Its mtu is the one the attachment requested (the CNI configuration's), which
+// the plugin also applied to the port itself, so the sub-interface is sized like
+// its link-interface rather than left at the platform default. The 4 bytes the
+// tag adds on the wire are the workload's to account for; the merge already
+// refused the attachment if no member domain could carry the requested size.
+func (*Layer2) declareTrunkVLAN(intfs *Interfaces, name string, p *v1alpha1.AttachedPort) {
+	for i := range intfs.VLANs {
+		if intfs.VLANs[i].Name == name {
+			return
+		}
+	}
+	mtu := int(p.MTU)
+	if mtu == 0 {
+		mtu = workloadcni.DefaultPortMTU
+	}
+	intfs.VLANs = append(intfs.VLANs, VLAN{
+		Name:          name,
+		VlanID:        int(p.VLAN),
+		MTU:           &mtu,
+		LinkInterface: p.Interface,
+		NetworkStack: &NetworkStack{
+			IPv6: &NetworkStackV6{
+				AddrGenMode: types.ToPtr(NoLinkLocal),
+			},
+		},
+	})
 }

--- a/pkg/cra-vsr/layerbgp.go
+++ b/pkg/cra-vsr/layerbgp.go
@@ -82,17 +82,41 @@ func (LayerBGP) convStaticRoute(from v1alpha1.StaticRoute) StaticRoute {
 	}
 
 	if from.NextHop != nil {
-		if from.NextHop.Address != nil {
-			nh.NextHop = *from.NextHop.Address
-		}
-		if from.NextHop.Vrf != nil {
+		switch {
+		case from.NextHop.Interface != nil:
+			// Interface (on-link) next hop, e.g. workload CNI host routes pointing
+			// at the moved CRA-side interface: `... next-hop <ifname>`. An
+			// interface next hop resolves in the route's own VRF, so no VRF
+			// attribute is rendered.
+			nh.NextHop = *from.NextHop.Interface
+		case from.NextHop.Vrf != nil:
 			nh.NextHop = *from.NextHop.Vrf
 			nh.VRF = from.NextHop.Vrf
+		case from.NextHop.Address != nil:
+			nh.NextHop = *from.NextHop.Address
 		}
 	}
 	to.NextHops = append(to.NextHops, nh)
 
 	return to
+}
+
+// convWorkloadPorts converts the NNC workload-port spec into the cra-vsr renderer's
+// WorkloadPort form (see routed.go / applyWorkloadPorts).
+func (LayerBGP) convWorkloadPorts(from []v1alpha1.WorkloadPort) []WorkloadPort {
+	if len(from) == 0 {
+		return nil
+	}
+	out := make([]WorkloadPort, 0, len(from))
+	for i := range from {
+		out = append(out, WorkloadPort{
+			IfName:     from[i].Interface,
+			GatewayV4:  from[i].GatewayV4,
+			GatewayV6:  from[i].GatewayV6,
+			HostRoutes: from[i].HostRoutes,
+		})
+	}
+	return out
 }
 
 func (LayerBGP) mkStaticRoute(routing *Routing, routes ...StaticRoute) {
@@ -653,6 +677,10 @@ func (l *LayerBGP) setupLocalVRF(name string, conf *v1alpha1.VRF) error {
 		l.setupNeighbor(bgp, &conf.BGPPeers[i])
 	}
 
+	if err := applyWorkloadPorts(vrf, l.convWorkloadPorts(conf.WorkloadPorts)...); err != nil {
+		return fmt.Errorf("applying workload ports to vrf %s: %w", name, err)
+	}
+
 	return nil
 }
 
@@ -737,6 +765,10 @@ func (l *LayerBGP) setupFabricVRF(name string, conf *v1alpha1.FabricVRF) error {
 		l.setupNeighbor(bgp, &conf.BGPPeers[i])
 	}
 
+	if err := applyWorkloadPorts(vrf, l.convWorkloadPorts(conf.WorkloadPorts)...); err != nil {
+		return fmt.Errorf("applying workload ports to fabric vrf %s: %w", name, err)
+	}
+
 	return nil
 }
 
@@ -813,6 +845,10 @@ func (l *LayerBGP) setupClusterVRF() error {
 
 		for _, rt := range conf.StaticRoutes {
 			l.mkStaticRoute(vrf.Routing, l.convStaticRoute(rt))
+		}
+
+		if err := applyWorkloadPorts(vrf, l.convWorkloadPorts(conf.WorkloadPorts)...); err != nil {
+			return fmt.Errorf("applying workload ports to cluster vrf %s: %w", name, err)
 		}
 	}
 
@@ -944,12 +980,16 @@ func (l *LayerBGP) setupManagementVRF() error {
 		for i := range conf.BGPPeers {
 			l.setupNeighbor(bgp, &conf.BGPPeers[i])
 		}
+
+		if err := applyWorkloadPorts(vrf, l.convWorkloadPorts(conf.WorkloadPorts)...); err != nil {
+			return fmt.Errorf("applying workload ports to management vrf %s: %w", name, err)
+		}
 	}
 
 	return nil
 }
 
-func (l *LayerBGP) setupDefaultVRF() {
+func (l *LayerBGP) setupDefaultVRF() error {
 	baseCfg := l.mgr.baseConfig
 
 	bgp := l.ns.Routing.BGP
@@ -996,6 +1036,11 @@ func (l *LayerBGP) setupDefaultVRF() {
 			},
 		})
 	}
+
+	if err := applyGlobalWorkloadPorts(l.ns, l.convWorkloadPorts(l.nodeCfg.GlobalWorkloadPorts)...); err != nil {
+		return fmt.Errorf("applying global workload ports: %w", err)
+	}
+	return nil
 }
 
 //nolint:funlen
@@ -1199,7 +1244,9 @@ func (l *LayerBGP) setupGlobalConfiguration() {
 
 func (l *LayerBGP) setup() error {
 	l.setupGlobalConfiguration()
-	l.setupDefaultVRF()
+	if err := l.setupDefaultVRF(); err != nil {
+		return fmt.Errorf("failed to setup BGP default VRF: %w", err)
+	}
 
 	if err := l.setupManagementVRF(); err != nil {
 		return fmt.Errorf("failed to setup BGP management VRF: %w", err)

--- a/pkg/cra-vsr/layerbgp.go
+++ b/pkg/cra-vsr/layerbgp.go
@@ -102,7 +102,7 @@ func (LayerBGP) convStaticRoute(from v1alpha1.StaticRoute) StaticRoute {
 }
 
 // convWorkloadPorts converts the NNC workload-port spec into the cra-vsr renderer's
-// WorkloadPort form (see routed.go / applyWorkloadPorts).
+// WorkloadPort form (see workloadports.go / applyWorkloadPorts).
 func (LayerBGP) convWorkloadPorts(from []v1alpha1.WorkloadPort) []WorkloadPort {
 	if len(from) == 0 {
 		return nil
@@ -111,12 +111,39 @@ func (LayerBGP) convWorkloadPorts(from []v1alpha1.WorkloadPort) []WorkloadPort {
 	for i := range from {
 		out = append(out, WorkloadPort{
 			IfName:     from[i].Interface,
+			Transport:  from[i].Transport,
+			SocketPath: from[i].SocketPath,
+			SocketMode: from[i].SocketMode,
 			GatewayV4:  from[i].GatewayV4,
 			GatewayV6:  from[i].GatewayV6,
 			HostRoutes: from[i].HostRoutes,
 		})
 	}
 	return out
+}
+
+// applyWorkloadPorts layers the NNC workload ports of a VRF onto the composed VSR
+// VRF and registers any fast-path fpvhost virtual-ports (vhostuser transport) on
+// the global system subtree.
+func (l *LayerBGP) applyWorkloadPorts(vrf *VRF, ports []v1alpha1.WorkloadPort) error {
+	vports, err := applyWorkloadPorts(vrf, l.convWorkloadPorts(ports)...)
+	if err != nil {
+		return err
+	}
+	registerFpvhostVirtualPorts(l.vrouter, vports)
+	return nil
+}
+
+// applyGlobalWorkloadPorts layers the NNC workload ports requested without a
+// target VRF onto the namespace's default table and registers any fast-path
+// fpvhost virtual-ports on the global system subtree.
+func (l *LayerBGP) applyGlobalWorkloadPorts(ports []v1alpha1.WorkloadPort) error {
+	vports, err := applyGlobalWorkloadPorts(l.ns, l.convWorkloadPorts(ports)...)
+	if err != nil {
+		return err
+	}
+	registerFpvhostVirtualPorts(l.vrouter, vports)
+	return nil
 }
 
 func (LayerBGP) mkStaticRoute(routing *Routing, routes ...StaticRoute) {
@@ -677,7 +704,7 @@ func (l *LayerBGP) setupLocalVRF(name string, conf *v1alpha1.VRF) error {
 		l.setupNeighbor(bgp, &conf.BGPPeers[i])
 	}
 
-	if err := applyWorkloadPorts(vrf, l.convWorkloadPorts(conf.WorkloadPorts)...); err != nil {
+	if err := l.applyWorkloadPorts(vrf, conf.WorkloadPorts); err != nil {
 		return fmt.Errorf("applying workload ports to vrf %s: %w", name, err)
 	}
 
@@ -765,7 +792,7 @@ func (l *LayerBGP) setupFabricVRF(name string, conf *v1alpha1.FabricVRF) error {
 		l.setupNeighbor(bgp, &conf.BGPPeers[i])
 	}
 
-	if err := applyWorkloadPorts(vrf, l.convWorkloadPorts(conf.WorkloadPorts)...); err != nil {
+	if err := l.applyWorkloadPorts(vrf, conf.WorkloadPorts); err != nil {
 		return fmt.Errorf("applying workload ports to fabric vrf %s: %w", name, err)
 	}
 
@@ -847,7 +874,7 @@ func (l *LayerBGP) setupClusterVRF() error {
 			l.mkStaticRoute(vrf.Routing, l.convStaticRoute(rt))
 		}
 
-		if err := applyWorkloadPorts(vrf, l.convWorkloadPorts(conf.WorkloadPorts)...); err != nil {
+		if err := l.applyWorkloadPorts(vrf, conf.WorkloadPorts); err != nil {
 			return fmt.Errorf("applying workload ports to cluster vrf %s: %w", name, err)
 		}
 	}
@@ -981,7 +1008,7 @@ func (l *LayerBGP) setupManagementVRF() error {
 			l.setupNeighbor(bgp, &conf.BGPPeers[i])
 		}
 
-		if err := applyWorkloadPorts(vrf, l.convWorkloadPorts(conf.WorkloadPorts)...); err != nil {
+		if err := l.applyWorkloadPorts(vrf, conf.WorkloadPorts); err != nil {
 			return fmt.Errorf("applying workload ports to management vrf %s: %w", name, err)
 		}
 	}
@@ -1037,7 +1064,7 @@ func (l *LayerBGP) setupDefaultVRF() error {
 		})
 	}
 
-	if err := applyGlobalWorkloadPorts(l.ns, l.convWorkloadPorts(l.nodeCfg.GlobalWorkloadPorts)...); err != nil {
+	if err := l.applyGlobalWorkloadPorts(l.nodeCfg.GlobalWorkloadPorts); err != nil {
 		return fmt.Errorf("applying global workload ports: %w", err)
 	}
 	return nil

--- a/pkg/cra-vsr/manager.go
+++ b/pkg/cra-vsr/manager.go
@@ -173,6 +173,13 @@ func (m *Manager) isReservedVRF(name string) bool {
 	return name == m.baseConfig.ManagementVRF.Name || name == m.baseConfig.ClusterVRF.Name
 }
 
+// ApplyConfiguration renders nodeCfg and commits it to the VSR. The candidate is
+// first replaced with the startup configuration read at agent start and the
+// rendered configuration is merged on top, so the startup configuration is the
+// contract for everything the agent does not render itself: the base config,
+// and anything committed on the device out of band (e.g. an online licence
+// activation) survives a reconcile only if it has been saved to startup
+// (`copy running startup`).
 func (m *Manager) ApplyConfiguration(
 	ctx context.Context,
 	nodeCfg *v1alpha1.NodeNetworkConfigSpec,
@@ -223,7 +230,7 @@ func (m *Manager) makeVRouter(nodeCfg *v1alpha1.NodeNetworkConfigSpec) (*VRouter
 		return nil, err
 	}
 
-	l2 := NewLayer2(nodeCfg, &ns, m)
+	l2 := NewLayer2(nodeCfg, &ns, vrouter, m)
 	if err := l2.setup(); err != nil {
 		return nil, err
 	}

--- a/pkg/cra-vsr/types.go
+++ b/pkg/cra-vsr/types.go
@@ -358,7 +358,11 @@ type Interfaces struct {
 }
 
 type Infrastructure struct {
-	Name string `xml:"name"`
+	XMLName xml.Name       `xml:"urn:6wind:vrouter/infrastructure infrastructure"`
+	Name    string         `xml:"name"`
+	Port    *string        `xml:"port,omitempty"`
+	IPv4    *IPAddressList `xml:"ipv4,omitempty"`
+	IPv6    *IPAddressList `xml:"ipv6,omitempty"`
 }
 
 type Physical struct {

--- a/pkg/cra-vsr/types.go
+++ b/pkg/cra-vsr/types.go
@@ -53,8 +53,57 @@ type VRouterState struct {
 }
 
 type VRouter struct {
+	System     *System        `xml:"system,omitempty"`
 	Namespaces []Namespace    `xml:"vrf,omitempty"`
 	Routing    *GlobalRouting `xml:"routing,omitempty"`
+}
+
+// System is the global (non-VRF) 6WIND vrouter system container. Only the
+// fast-path subtree is modelled: it hosts the fpvhost virtual-port declarations
+// that the vhost-user transport needs (socket-mode, profile). It is omitted
+// entirely unless at least one fpvhost port is present, so the common veth and
+// L2 paths never touch the system subtree.
+type System struct {
+	XMLName  xml.Name  `xml:"urn:6wind:vrouter/system system"`
+	FastPath *FastPath `xml:"fast-path,omitempty"`
+}
+
+// FastPath is the 6WIND fast-path (DPDK) container. Only the virtual-port list
+// is modelled here.
+type FastPath struct {
+	XMLName     xml.Name     `xml:"urn:6wind:vrouter/fast-path fast-path"`
+	VirtualPort *VirtualPort `xml:"virtual-port,omitempty"`
+}
+
+// VirtualPort groups the fast-path virtual-port declarations by kind. Only the
+// fpvhost kind is modelled (the infrastructure kind is auto-created by VSR when
+// referenced by an interface).
+type VirtualPort struct {
+	Fpvhosts []FpvhostVirtualPort `xml:"fpvhost,omitempty"`
+}
+
+// FpvhostVirtualPort is a single fast-path fpvhost virtual-port declaration:
+//
+//	system fast-path virtual-port fpvhost <name> [profile <p>] [socket-mode <mode>]
+//
+// The vSR auto-discovers a network-port for every socket directory under
+// /run/vsr-vhost-user/<dir>/ (type virtual); this virtual-port's Name MUST
+// match that autodiscovered port exactly (fpvhost-<dir>), and the socket at
+// /run/vsr-vhost-user/<dir>/socket is then created by the vSR itself - there is
+// no configurable "sockpath" leaf; the path is implicit from the name. Profile
+// defaults to "nfv" and SocketMode defaults to "server" when unset. SocketMode
+// is rendered from the VSR fast-path perspective (already inverted from the
+// workload's view by the caller).
+//
+// SocketPath is kept as a Go field for callers that still want to carry the
+// allocated socket path around (e.g. for logging/debugging), but it is never
+// serialized: lab verification against a real vSR 3.12.2 (cra-vsr-6wind,
+// ce-vhost) showed the device has no "sockpath" leaf at all.
+type FpvhostVirtualPort struct {
+	XMLName    xml.Name `xml:"urn:6wind:vrouter/fpvhost fpvhost"`
+	Name       string   `xml:"name"`
+	Profile    *string  `xml:"profile,omitempty"`
+	SocketMode *string  `xml:"socket-mode,omitempty"`
 }
 
 type GlobalRouting struct {
@@ -352,6 +401,7 @@ type Interfaces struct {
 	VXLANs    []VXLAN          `xml:"vxlan,omitempty"`
 	VLANs     []VLAN           `xml:"vlan,omitempty"`
 	Infras    []Infrastructure `xml:"infrastructure,omitempty"`
+	Fpvhosts  []Fpvhost        `xml:"fpvhost,omitempty"`
 	GREs      []GRE            `xml:"gre,omitempty"`
 	GRETaps   []GRETap         `xml:"gretap,omitempty"`
 	Loopbacks []Loopback       `xml:"loopback,omitempty"`
@@ -359,6 +409,23 @@ type Interfaces struct {
 
 type Infrastructure struct {
 	XMLName xml.Name       `xml:"urn:6wind:vrouter/infrastructure infrastructure"`
+	Name    string         `xml:"name"`
+	Port    *string        `xml:"port,omitempty"`
+	IPv4    *IPAddressList `xml:"ipv4,omitempty"`
+	IPv6    *IPAddressList `xml:"ipv6,omitempty"`
+}
+
+// Fpvhost is a fast-path vhost-user (virtio-user) interface bound to a fpvhost
+// virtual-port:
+//
+//	vrf main interface fpvhost <name> port fpvhost-<deviceID>
+//
+// It mirrors Infrastructure (a moved CRA-side port) but is backed by a DPDK
+// vhost socket instead of a veth. VSR-only. Port references the fast-path
+// virtual-port's auto-discovered name (fpvhost-<deviceID>, see
+// FpvhostVirtualPort), not the interface's own Name.
+type Fpvhost struct {
+	XMLName xml.Name       `xml:"urn:6wind:vrouter/fpvhost fpvhost"`
 	Name    string         `xml:"name"`
 	Port    *string        `xml:"port,omitempty"`
 	IPv4    *IPAddressList `xml:"ipv4,omitempty"`

--- a/pkg/cra-vsr/workloadports.go
+++ b/pkg/cra-vsr/workloadports.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cra
+
+import (
+	"fmt"
+
+	"github.com/telekom/das-schiff-network-operator/pkg/helpers/types"
+	"github.com/telekom/das-schiff-network-operator/pkg/workloadcni"
+)
+
+// infraPortPrefix is prepended to the in-netns interface name to derive the
+// VSR "port" reference for a moved interface (e.g. a workload CNI veth end).
+// VSR references an interface that was moved into the CRA network namespace as
+// infra-<ifname>, matched via the interface's ifalias (which the workload CNI
+// sets to the same value). Shared with pkg/cni via workloadcni so both agree.
+const infraPortPrefix = workloadcni.InfraPortPrefix
+
+// WorkloadPort describes a single routed workload attachment whose CRA-side
+// interface has been moved into the CRA network namespace by the workload CNI.
+// The VSR flavor cannot program the datapath via raw netlink (the fast path
+// owns it), so the on-link gateway addresses and the workload's host routes
+// are rendered as NETCONF and pushed instead.
+type WorkloadPort struct {
+	// IfName is the interface name inside the CRA network namespace (the moved
+	// veth end, e.g. "cra012345"). Referenced by VSR as infra-<IfName>.
+	IfName string
+	// GatewayV4 is the on-link IPv4 gateway address (with prefix length, e.g.
+	// "169.254.100.100/32") configured on the infrastructure interface.
+	GatewayV4 string
+	// GatewayV6 is the on-link IPv6 gateway address (with prefix length, e.g.
+	// "fd00:7:caa5:1::/128") configured on the infrastructure interface.
+	GatewayV6 string
+	// HostRoutes are the workload's routable host addresses (e.g. "10.0.0.5/32",
+	// "fd00:200::5/128") installed as interface-static routes via IfName so VSR
+	// redistributes them into BGP.
+	HostRoutes []string
+}
+
+// applyWorkloadPorts merges the given workload ports into an already-composed VRF:
+// each port adds an infrastructure interface (port infra-<ifname> + on-link
+// gateway addresses) and interface-static routes for the workload host routes.
+//
+// It never creates a VRF. The VSR reconcile path looks up the existing
+// cluster/fabric/local L3VRF (LookupVRF) assembled from the NodeNetworkConfig
+// spec and layers the workload ports onto it, so a routed attachment is bound into
+// the VRF that already exists rather than a duplicate one.
+func applyWorkloadPorts(vrf *VRF, ports ...WorkloadPort) error {
+	if len(ports) == 0 {
+		return nil
+	}
+	if vrf.Interfaces == nil {
+		vrf.Interfaces = &Interfaces{}
+	}
+	if vrf.Routing == nil {
+		vrf.Routing = &Routing{}
+	}
+	return addWorkloadPorts(vrf.Interfaces, vrf.Routing, ports)
+}
+
+// applyGlobalWorkloadPorts renders workload ports that were requested without a
+// target VRF into the namespace's default (no-l3vrf) table: an infrastructure
+// interface (port infra-<ifname> + on-link gateway addresses) plus
+// interface-static routes for the workload host routes, exactly as for an L3VRF.
+// Unlike an L3VRF (which redistributes static/connected into its own BGP), the
+// default table's BGP is the underlay session, so each host route is instead
+// advertised via an explicit BGP network statement (see advertiseHostRoutes).
+func applyGlobalWorkloadPorts(ns *Namespace, ports ...WorkloadPort) error {
+	if len(ports) == 0 {
+		return nil
+	}
+	if ns.Interfaces == nil {
+		ns.Interfaces = &Interfaces{}
+	}
+	if ns.Routing == nil {
+		ns.Routing = &Routing{}
+	}
+	if err := addWorkloadPorts(ns.Interfaces, ns.Routing, ports); err != nil {
+		return err
+	}
+	advertiseHostRoutes(ns.Routing.BGP, ports)
+	return nil
+}
+
+// addWorkloadPorts renders each workload port as an infrastructure interface (port
+// infra-<ifname> + on-link gateway addresses) plus interface-static routes for
+// the workload host routes into the given interface and routing containers.
+func addWorkloadPorts(ifaces *Interfaces, routing *Routing, ports []WorkloadPort) error {
+	if routing.Static == nil {
+		routing.Static = &StaticRouting{}
+	}
+
+	for i := range ports {
+		p := ports[i]
+		if p.IfName == "" {
+			return fmt.Errorf("workload port %d: ifname is required", i)
+		}
+
+		infra := Infrastructure{
+			Name: p.IfName,
+			Port: types.ToPtr(infraPortPrefix + p.IfName),
+		}
+		if p.GatewayV4 != "" {
+			infra.IPv4 = &IPAddressList{IPAddresses: []IPAddress{{IP: p.GatewayV4}}}
+		}
+		if p.GatewayV6 != "" {
+			infra.IPv6 = &IPAddressList{IPAddresses: []IPAddress{{IP: p.GatewayV6}}}
+		}
+		ifaces.Infras = append(ifaces.Infras, infra)
+
+		for _, dst := range p.HostRoutes {
+			route := StaticRoute{
+				Destination: dst,
+				NextHops:    []NextHop{{NextHop: p.IfName}},
+			}
+			if isIPv4(dst) {
+				routing.Static.IPv4 = append(routing.Static.IPv4, route)
+			} else {
+				routing.Static.IPv6 = append(routing.Static.IPv6, route)
+			}
+		}
+	}
+	return nil
+}
+
+// advertiseHostRoutes adds a BGP network statement for each workload-port host
+// route so the default-table underlay session advertises the workload /32,/128
+// prefixes (which exist in the RIB as the interface-static routes). It is a
+// no-op when bgp is nil (no underlay session composed).
+func advertiseHostRoutes(bgp *BGP, ports []WorkloadPort) {
+	if bgp == nil {
+		return
+	}
+	if bgp.AF == nil {
+		bgp.AF = &BGPAddrFamily{}
+	}
+	for i := range ports {
+		for _, dst := range ports[i].HostRoutes {
+			if isIPv4(dst) {
+				if bgp.AF.UcastV4 == nil {
+					bgp.AF.UcastV4 = &BGPUcast{}
+				}
+				bgp.AF.UcastV4.Network = append(bgp.AF.UcastV4.Network, BGPUcastNetwork{Prefix: dst})
+			} else {
+				if bgp.AF.UcastV6 == nil {
+					bgp.AF.UcastV6 = &BGPUcast{}
+				}
+				bgp.AF.UcastV6.Network = append(bgp.AF.UcastV6.Network, BGPUcastNetwork{Prefix: dst})
+			}
+		}
+	}
+}

--- a/pkg/cra-vsr/workloadports.go
+++ b/pkg/cra-vsr/workloadports.go
@@ -18,7 +18,9 @@ package cra
 
 import (
 	"fmt"
+	"path/filepath"
 
+	"github.com/telekom/das-schiff-network-operator/api/v1alpha1"
 	"github.com/telekom/das-schiff-network-operator/pkg/helpers/types"
 	"github.com/telekom/das-schiff-network-operator/pkg/workloadcni"
 )
@@ -30,6 +32,89 @@ import (
 // sets to the same value). Shared with pkg/cni via workloadcni so both agree.
 const infraPortPrefix = workloadcni.InfraPortPrefix
 
+// fpvhostPortPrefix is prepended to the device-plugin socket directory to
+// derive the VSR fast-path fpvhost virtual-port reference for a vhost-user
+// attachment (fpvhost-<deviceID>), mirroring infraPortPrefix for the veth
+// transport.
+const fpvhostPortPrefix = workloadcni.FpvhostPortPrefix
+
+// fpvhostPortName derives the VSR fast-path fpvhost virtual-port name from the
+// device-plugin-allocated host-side socket path. The vSR auto-discovers a
+// network-port for every directory under /run/vsr-vhost-user/<dir>/ (type
+// virtual), and the fast-path virtual-port name must match that auto-discovered
+// port exactly - it is not derived from the workload's interface name, and a
+// commit naming any other port fails with "The fpvhost port must be configured
+// in the fast path". Callers reject an empty socket path before getting here.
+func fpvhostPortName(socketPath string) string {
+	return fpvhostPortPrefix + filepath.Base(filepath.Dir(socketPath))
+}
+
+// registerFpvhostVirtualPorts adds the given fast-path fpvhost virtual-port
+// declarations to the global system subtree of vrouter, creating the system /
+// fast-path / virtual-port containers on first use and de-duplicating by name.
+// The system subtree stays absent entirely when no fpvhost ports exist, so the
+// common veth and L2 paths never touch it.
+func registerFpvhostVirtualPorts(vrouter *VRouter, vports []FpvhostVirtualPort) {
+	if vrouter == nil || len(vports) == 0 {
+		return
+	}
+	if vrouter.System == nil {
+		vrouter.System = &System{}
+	}
+	if vrouter.System.FastPath == nil {
+		vrouter.System.FastPath = &FastPath{}
+	}
+	if vrouter.System.FastPath.VirtualPort == nil {
+		vrouter.System.FastPath.VirtualPort = &VirtualPort{}
+	}
+	existing := vrouter.System.FastPath.VirtualPort
+	for i := range vports {
+		if fpvhostVirtualPortExists(existing.Fpvhosts, vports[i].Name) {
+			continue
+		}
+		existing.Fpvhosts = append(existing.Fpvhosts, vports[i])
+	}
+}
+
+// fpvhostVirtualPortExists reports whether a fpvhost virtual-port with the given
+// name is already declared.
+func fpvhostVirtualPortExists(ports []FpvhostVirtualPort, name string) bool {
+	for i := range ports {
+		if ports[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// newFpvhostVirtualPort builds the fast-path fpvhost virtual-port declaration
+// for an interface. SocketPath is the host-side socket the 6WIND device plugin
+// allocated (never the pod-side path, which lives in the pod mount namespace and
+// would leave VSR bound to a socket nothing connects to). The virtual-port name
+// is derived from SocketPath's directory (fpvhost-<deviceID>), matching the
+// vSR's auto-discovered network-port for that socket directory; the socket path
+// itself is implied by that port and is not part of the model.
+//
+// The socket mode is inverted relative to the workload: the two ends of a
+// vhost-user socket must take opposite roles, so a pod running a server socket
+// pairs with a VSR client socket. An empty/unknown workload mode defaults to a
+// VSR server socket.
+func newFpvhostVirtualPort(socketPath, workloadSocketMode string) FpvhostVirtualPort {
+	return FpvhostVirtualPort{
+		Name:       fpvhostPortName(socketPath),
+		SocketMode: types.ToPtr(invertSocketMode(workloadSocketMode)),
+	}
+}
+
+// invertSocketMode flips the vhost-user socket mode between the workload and the
+// VSR fast path: the two ends of a vhost-user socket must take opposite roles.
+func invertSocketMode(workloadMode string) string {
+	if workloadMode == v1alpha1.SocketModeServer {
+		return v1alpha1.SocketModeClient
+	}
+	return v1alpha1.SocketModeServer
+}
+
 // WorkloadPort describes a single routed workload attachment whose CRA-side
 // interface has been moved into the CRA network namespace by the workload CNI.
 // The VSR flavor cannot program the datapath via raw netlink (the fast path
@@ -37,8 +122,19 @@ const infraPortPrefix = workloadcni.InfraPortPrefix
 // are rendered as NETCONF and pushed instead.
 type WorkloadPort struct {
 	// IfName is the interface name inside the CRA network namespace (the moved
-	// veth end, e.g. "cra012345"). Referenced by VSR as infra-<IfName>.
+	// veth end, e.g. "cra012345"). Referenced by VSR as infra-<IfName> (veth
+	// transport) or fpvhost-<IfName> (vhostuser transport).
 	IfName string
+	// Transport selects the CRA-side wiring: veth (default, an infrastructure
+	// port) or vhostuser (a fast-path fpvhost virtual-port).
+	Transport v1alpha1.PortTransport
+	// SocketPath is the host-side vhost-user socket path allocated by the 6WIND
+	// device plugin. Only meaningful for the vhostuser transport.
+	SocketPath string
+	// SocketMode is the workload-side vhost-user socket mode ("client"/"server").
+	// It is inverted before being rendered onto the VSR fpvhost virtual-port.
+	// Only meaningful for the vhostuser transport.
+	SocketMode string
 	// GatewayV4 is the on-link IPv4 gateway address (with prefix length, e.g.
 	// "169.254.100.100/32") configured on the infrastructure interface.
 	GatewayV4 string
@@ -53,15 +149,18 @@ type WorkloadPort struct {
 
 // applyWorkloadPorts merges the given workload ports into an already-composed VRF:
 // each port adds an infrastructure interface (port infra-<ifname> + on-link
-// gateway addresses) and interface-static routes for the workload host routes.
+// gateway addresses) — or, for the vhostuser transport, a fpvhost interface
+// (port fpvhost-<ifname>) — and interface-static routes for the workload host
+// routes. For vhostuser ports it also returns the fast-path fpvhost virtual-port
+// declarations the caller must register on the global system subtree.
 //
 // It never creates a VRF. The VSR reconcile path looks up the existing
 // cluster/fabric/local L3VRF (LookupVRF) assembled from the NodeNetworkConfig
 // spec and layers the workload ports onto it, so a routed attachment is bound into
 // the VRF that already exists rather than a duplicate one.
-func applyWorkloadPorts(vrf *VRF, ports ...WorkloadPort) error {
+func applyWorkloadPorts(vrf *VRF, ports ...WorkloadPort) ([]FpvhostVirtualPort, error) {
 	if len(ports) == 0 {
-		return nil
+		return nil, nil
 	}
 	if vrf.Interfaces == nil {
 		vrf.Interfaces = &Interfaces{}
@@ -79,9 +178,9 @@ func applyWorkloadPorts(vrf *VRF, ports ...WorkloadPort) error {
 // Unlike an L3VRF (which redistributes static/connected into its own BGP), the
 // default table's BGP is the underlay session, so each host route is instead
 // advertised via an explicit BGP network statement (see advertiseHostRoutes).
-func applyGlobalWorkloadPorts(ns *Namespace, ports ...WorkloadPort) error {
+func applyGlobalWorkloadPorts(ns *Namespace, ports ...WorkloadPort) ([]FpvhostVirtualPort, error) {
 	if len(ports) == 0 {
-		return nil
+		return nil, nil
 	}
 	if ns.Interfaces == nil {
 		ns.Interfaces = &Interfaces{}
@@ -89,38 +188,58 @@ func applyGlobalWorkloadPorts(ns *Namespace, ports ...WorkloadPort) error {
 	if ns.Routing == nil {
 		ns.Routing = &Routing{}
 	}
-	if err := addWorkloadPorts(ns.Interfaces, ns.Routing, ports); err != nil {
-		return err
+	vports, err := addWorkloadPorts(ns.Interfaces, ns.Routing, ports)
+	if err != nil {
+		return nil, err
 	}
 	advertiseHostRoutes(ns.Routing.BGP, ports)
-	return nil
+	return vports, nil
 }
 
 // addWorkloadPorts renders each workload port as an infrastructure interface (port
-// infra-<ifname> + on-link gateway addresses) plus interface-static routes for
-// the workload host routes into the given interface and routing containers.
-func addWorkloadPorts(ifaces *Interfaces, routing *Routing, ports []WorkloadPort) error {
+// infra-<ifname> + on-link gateway addresses) — or, for the vhostuser transport,
+// as a fpvhost interface (port fpvhost-<ifname>) — plus interface-static routes
+// for the workload host routes into the given interface and routing containers.
+// It returns the fpvhost virtual-port declarations for the vhostuser ports.
+func addWorkloadPorts(ifaces *Interfaces, routing *Routing, ports []WorkloadPort) ([]FpvhostVirtualPort, error) {
 	if routing.Static == nil {
 		routing.Static = &StaticRouting{}
 	}
 
+	var vports []FpvhostVirtualPort
 	for i := range ports {
 		p := ports[i]
 		if p.IfName == "" {
-			return fmt.Errorf("workload port %d: ifname is required", i)
+			return nil, fmt.Errorf("workload port %d: ifname is required", i)
 		}
 
-		infra := Infrastructure{
-			Name: p.IfName,
-			Port: types.ToPtr(infraPortPrefix + p.IfName),
-		}
+		var v4, v6 *IPAddressList
 		if p.GatewayV4 != "" {
-			infra.IPv4 = &IPAddressList{IPAddresses: []IPAddress{{IP: p.GatewayV4}}}
+			v4 = &IPAddressList{IPAddresses: []IPAddress{{IP: p.GatewayV4}}}
 		}
 		if p.GatewayV6 != "" {
-			infra.IPv6 = &IPAddressList{IPAddresses: []IPAddress{{IP: p.GatewayV6}}}
+			v6 = &IPAddressList{IPAddresses: []IPAddress{{IP: p.GatewayV6}}}
 		}
-		ifaces.Infras = append(ifaces.Infras, infra)
+
+		if p.Transport == v1alpha1.PortTransportVhostUser {
+			if p.SocketPath == "" {
+				return nil, fmt.Errorf("workload port %d (%s): vhostuser transport requires a socket path", i, p.IfName)
+			}
+			ifaces.Fpvhosts = append(ifaces.Fpvhosts, Fpvhost{
+				Name: p.IfName,
+				Port: types.ToPtr(fpvhostPortName(p.SocketPath)),
+				IPv4: v4,
+				IPv6: v6,
+			})
+			vports = append(vports, newFpvhostVirtualPort(p.SocketPath, p.SocketMode))
+		} else {
+			ifaces.Infras = append(ifaces.Infras, Infrastructure{
+				Name: p.IfName,
+				Port: types.ToPtr(infraPortPrefix + p.IfName),
+				IPv4: v4,
+				IPv6: v6,
+			})
+		}
 
 		for _, dst := range p.HostRoutes {
 			route := StaticRoute{
@@ -134,7 +253,7 @@ func addWorkloadPorts(ifaces *Interfaces, routing *Routing, ports []WorkloadPort
 			}
 		}
 	}
-	return nil
+	return vports, nil
 }
 
 // advertiseHostRoutes adds a BGP network statement for each workload-port host

--- a/pkg/cra-vsr/workloadports_test.go
+++ b/pkg/cra-vsr/workloadports_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cra
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	"github.com/telekom/das-schiff-network-operator/api/v1alpha1"
+)
+
+// craPortIfName is the reusable test interface name for the moved CRA-side port.
+const craPortIfName = "craport0"
+
+// TestApplyWorkloadPortsXML verifies that layering a workload port onto an existing
+// VRF (as the VSR reconcile path does) renders the NETCONF constructs VSR
+// expects. The VRF is composed first (mirroring LookupVRF) and then merged into.
+func TestApplyWorkloadPortsXML(t *testing.T) {
+	vrf := &VRF{
+		Name:       "cluster",
+		Interfaces: &Interfaces{},
+		Routing:    &Routing{NCOperation: Merge, Static: &StaticRouting{}},
+	}
+	if err := applyWorkloadPorts(vrf, WorkloadPort{
+		IfName:     craPortIfName,
+		GatewayV4:  "169.254.100.100/32",
+		GatewayV6:  "fd00:7:caa5:1::/128",
+		HostRoutes: []string{"10.0.0.5/32", "fd00:200::5/128"},
+	}); err != nil {
+		t.Fatalf("applyWorkloadPorts: %v", err)
+	}
+
+	out, err := xml.Marshal(vrf)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+
+	// Assert the key NETCONF constructs are rendered as VSR expects.
+	wants := []string{
+		"<name>cluster</name>",
+		`<infrastructure xmlns="urn:6wind:vrouter/infrastructure"><name>craport0</name>`,
+		"<port>infra-craport0</port>",
+		"<ipv4><address><ip>169.254.100.100/32</ip></address></ipv4>",
+		"<ipv6><address><ip>fd00:7:caa5:1::/128</ip></address></ipv6>",
+		"<ipv4-route><destination>10.0.0.5/32</destination><next-hop><next-hop>craport0</next-hop></next-hop></ipv4-route>",
+		"<ipv6-route><destination>fd00:200::5/128</destination><next-hop><next-hop>craport0</next-hop></next-hop></ipv6-route>",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("rendered XML missing %q\nfull XML:\n%s", w, got)
+		}
+	}
+}
+
+func TestApplyWorkloadPortsRetainsLongInfrastructurePortReference(t *testing.T) {
+	const ifName = "cra012345678901"
+	vrf := &VRF{
+		Name:       "cluster",
+		Interfaces: &Interfaces{},
+		Routing:    &Routing{NCOperation: Merge, Static: &StaticRouting{}},
+	}
+
+	if _, err := applyWorkloadPorts(vrf, WorkloadPort{IfName: ifName}); err != nil {
+		t.Fatalf("applyWorkloadPorts: %v", err)
+	}
+
+	if len(vrf.Interfaces.Infras) != 1 {
+		t.Fatalf("expected one infrastructure interface, got %+v", vrf.Interfaces.Infras)
+	}
+	infra := vrf.Interfaces.Infras[0]
+	if infra.Name != ifName {
+		t.Errorf("infrastructure interface name = %q, want %q", infra.Name, ifName)
+	}
+	if infra.Port == nil || *infra.Port != infraPortPrefix+ifName {
+		t.Errorf("infrastructure port = %v, want %q", infra.Port, infraPortPrefix+ifName)
+	}
+	if infra.Port != nil && len(*infra.Port) <= 15 {
+		t.Errorf("infrastructure port reference %q unexpectedly fits the interface-name limit", *infra.Port)
+	}
+}
+
+func TestApplyWorkloadPortsErrors(t *testing.T) {
+	vrf := &VRF{Name: "cluster"}
+	if err := applyWorkloadPorts(vrf, WorkloadPort{}); err == nil {
+		t.Errorf("expected error for empty ifname")
+	}
+}
+
+// TestApplyWorkloadPortsMerge verifies that workload ports layer onto an
+// already-composed VRF (the NNC reconcile path) instead of replacing it: the
+// pre-existing infra interface and static routes must be preserved.
+func TestApplyWorkloadPortsMerge(t *testing.T) {
+	vrf := &VRF{
+		Name:       "cluster",
+		Interfaces: &Interfaces{Infras: []Infrastructure{{Name: "existing"}}},
+		Routing: &Routing{
+			Static: &StaticRouting{
+				IPv4: []StaticRoute{{Destination: "10.9.9.0/24", NextHops: []NextHop{{NextHop: "blackhole"}}}},
+			},
+		},
+	}
+
+	err := applyWorkloadPorts(vrf, WorkloadPort{
+		IfName:     craPortIfName,
+		GatewayV4:  "169.254.1.1/32",
+		HostRoutes: []string{"10.0.0.5/32", "fd00:200::5/128"},
+	})
+	if err != nil {
+		t.Fatalf("applyWorkloadPorts: %v", err)
+	}
+
+	if len(vrf.Interfaces.Infras) != 2 || vrf.Interfaces.Infras[0].Name != "existing" {
+		t.Errorf("existing infra not preserved: %+v", vrf.Interfaces.Infras)
+	}
+	if vrf.Interfaces.Infras[1].Port == nil || *vrf.Interfaces.Infras[1].Port != "infra-craport0" {
+		t.Errorf("routed infra port = %v", vrf.Interfaces.Infras[1].Port)
+	}
+	if len(vrf.Routing.Static.IPv4) != 2 || vrf.Routing.Static.IPv4[0].Destination != "10.9.9.0/24" {
+		t.Errorf("existing v4 static not preserved: %+v", vrf.Routing.Static.IPv4)
+	}
+	if vrf.Routing.Static.IPv4[1].NextHops[0].NextHop != craPortIfName {
+		t.Errorf("routed v4 next-hop = %q", vrf.Routing.Static.IPv4[1].NextHops[0].NextHop)
+	}
+	if len(vrf.Routing.Static.IPv6) != 1 || vrf.Routing.Static.IPv6[0].NextHops[0].NextHop != craPortIfName {
+		t.Errorf("routed v6 static = %+v", vrf.Routing.Static.IPv6)
+	}
+
+	// Empty port list is a no-op.
+	before := len(vrf.Interfaces.Infras)
+	if err := applyWorkloadPorts(vrf); err != nil {
+		t.Fatalf("applyWorkloadPorts(empty): %v", err)
+	}
+	if len(vrf.Interfaces.Infras) != before {
+		t.Errorf("empty applyWorkloadPorts mutated vrf")
+	}
+}
+
+// TestApplyGlobalWorkloadPorts verifies that null-VRF workload ports are rendered
+// into the namespace's default (no-l3vrf) table: infra interface + interface
+// static routes at namespace level, plus a BGP network statement per host route
+// (advertised by the underlay session instead of L3VRF redistribution).
+func TestApplyGlobalWorkloadPorts(t *testing.T) {
+	ns := &Namespace{
+		Interfaces: &Interfaces{},
+		Routing: &Routing{
+			Static: &StaticRouting{},
+			BGP: &BGP{
+				AF: &BGPAddrFamily{
+					UcastV4: &BGPUcast{
+						Network: []BGPUcastNetwork{{Prefix: "10.255.0.1/32"}}, // pre-existing VTEP
+					},
+				},
+			},
+		},
+	}
+
+	if err := applyGlobalWorkloadPorts(ns, WorkloadPort{
+		IfName:     craPortIfName,
+		GatewayV4:  "169.254.1.1/32",
+		GatewayV6:  "fe80::1/128",
+		HostRoutes: []string{"10.0.0.5/32", "fd00:200::5/128"},
+	}); err != nil {
+		t.Fatalf("applyGlobalWorkloadPorts: %v", err)
+	}
+
+	// Infra + static routes land at namespace level.
+	if len(ns.Interfaces.Infras) != 1 || ns.Interfaces.Infras[0].Port == nil ||
+		*ns.Interfaces.Infras[0].Port != "infra-craport0" {
+		t.Errorf("namespace infra not rendered: %+v", ns.Interfaces.Infras)
+	}
+	if len(ns.Routing.Static.IPv4) != 1 || len(ns.Routing.Static.IPv6) != 1 {
+		t.Errorf("namespace static routes = v4:%+v v6:%+v", ns.Routing.Static.IPv4, ns.Routing.Static.IPv6)
+	}
+
+	// Host routes advertised via BGP network statements (VTEP preserved).
+	if len(ns.Routing.BGP.AF.UcastV4.Network) != 2 ||
+		ns.Routing.BGP.AF.UcastV4.Network[1].Prefix != "10.0.0.5/32" {
+		t.Errorf("v4 network statements = %+v", ns.Routing.BGP.AF.UcastV4.Network)
+	}
+	if ns.Routing.BGP.AF.UcastV6 == nil || len(ns.Routing.BGP.AF.UcastV6.Network) != 1 ||
+		ns.Routing.BGP.AF.UcastV6.Network[0].Prefix != "fd00:200::5/128" {
+		t.Errorf("v6 network statements = %+v", ns.Routing.BGP.AF.UcastV6)
+	}
+
+	// The XML must carry the advertised prefix.
+	out, err := xml.Marshal(ns)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), "<network><ip-prefix>10.0.0.5/32</ip-prefix></network>") {
+		t.Errorf("rendered XML missing v4 network statement\n%s", out)
+	}
+}
+
+// TestApplyGlobalWorkloadPortsNoBGP verifies host-route advertisement is skipped
+// gracefully when no underlay BGP session is composed.
+func TestApplyGlobalWorkloadPortsNoBGP(t *testing.T) {
+	ns := &Namespace{Interfaces: &Interfaces{}, Routing: &Routing{}}
+	if err := applyGlobalWorkloadPorts(ns, WorkloadPort{
+		IfName:     craPortIfName,
+		HostRoutes: []string{"10.0.0.5/32"},
+	}); err != nil {
+		t.Fatalf("applyGlobalWorkloadPorts: %v", err)
+	}
+	if len(ns.Interfaces.Infras) != 1 {
+		t.Errorf("infra not rendered without BGP: %+v", ns.Interfaces.Infras)
+	}
+}
+
+// TestConvStaticRouteInterfaceNextHop verifies the NNC interface (on-link)
+// next-hop is rendered as `next-hop <ifname>`.
+func TestConvStaticRouteInterfaceNextHop(t *testing.T) {
+	ifname := craPortIfName
+	got := LayerBGP{}.convStaticRoute(v1alpha1.StaticRoute{
+		Prefix:  "10.0.0.5/32",
+		NextHop: &v1alpha1.NextHop{Interface: &ifname},
+	})
+	if got.Destination != "10.0.0.5/32" {
+		t.Errorf("destination = %q", got.Destination)
+	}
+	if len(got.NextHops) != 1 || got.NextHops[0].NextHop != craPortIfName {
+		t.Errorf("next-hop = %+v, want craport0", got.NextHops)
+	}
+	if got.NextHops[0].VRF != nil {
+		t.Errorf("interface next-hop must not set VRF, got %v", got.NextHops[0].VRF)
+	}
+}

--- a/pkg/cra-vsr/workloadports_test.go
+++ b/pkg/cra-vsr/workloadports_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/telekom/das-schiff-network-operator/api/v1alpha1"
+	"github.com/telekom/das-schiff-network-operator/pkg/config"
 )
 
 // craPortIfName is the reusable test interface name for the moved CRA-side port.
@@ -36,7 +37,7 @@ func TestApplyWorkloadPortsXML(t *testing.T) {
 		Interfaces: &Interfaces{},
 		Routing:    &Routing{NCOperation: Merge, Static: &StaticRouting{}},
 	}
-	if err := applyWorkloadPorts(vrf, WorkloadPort{
+	if _, err := applyWorkloadPorts(vrf, WorkloadPort{
 		IfName:     craPortIfName,
 		GatewayV4:  "169.254.100.100/32",
 		GatewayV6:  "fd00:7:caa5:1::/128",
@@ -97,8 +98,203 @@ func TestApplyWorkloadPortsRetainsLongInfrastructurePortReference(t *testing.T) 
 
 func TestApplyWorkloadPortsErrors(t *testing.T) {
 	vrf := &VRF{Name: "cluster"}
-	if err := applyWorkloadPorts(vrf, WorkloadPort{}); err == nil {
+	if _, err := applyWorkloadPorts(vrf, WorkloadPort{}); err == nil {
 		t.Errorf("expected error for empty ifname")
+	}
+	if _, err := applyWorkloadPorts(vrf, WorkloadPort{
+		IfName:    craPortIfName,
+		Transport: v1alpha1.PortTransportVhostUser,
+	}); err == nil {
+		t.Errorf("expected error for vhostuser transport without a socket path")
+		t.Errorf("expected error for empty ifname")
+	}
+}
+
+// TestApplyWorkloadPortsVhostUserXML verifies a vhostuser workload port renders as a
+// fpvhost interface (port fpvhost-<deviceID>, derived from the socket path) instead of
+// an infrastructure port, and returns a fast-path fpvhost virtual-port with the
+// inverted socket mode.
+func TestApplyWorkloadPortsVhostUserXML(t *testing.T) {
+	vrf := &VRF{
+		Name:       "cluster",
+		Interfaces: &Interfaces{},
+		Routing:    &Routing{NCOperation: Merge, Static: &StaticRouting{}},
+	}
+	vports, err := applyWorkloadPorts(vrf, WorkloadPort{
+		IfName:     craPortIfName,
+		Transport:  v1alpha1.PortTransportVhostUser,
+		SocketPath: "/run/vsr-vhost-user/3f9a2b1c7d/socket",
+		SocketMode: "server", // workload server -> VSR client
+		GatewayV4:  "169.254.100.100/32",
+		HostRoutes: []string{"10.0.0.5/32"},
+	})
+	if err != nil {
+		t.Fatalf("applyWorkloadPorts: %v", err)
+	}
+
+	if len(vrf.Interfaces.Infras) != 0 {
+		t.Errorf("vhostuser port must not render an infrastructure interface: %+v", vrf.Interfaces.Infras)
+	}
+	if len(vports) != 1 || vports[0].Name != "fpvhost-3f9a2b1c7d" {
+		t.Fatalf("expected one fpvhost virtual-port fpvhost-3f9a2b1c7d, got %+v", vports)
+	}
+	if vports[0].SocketMode == nil || *vports[0].SocketMode != v1alpha1.SocketModeClient {
+		t.Errorf("workload socket-mode server must invert to VSR client, got %v", vports[0].SocketMode)
+	}
+
+	out, err := xml.Marshal(vrf)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+	for _, w := range []string{
+		"<fpvhost xmlns=\"urn:6wind:vrouter/fpvhost\"><name>craport0</name>",
+		"<port>fpvhost-3f9a2b1c7d</port>",
+		"<ipv4><address><ip>169.254.100.100/32</ip></address></ipv4>",
+		"<ipv4-route><destination>10.0.0.5/32</destination><next-hop><next-hop>craport0</next-hop></next-hop></ipv4-route>",
+	} {
+		if !strings.Contains(got, w) {
+			t.Errorf("rendered XML missing %q\nfull XML:\n%s", w, got)
+		}
+	}
+}
+
+func TestApplyWorkloadPortsVhostUserRetainsLongVirtualPortReference(t *testing.T) {
+	const ifName = "vho012345678901"
+	vrf := &VRF{
+		Name:       "cluster",
+		Interfaces: &Interfaces{},
+		Routing:    &Routing{NCOperation: Merge, Static: &StaticRouting{}},
+	}
+
+	vports, err := applyWorkloadPorts(vrf, WorkloadPort{
+		IfName:     ifName,
+		Transport:  v1alpha1.PortTransportVhostUser,
+		SocketPath: "/run/vsr-vhost-user/3f9a2b1c7d/socket",
+		SocketMode: v1alpha1.SocketModeServer,
+	})
+	if err != nil {
+		t.Fatalf("applyWorkloadPorts: %v", err)
+	}
+
+	if len(vrf.Interfaces.Fpvhosts) != 1 {
+		t.Fatalf("expected one fpvhost interface, got %+v", vrf.Interfaces.Fpvhosts)
+	}
+	fpvhost := vrf.Interfaces.Fpvhosts[0]
+	wantPort := fpvhostPortPrefix + "3f9a2b1c7d"
+	if fpvhost.Name != ifName || fpvhost.Port == nil || *fpvhost.Port != wantPort {
+		t.Errorf("fpvhost interface = %+v, want name %q and port %q", fpvhost, ifName, wantPort)
+	}
+	if len(vports) != 1 || vports[0].Name != wantPort {
+		t.Errorf("fpvhost virtual-port = %+v, want name %q", vports, wantPort)
+	}
+	if len(wantPort) <= 15 {
+		t.Errorf("fpvhost port reference %q unexpectedly fits the interface-name limit", wantPort)
+	}
+
+	vrouter := &VRouter{}
+	registerFpvhostVirtualPorts(vrouter, vports)
+	if vrouter.System == nil || vrouter.System.FastPath == nil || vrouter.System.FastPath.VirtualPort == nil ||
+		len(vrouter.System.FastPath.VirtualPort.Fpvhosts) != 1 ||
+		vrouter.System.FastPath.VirtualPort.Fpvhosts[0].Name != wantPort {
+		t.Errorf("registered fpvhost virtual-port = %+v, want %q", vrouter.System, wantPort)
+	}
+}
+
+// TestRegisterFpvhostVirtualPortsXML verifies the global system fast-path
+// virtual-port subtree renders as VSR expects and de-duplicates by name.
+func TestRegisterFpvhostVirtualPortsXML(t *testing.T) {
+	vrouter := &VRouter{}
+	registerFpvhostVirtualPorts(vrouter, []FpvhostVirtualPort{
+		newFpvhostVirtualPort("/run/vsr-vhost-user/3f9a2b1c7d/socket", "client"), // -> VSR server
+	})
+	// Duplicate registration must not add a second entry.
+	registerFpvhostVirtualPorts(vrouter, []FpvhostVirtualPort{
+		newFpvhostVirtualPort("/run/vsr-vhost-user/3f9a2b1c7d/socket", "client"),
+	})
+
+	if vrouter.System == nil || vrouter.System.FastPath == nil || vrouter.System.FastPath.VirtualPort == nil {
+		t.Fatal("expected system fast-path virtual-port subtree to be created")
+	}
+	if n := len(vrouter.System.FastPath.VirtualPort.Fpvhosts); n != 1 {
+		t.Fatalf("expected 1 de-duplicated fpvhost virtual-port, got %d", n)
+	}
+
+	out, err := xml.Marshal(&VRouterConfig{VRouter: *vrouter})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+	for _, w := range []string{
+		"<system xmlns=\"urn:6wind:vrouter/system\">",
+		"<fast-path xmlns=\"urn:6wind:vrouter/fast-path\">",
+		"<virtual-port><fpvhost xmlns=\"urn:6wind:vrouter/fpvhost\"><name>fpvhost-3f9a2b1c7d</name>",
+		"<socket-mode>server</socket-mode>",
+	} {
+		if !strings.Contains(got, w) {
+			t.Errorf("rendered XML missing %q\nfull XML:\n%s", w, got)
+		}
+	}
+	if strings.Contains(got, "sockpath") {
+		t.Errorf("rendered XML must not contain a sockpath leaf (no such leaf exists on the device):\n%s", got)
+	}
+	if strings.Contains(got, "<sockmode>") {
+		t.Errorf("rendered XML must not contain a sockmode leaf (renamed to socket-mode):\n%s", got)
+	}
+}
+
+// TestLayer2AttachPortsXML verifies L2-attached ports render as bridge
+// link-interfaces (slaves) with a matching interface entry in the namespace's
+// own interface set (never the IRB VRF's) and no L3 addressing.
+func TestLayer2AttachPortsXML(t *testing.T) {
+	intfs := &Interfaces{}
+	l := &Layer2{vrouter: &VRouter{}, ns: &Namespace{Name: "hbn", Interfaces: intfs}}
+	br := &Bridge{Name: "l2.100"}
+	info := &InfoL2{
+		vni: 100,
+		attachedPorts: []v1alpha1.AttachedPort{
+			{Interface: "cra-veth", PortWiring: v1alpha1.PortWiring{Transport: v1alpha1.PortTransportVeth}},
+			{Interface: "cra-vho", PortWiring: v1alpha1.PortWiring{
+				Transport:  v1alpha1.PortTransportVhostUser,
+				SocketPath: "/run/vsr-vhost-user/3f9a2b1c7d/socket",
+				SocketMode: "server",
+			}},
+		},
+	}
+
+	if err := l.attachPorts(info, br); err != nil {
+		t.Fatalf("attachPorts: %v", err)
+	}
+
+	if len(br.Slaves) != 2 || br.Slaves[0].Name != "cra-veth" || br.Slaves[1].Name != "cra-vho" {
+		t.Fatalf("expected both ports enslaved to the bridge, got %+v", br.Slaves)
+	}
+	if len(intfs.Infras) != 1 || intfs.Infras[0].Name != "cra-veth" {
+		t.Errorf("expected a veth infrastructure interface, got %+v", intfs.Infras)
+	}
+	if len(intfs.Fpvhosts) != 1 || intfs.Fpvhosts[0].Name != "cra-vho" {
+		t.Errorf("expected a fpvhost interface, got %+v", intfs.Fpvhosts)
+	}
+	if intfs.Infras[0].IPv4 != nil || intfs.Infras[0].IPv6 != nil {
+		t.Errorf("L2-attached port must carry no L3 addressing")
+	}
+	// The vhostuser attach must register a global fpvhost virtual-port.
+	if l.vrouter.System == nil || len(l.vrouter.System.FastPath.VirtualPort.Fpvhosts) != 1 {
+		t.Errorf("expected the vhostuser attach to register a fpvhost virtual-port")
+	}
+
+	out, err := xml.Marshal(br)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+	for _, w := range []string{
+		"<link-interface><slave>cra-veth</slave></link-interface>",
+		"<link-interface><slave>cra-vho</slave></link-interface>",
+	} {
+		if !strings.Contains(got, w) {
+			t.Errorf("rendered bridge XML missing %q\nfull XML:\n%s", w, got)
+		}
 	}
 }
 
@@ -116,7 +312,7 @@ func TestApplyWorkloadPortsMerge(t *testing.T) {
 		},
 	}
 
-	err := applyWorkloadPorts(vrf, WorkloadPort{
+	_, err := applyWorkloadPorts(vrf, WorkloadPort{
 		IfName:     craPortIfName,
 		GatewayV4:  "169.254.1.1/32",
 		HostRoutes: []string{"10.0.0.5/32", "fd00:200::5/128"},
@@ -143,7 +339,7 @@ func TestApplyWorkloadPortsMerge(t *testing.T) {
 
 	// Empty port list is a no-op.
 	before := len(vrf.Interfaces.Infras)
-	if err := applyWorkloadPorts(vrf); err != nil {
+	if _, err := applyWorkloadPorts(vrf); err != nil {
 		t.Fatalf("applyWorkloadPorts(empty): %v", err)
 	}
 	if len(vrf.Interfaces.Infras) != before {
@@ -170,7 +366,7 @@ func TestApplyGlobalWorkloadPorts(t *testing.T) {
 		},
 	}
 
-	if err := applyGlobalWorkloadPorts(ns, WorkloadPort{
+	if _, err := applyGlobalWorkloadPorts(ns, WorkloadPort{
 		IfName:     craPortIfName,
 		GatewayV4:  "169.254.1.1/32",
 		GatewayV6:  "fe80::1/128",
@@ -212,7 +408,7 @@ func TestApplyGlobalWorkloadPorts(t *testing.T) {
 // gracefully when no underlay BGP session is composed.
 func TestApplyGlobalWorkloadPortsNoBGP(t *testing.T) {
 	ns := &Namespace{Interfaces: &Interfaces{}, Routing: &Routing{}}
-	if err := applyGlobalWorkloadPorts(ns, WorkloadPort{
+	if _, err := applyGlobalWorkloadPorts(ns, WorkloadPort{
 		IfName:     craPortIfName,
 		HostRoutes: []string{"10.0.0.5/32"},
 	}); err != nil {
@@ -239,5 +435,150 @@ func TestConvStaticRouteInterfaceNextHop(t *testing.T) {
 	}
 	if got.NextHops[0].VRF != nil {
 		t.Errorf("interface next-hop must not set VRF, got %v", got.NextHops[0].VRF)
+	}
+}
+
+// TestLayer2AttachTrunkPortsXML verifies a trunked port renders one base
+// interface shared by every domain it carries, one vlan interface per member
+// (carrying the workload-side id) and one bridge slave per domain — including
+// across an IRB Layer2 whose bridge lives in a tenant VRF.
+func TestLayer2AttachTrunkPortsXML(t *testing.T) {
+	ns := &Namespace{Name: "hbn", Interfaces: &Interfaces{}}
+	l := &Layer2{vrouter: &VRouter{}, ns: ns}
+
+	// The green domain lives in the netns itself, the red one is an IRB domain
+	// whose bridge sits in a tenant VRF.
+	green := &Bridge{Name: "l2.100"}
+	red := &Bridge{Name: "l2.200"}
+	port := v1alpha1.AttachedPort{
+		Interface:  "cra012345",
+		PortWiring: v1alpha1.PortWiring{Transport: v1alpha1.PortTransportVeth},
+		MTU:        9000,
+	}
+
+	greenPort := port
+	greenPort.VLAN = 100
+	if err := l.attachPorts(&InfoL2{vni: 100, mtu: 9000,
+		attachedPorts: []v1alpha1.AttachedPort{greenPort}}, green); err != nil {
+		t.Fatalf("attachPorts (green): %v", err)
+	}
+	// Translated: the fabric-side 200 is carried as 3000 on the workload side.
+	redPort := port
+	redPort.VLAN = 3000
+	if err := l.attachPorts(&InfoL2{vni: 200, mtu: 9000,
+		attachedPorts: []v1alpha1.AttachedPort{redPort}}, red); err != nil {
+		t.Fatalf("attachPorts (red): %v", err)
+	}
+
+	// The shared port is declared exactly once, in the namespace's own set.
+	if len(ns.Interfaces.Infras) != 1 || ns.Interfaces.Infras[0].Name != "cra012345" {
+		t.Fatalf("expected exactly one shared infra interface, got %+v", ns.Interfaces.Infras)
+	}
+	if len(ns.Interfaces.VLANs) != 2 {
+		t.Fatalf("expected one vlan interface per member, got %+v", ns.Interfaces.VLANs)
+	}
+	for i, want := range []struct {
+		name   string
+		vlanID int
+	}{{"cra012345.100", 100}, {"cra012345.3000", 3000}} {
+		got := ns.Interfaces.VLANs[i]
+		if got.Name != want.name || got.VlanID != want.vlanID || got.LinkInterface != "cra012345" {
+			t.Errorf("vlan interface %d = %+v, want %s on cra012345 with vlan-id %d",
+				i, got, want.name, want.vlanID)
+		}
+		// The sub-interface is sized like the port the attachment asked for,
+		// not left at the platform default.
+		if got.MTU == nil || *got.MTU != 9000 {
+			t.Errorf("vlan interface %s mtu = %v, want 9000", want.name, got.MTU)
+		}
+	}
+	// The sub-interfaces are slaved, never the raw port: untagged and unlisted
+	// tags are not forwarded anywhere.
+	if len(green.Slaves) != 1 || green.Slaves[0].Name != "cra012345.100" {
+		t.Errorf("green slaves = %+v, want cra012345.100", green.Slaves)
+	}
+	if len(red.Slaves) != 1 || red.Slaves[0].Name != "cra012345.3000" {
+		t.Errorf("red slaves = %+v, want cra012345.3000", red.Slaves)
+	}
+
+	out, err := xml.Marshal(ns.Interfaces)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+	for _, w := range []string{
+		"<name>cra012345.100</name><vlan-id>100</vlan-id><link-interface>cra012345</link-interface>",
+		"<name>cra012345.3000</name><vlan-id>3000</vlan-id><link-interface>cra012345</link-interface>",
+	} {
+		if !strings.Contains(got, w) {
+			t.Errorf("rendered interfaces XML missing %q\nfull XML:\n%s", w, got)
+		}
+	}
+}
+
+// TestLayer2AttachTrunkRejectsOverlongName guards the kernel interface-name
+// limit the fast path materialises the vlan interface under.
+func TestLayer2AttachTrunkRejectsOverlongName(t *testing.T) {
+	ns := &Namespace{Name: "hbn", Interfaces: &Interfaces{}}
+	l := &Layer2{vrouter: &VRouter{}, ns: ns}
+	err := l.attachPorts(&InfoL2{vni: 100, attachedPorts: []v1alpha1.AttachedPort{{
+		Interface:  "cra0123456789",
+		PortWiring: v1alpha1.PortWiring{Transport: v1alpha1.PortTransportVeth},
+		VLAN:       4094,
+	}}}, &Bridge{Name: "l2.100"})
+	if err == nil {
+		t.Fatal("expected an error for an over-long trunk sub-interface name")
+	}
+}
+
+// TestLayer2AccessPortOnIRBDomainDeclaredInNamespace pins the interface set an
+// L2 *access* port is declared in when its domain is an IRB Layer2 whose bridge
+// lives in a tenant VRF: the port must land in the namespace's own interface
+// set, next to vlan.<id> / vx.<vni>, and only be *enslaved* from the VRF's
+// bridge. Declaring it under the l3vrf makes vSR 3.12.2 accept the commit but
+// never create the interface (a netdev cannot be a VRF slave and a bridge
+// slave at once).
+func TestLayer2AccessPortOnIRBDomainDeclaredInNamespace(t *testing.T) {
+	ns := &Namespace{
+		Name:       "hbn",
+		Interfaces: &Interfaces{},
+		VRFs:       []VRF{{Name: "m2m", Interfaces: &Interfaces{}}},
+	}
+	nodeCfg := &v1alpha1.NodeNetworkConfigSpec{
+		Layer2s: map[string]v1alpha1.Layer2{
+			"501": {
+				VLAN: 501, VNI: 4000002, MTU: 1500,
+				IRB: &v1alpha1.IRB{VRF: "m2m", MACAddress: "1a:ee:cf:2f:a7:a8", IPAddresses: []string{"10.250.0.1/24"}},
+				AttachedPorts: []v1alpha1.AttachedPort{{
+					Interface: "vhof5b3987d1677",
+					PortWiring: v1alpha1.PortWiring{
+						Transport:  v1alpha1.PortTransportVhostUser,
+						SocketPath: "/run/vsr-vhost-user/5f0a18537d/socket",
+						SocketMode: "server",
+					},
+				}},
+			},
+		},
+	}
+	mgr := &Manager{baseConfig: &config.BaseConfig{VTEPLoopbackIP: "10.50.0.20"}}
+	l := NewLayer2(nodeCfg, ns, &VRouter{}, mgr)
+	if err := l.setup(); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	vrf := LookupVRF(ns, "m2m")
+	if vrf.Interfaces.Bridges == nil || len(vrf.Interfaces.Bridges) != 1 {
+		t.Fatalf("expected the IRB bridge in the VRF, got %+v", vrf.Interfaces)
+	}
+	br := vrf.Interfaces.Bridges[0]
+	if len(br.Slaves) != 3 || br.Slaves[2].Name != "vhof5b3987d1677" {
+		t.Errorf("expected the access port enslaved to %s, got %+v", br.Name, br.Slaves)
+	}
+	if len(vrf.Interfaces.Fpvhosts) != 0 {
+		t.Errorf("access port must not be declared in the IRB VRF, got %+v", vrf.Interfaces.Fpvhosts)
+	}
+	if len(ns.Interfaces.Fpvhosts) != 1 || ns.Interfaces.Fpvhosts[0].Name != "vhof5b3987d1677" ||
+		ns.Interfaces.Fpvhosts[0].Port == nil || *ns.Interfaces.Fpvhosts[0].Port != "fpvhost-5f0a18537d" {
+		t.Errorf("expected the access port declared in the namespace's interface set, got %+v", ns.Interfaces.Fpvhosts)
 	}
 }

--- a/pkg/reconciler/agent-cra-vsr/nodenetworkconfig_reconciler.go
+++ b/pkg/reconciler/agent-cra-vsr/nodenetworkconfig_reconciler.go
@@ -19,13 +19,16 @@ package agent_cra_vsr //nolint:revive
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/telekom/das-schiff-network-operator/api/v1alpha1"
 	cra "github.com/telekom/das-schiff-network-operator/pkg/cra-vsr"
+	"github.com/telekom/das-schiff-network-operator/pkg/healthcheck"
 	"github.com/telekom/das-schiff-network-operator/pkg/reconciler/common"
+	"github.com/telekom/das-schiff-network-operator/pkg/workloadcni"
 )
 
 // CRAVSRConfigApplier implements the common.ConfigApplier interface for CRA-VSR.
@@ -65,6 +68,10 @@ func NewNodeNetworkConfigReconciler(
 		common.ReconcilerOptions{
 			RestoreOnReconcileFailure: false, // VSR cannot commit invalid configs
 			LocalASN:                  craManager.LocalASN(),
+			// Merge workload CNI attachments (recorded in the node's
+			// NodeWorkloadPorts object) into the config before NETCONF rendering:
+			// VSR's CRA-side FIB is owned by the agent, not the CNI.
+			WorkloadPortsSource: workloadcni.NewNodeSource(clusterClient, os.Getenv(healthcheck.NodenameEnv)),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

Consumes the shared routed/L2/vhost-user `WorkloadPort` inputs from the preceding stack and owns CRA-VSR realization only:

- renders routed workload ports as VSR infrastructure interfaces and routes;
- renders L2 bridge slaves and vhost-user fpvhost ports through NETCONF;
- wires the workload-CNI server into the CRA-VSR agent.

The routed foundation is #343, L2 CNI attachment is #344, and the VSR-targeted vhost-user CNI handoff is #374. This PR contains no workload CNI allocation or device-plugin logic.