### PR TITLE
chore: regenerate BPF bindings for ebpf 0.22

### DIFF
--- a/pkg/bpf/nwopbpf_arm64_bpfel.go
+++ b/pkg/bpf/nwopbpf_arm64_bpfel.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	nwopbpfMapNeighborRingbuf        = "neighbor_ringbuf"
+	nwopbpfProgHandleNeighborReplyTc = "handle_neighbor_reply_tc"
+)
+
 // loadNwopbpf returns the embedded CollectionSpec for nwopbpf.
 func loadNwopbpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_NwopbpfBytes)
@@ -32,7 +40,7 @@ func loadNwopbpf() (*ebpf.CollectionSpec, error) {
 //	*nwopbpfMaps
 //
 // See ebpf.CollectionSpec.LoadAndAssign documentation for details.
-func loadNwopbpfObjects(obj interface{}, opts *ebpf.CollectionOptions) error {
+func loadNwopbpfObjects(obj any, opts *ebpf.CollectionOptions) error {
 	spec, err := loadNwopbpf()
 	if err != nil {
 		return err

--- a/pkg/bpf/nwopbpf_x86_bpfel.go
+++ b/pkg/bpf/nwopbpf_x86_bpfel.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	nwopbpfMapNeighborRingbuf        = "neighbor_ringbuf"
+	nwopbpfProgHandleNeighborReplyTc = "handle_neighbor_reply_tc"
+)
+
 // loadNwopbpf returns the embedded CollectionSpec for nwopbpf.
 func loadNwopbpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_NwopbpfBytes)
@@ -32,7 +40,7 @@ func loadNwopbpf() (*ebpf.CollectionSpec, error) {
 //	*nwopbpfMaps
 //
 // See ebpf.CollectionSpec.LoadAndAssign documentation for details.
-func loadNwopbpfObjects(obj interface{}, opts *ebpf.CollectionOptions) error {
+func loadNwopbpfObjects(obj any, opts *ebpf.CollectionOptions) error {
 	spec, err := loadNwopbpf()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Purpose

This follow-up targets the head branch of Dependabot PR #362 and contains only generated BPF bindings required by cilium/ebpf v0.22.0.

Generated with make generate in an amd64 Linux container matching CI; the resulting diff is clean against generator output.

Copilot also flagged the logr v1.4.4 release notes as a possible Go 1.25 concern. The module itself declares Go 1.18 and its upstream test matrix includes Go 1.25, so no compatibility downgrade is necessary; the dependency remains unchanged.

After this follow-up is merged, retest #362.

Related: #362.
