### PR TITLE
chore(bpf): regenerate bindings for cilium/ebpf v0.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/telekom/das-schiff-network-operator
 go 1.25.0
 
 require (
-	github.com/cilium/ebpf v0.21.0
+	github.com/cilium/ebpf v0.22.0
 	github.com/cnf/structhash v0.0.0-20250313080605-df4c6cc74a9a
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/carlmjohnson/be v0.25.2 h1:EPTT7qCF5xJjcgrV5yX/muP5HTqSJR2VOjO6O4l9cY
 github.com/carlmjohnson/be v0.25.2/go.mod h1:2P+bH/INocW7e411OYCCIwT3nnJneZyveVav0WBBM1U=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cilium/ebpf v0.21.0 h1:4dpx1J/B/1apeTmWBH5BkVLayHTkFrMovVPnHEk+l3k=
-github.com/cilium/ebpf v0.21.0/go.mod h1:1kHKv6Kvh5a6TePP5vvvoMa1bclRyzUXELSs272fmIQ=
+github.com/cilium/ebpf v0.22.0 h1:v2ktp0roffpMOj2MMf3idtCQZOsAoC4BJbAJN+ke2bY=
+github.com/cilium/ebpf v0.22.0/go.mod h1:CDzZbe2hC5JjlDC+CY3KFCzlYwN4gbxppYM+Z10bQt4=
 github.com/cnf/structhash v0.0.0-20250313080605-df4c6cc74a9a h1:Ohw57yVY2dBTt+gsC6aZdteyxwlxfbtgkFEMTEkwgSw=
 github.com/cnf/structhash v0.0.0-20250313080605-df4c6cc74a9a/go.mod h1:pCxVEbcm3AMg7ejXyorUXi6HQCzOIBf7zEDVPtw0/U4=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=

--- a/pkg/bpf/nwopbpf_arm64_bpfel.go
+++ b/pkg/bpf/nwopbpf_arm64_bpfel.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	nwopbpfMapNeighborRingbuf        = "neighbor_ringbuf"
+	nwopbpfProgHandleNeighborReplyTc = "handle_neighbor_reply_tc"
+)
+
 // loadNwopbpf returns the embedded CollectionSpec for nwopbpf.
 func loadNwopbpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_NwopbpfBytes)
@@ -32,7 +40,7 @@ func loadNwopbpf() (*ebpf.CollectionSpec, error) {
 //	*nwopbpfMaps
 //
 // See ebpf.CollectionSpec.LoadAndAssign documentation for details.
-func loadNwopbpfObjects(obj interface{}, opts *ebpf.CollectionOptions) error {
+func loadNwopbpfObjects(obj any, opts *ebpf.CollectionOptions) error {
 	spec, err := loadNwopbpf()
 	if err != nil {
 		return err

--- a/pkg/bpf/nwopbpf_x86_bpfel.go
+++ b/pkg/bpf/nwopbpf_x86_bpfel.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	nwopbpfMapNeighborRingbuf        = "neighbor_ringbuf"
+	nwopbpfProgHandleNeighborReplyTc = "handle_neighbor_reply_tc"
+)
+
 // loadNwopbpf returns the embedded CollectionSpec for nwopbpf.
 func loadNwopbpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_NwopbpfBytes)
@@ -32,7 +40,7 @@ func loadNwopbpf() (*ebpf.CollectionSpec, error) {
 //	*nwopbpfMaps
 //
 // See ebpf.CollectionSpec.LoadAndAssign documentation for details.
-func loadNwopbpfObjects(obj interface{}, opts *ebpf.CollectionOptions) error {
+func loadNwopbpfObjects(obj any, opts *ebpf.CollectionOptions) error {
 	spec, err := loadNwopbpf()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Root cause

`bpf2go` ships with `cilium/ebpf`. Its generated output changed in v0.22.0:

- it emits object name constants for maps and programs
- it uses `any` instead of `interface{}`

The repo commits the `bpf2go` output in `pkg/bpf/nwopbpf_*_bpfel.go`. The `validate generated files` job runs `make generate` and fails on any diff. Dependabot bumps the module but cannot run `make generate`, so the job fails on every `cilium/ebpf` bump.

## Change

Bump `cilium/ebpf` to v0.22.0 and commit the regenerated bindings in the same change.

## Unblocks

- #342 (`go-minor-patch` group, 7 updates). This removes the `cilium/ebpf` part of that group as a cause of the `validate generated files` failure.

## Verification

- `make generate` produces no further diff
- `go build ./...` and `go vet ./...` pass
- `go test` over the `make test` package set passes
- `golangci-lint run ./...` reports 88 issues, identical to the `main` baseline