### PR TITLE
ci(e2e): pass the go.mod Go version to the image builds

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,10 +47,15 @@ jobs:
         id: ldflags
         run: echo "value=$(bash hack/version.sh)" >> "$GITHUB_OUTPUT"
 
+      - name: Read Go version
+        id: go-version
+        run: echo "version=$(awk '/^go / { print $2 }' go.mod)" >> $GITHUB_OUTPUT
+
       - name: Build cra-frr image
         run: |
           docker build \
             --build-arg ldflags="${{ steps.ldflags.outputs.value }}" \
+            --build-arg GO_VERSION=${{ steps.go-version.outputs.version }} \
             -f das-schiff-cra-frr.Dockerfile \
             -t das-schiff-cra-frr:latest .
 
@@ -105,10 +110,15 @@ jobs:
         id: ldflags
         run: echo "value=$(bash hack/version.sh)" >> "$GITHUB_OUTPUT"
 
+      - name: Read Go version
+        id: go-version
+        run: echo "version=$(awk '/^go / { print $2 }' go.mod)" >> $GITHUB_OUTPUT
+
       - name: Build image
         run: |
           docker build \
             --build-arg ldflags="${{ steps.ldflags.outputs.value }}" \
+            --build-arg GO_VERSION=${{ steps.go-version.outputs.version }} \
             -f ${{ matrix.image }}.Dockerfile \
             -t ${{ env.IMG_BASE }}/${{ matrix.image }}:latest .
 
@@ -142,9 +152,14 @@ jobs:
             -f e2e/images/nat64/Dockerfile \
             e2e/images/nat64/
 
+      - name: Read Go version
+        id: go-version
+        run: echo "version=$(awk '/^go / { print $2 }' go.mod)" >> $GITHUB_OUTPUT
+
       - name: Build tester image
         run: |
           docker build \
+            --build-arg GO_VERSION=${{ steps.go-version.outputs.version }} \
             -t ${{ env.IMG_BASE }}/das-schiff-e2e-tester:latest \
             -f e2e/images/tester/Dockerfile \
             e2e/images/tester/

--- a/e2e/images/tester/Dockerfile
+++ b/e2e/images/tester/Dockerfile
@@ -1,6 +1,7 @@
 # Test runner image for das-schiff-network-operator e2e tests.
 # Includes ginkgo CLI, kubectl, Go, and network diagnostic tools.
-FROM golang:1.25 AS builder
+ARG GO_VERSION=1.25
+FROM golang:${GO_VERSION} AS builder
 
 # Install ginkgo CLI
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.27.2


### PR DESCRIPTION
> **Superseded by #301 — please close this PR in favour of #301.**
>
> I opened this before checking the open PR list. #301 (`ci: pass go.mod version to Docker builds`) already does everything here and more, and the two conflict on `.github/workflows/e2e.yaml` and `e2e/images/tester/Dockerfile`.
>
> #301 additionally covers the Makefile, `build-images.yaml`, the e2e setup Go builds and all nine service Dockerfiles. It also already uses the quoted `"$GITHUB_OUTPUT"` with `awk ... exit`, and sets `ARG GO_VERSION=1.25.0` — the two review points raised on this PR.
>
> The analysis below stays valid as the root-cause record for #353.

## Root cause

The e2e workflow builds its images with plain `docker build` and no `GO_VERSION` build argument. The Dockerfiles then use their default `ARG GO_VERSION=1.25`.

The Go builder image runs with `GOTOOLCHAIN=local`. When `go.mod` asks for a Go version above 1.25, `go mod download` fails:

```
go: go.mod requires go >= 1.26.0 (running go 1.25.13; GOTOOLCHAIN=local)
```

Every e2e image build then fails. `build-images.yaml` already reads the Go version from `go.mod`, so that workflow is not affected.

## Unblocks

- #353 (`kubernetes-minor-patch` group). Kubernetes 0.36 requires Go 1.26, so dependabot raises `go.mod` to `go 1.26.0` and all seven build jobs fail.

#353 has a second cause that neither this PR nor #301 addresses: golangci-lint v2.8.0 is built with Go 1.25 and refuses a `go.mod` targeting 1.26.0.

## Verification

Ran `docker build` on the `go.mod` of #353 (`go 1.26.0`): fails at `go mod download` without the build argument, builds with it.