### PR TITLE
ci(e2e): retry the E2E lab setup once

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -197,7 +197,22 @@ jobs:
           E2E_SKIP_BUILD: "true"
           E2E_IMAGE_DIR: /tmp/e2e-images
           E2E_NODE_IMAGE: ${{ env.IMG_BASE }}/das-schiff-kind-node:${{ env.KIND_NODE_VERSION }}
-        run: make e2e-up
+        # "kubeadm init" pulls registry.k8s.io/pause on every node. That pull
+        # fails from time to time and takes the whole job down. Tear the lab
+        # down and try once more before failing.
+        run: |
+          for attempt in 1 2; do
+            if make e2e-up; then
+              exit 0
+            fi
+            echo "::warning::E2E lab setup failed on attempt ${attempt}"
+            if [ "$attempt" -eq 2 ]; then
+              break
+            fi
+            make e2e-down || true
+            sleep 30
+          done
+          exit 1
 
       - name: Run E2E tests (legacy)
         id: legacy


### PR DESCRIPTION
## Root cause

`make e2e-up` runs `kubeadm init`, which pulls `registry.k8s.io/pause` on every node. That pull fails from time to time. A single failed pull ends the whole E2E job, and the run reports a test failure that no code change caused.

Example from run 31827077671:

```
[ERROR ImagePull]: failed to pull image registry.k8s.io/pause:3.10.1
error: error execution phase preflight: preflight checks failed
```

The step had no retry, so the job stopped there.

## Change

The `Set up E2E lab` step runs `make e2e-up` twice at most. After a failed attempt it runs `make e2e-down` and waits 30 seconds, so the retry starts from a clean lab. A lab that comes up on the first attempt is unaffected.

## Unblocks

Any PR whose `E2E Tests` job stops during lab setup. Seen on #359 and on earlier dependabot runs.

This does not cover failures inside the tests themselves. Those need separate work.

## Verification

The workflow parses as YAML and the step body passes `bash -n`. The retry path only runs after `make e2e-up` returns non-zero.