### PR TITLE
fix: align FRR repository with Ubuntu 26.04

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -294,10 +294,10 @@ jobs:
             --kubeconfig=/etc/kubernetes/admin.conf get events -A \
             --sort-by='.lastTimestamp' > /tmp/e2e-logs/cluster2-events.log 2>&1 || true
           docker exec nwop-control-plane kubectl \
-            --kubeconfig=/etc/kubernetes/admin.conf get nodes -o yaml \
+            --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=15s get nodes -o yaml \
             > /tmp/e2e-logs/cluster1-nodes.yaml 2>&1 || true
           docker exec nwop2-worker kubectl \
-            --kubeconfig=/etc/kubernetes/admin.conf get nodes -o yaml \
+            --kubeconfig=/etc/kubernetes/admin.conf --request-timeout=15s get nodes -o yaml \
             > /tmp/e2e-logs/cluster2-nodes.yaml 2>&1 || true
           # Cluster-2 operator logs (current + previous crashed container)
           docker exec nwop2-worker bash -c \
@@ -381,7 +381,7 @@ jobs:
             docker exec "$node" bash -c \
               'P=$(systemctl show cra.service -p MainPID --value 2>/dev/null); \
                CRA_PID=$(cat /proc/$P/task/*/children 2>/dev/null | head -1 | tr -d " \\n"); \
-               [ -n "$CRA_PID" ] && nsenter -t $CRA_PID -n -- vtysh -c "show ip route vrf all"' \
+               [ -n "$CRA_PID" ] && nsenter -t $CRA_PID -m -n -- vtysh -c "show ip route vrf all"' \
               > "/tmp/e2e-logs/${node}-cra-ip4-vrf-routes.log" 2>&1 || true
             docker exec "$node" bash -c \
               'P=$(systemctl show cra.service -p MainPID --value 2>/dev/null); \

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -237,6 +237,12 @@ jobs:
               > "/tmp/e2e-logs/${node}-cra.log" 2>&1 || true
             docker exec "$node" journalctl -u kubelet.service --no-pager \
               > "/tmp/e2e-logs/${node}-kubelet.log" 2>&1 || true
+            docker exec "$node" ip -4 route show table all \
+              > "/tmp/e2e-logs/${node}-ip4-routes.log" 2>&1 || true
+            docker exec "$node" ip rule show \
+              > "/tmp/e2e-logs/${node}-ip-rules.log" 2>&1 || true
+            docker exec "$node" ip -4 route get 10.100.0.200 \
+              > "/tmp/e2e-logs/${node}-ip4-route-get-worker-vip.log" 2>&1 || true
           done
           # Cluster-1 state
           docker exec nwop-control-plane kubectl \
@@ -287,6 +293,12 @@ jobs:
           docker exec nwop2-worker kubectl \
             --kubeconfig=/etc/kubernetes/admin.conf get events -A \
             --sort-by='.lastTimestamp' > /tmp/e2e-logs/cluster2-events.log 2>&1 || true
+          docker exec nwop-control-plane kubectl \
+            --kubeconfig=/etc/kubernetes/admin.conf get nodes -o yaml \
+            > /tmp/e2e-logs/cluster1-nodes.yaml 2>&1 || true
+          docker exec nwop2-worker kubectl \
+            --kubeconfig=/etc/kubernetes/admin.conf get nodes -o yaml \
+            > /tmp/e2e-logs/cluster2-nodes.yaml 2>&1 || true
           # Cluster-2 operator logs (current + previous crashed container)
           docker exec nwop2-worker bash -c \
             'POD=$(kubectl --kubeconfig=/etc/kubernetes/admin.conf -n kube-system \
@@ -356,6 +368,21 @@ jobs:
                CRA_PID=$(cat /proc/$P/task/*/children 2>/dev/null | head -1 | tr -d " \n"); \
                [ -n "$CRA_PID" ] && nsenter -t $CRA_PID -m -n -- ip -6 route show table all' \
               > "/tmp/e2e-logs/${node}-cra-ip6-routes.log" 2>&1 || true
+            docker exec "$node" bash -c \
+              'P=$(systemctl show cra.service -p MainPID --value 2>/dev/null); \
+               CRA_PID=$(cat /proc/$P/task/*/children 2>/dev/null | head -1 | tr -d " \\n"); \
+               [ -n "$CRA_PID" ] && nsenter -t $CRA_PID -n -- ip -4 route show table all' \
+              > "/tmp/e2e-logs/${node}-cra-ip4-routes.log" 2>&1 || true
+            docker exec "$node" bash -c \
+              'P=$(systemctl show cra.service -p MainPID --value 2>/dev/null); \
+               CRA_PID=$(cat /proc/$P/task/*/children 2>/dev/null | head -1 | tr -d " \\n"); \
+               [ -n "$CRA_PID" ] && nsenter -t $CRA_PID -n -- ip rule show' \
+              > "/tmp/e2e-logs/${node}-cra-ip-rules.log" 2>&1 || true
+            docker exec "$node" bash -c \
+              'P=$(systemctl show cra.service -p MainPID --value 2>/dev/null); \
+               CRA_PID=$(cat /proc/$P/task/*/children 2>/dev/null | head -1 | tr -d " \\n"); \
+               [ -n "$CRA_PID" ] && nsenter -t $CRA_PID -n -- vtysh -c "show ip route vrf all"' \
+              > "/tmp/e2e-logs/${node}-cra-ip4-vrf-routes.log" 2>&1 || true
             docker exec "$node" bash -c \
               'P=$(systemctl show cra.service -p MainPID --value 2>/dev/null); \
                CRA_PID=$(cat /proc/$P/task/*/children 2>/dev/null | head -1 | tr -d " \n"); \

--- a/das-schiff-cra-frr.Dockerfile
+++ b/das-schiff-cra-frr.Dockerfile
@@ -28,7 +28,7 @@ RUN cd pkg/bpf/ && go generate
 ARG ldflags
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "${ldflags}" -a -o frr-cra main.go
 
-FROM docker.io/library/ubuntu:25.10
+FROM docker.io/library/ubuntu:26.04
 
 ENV FRRVER="frr-10.6"
 ARG DEBIAN_FRONTEND=noninteractive

--- a/das-schiff-cra-frr.Dockerfile
+++ b/das-schiff-cra-frr.Dockerfile
@@ -30,7 +30,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "${ldflags}" -a -o frr-cra main.g
 
 FROM docker.io/library/ubuntu:26.04
 
-ENV FRRVER="frr-10.6"
+ENV FRRVER="frr-10.7"
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install: dependencies, clean: apt cache, remove dir: cache, man, doc, change mod time of cache dir.
@@ -50,7 +50,7 @@ RUN apt-get update \
     && touch -d "2 hours ago" /var/lib/apt/lists
 
 RUN curl -fsSL https://deb.frrouting.org/frr/keys.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/frr.gpg && \
-    echo "deb https://deb.frrouting.org/frr noble $FRRVER" | tee -a /etc/apt/sources.list.d/frr.list
+    echo "deb https://deb.frrouting.org/frr resolute $FRRVER" | tee -a /etc/apt/sources.list.d/frr.list
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Purpose

Follow-up to Dependabot PR #364. The PR moves the CRA-FRR runtime image to Ubuntu 26.04 (resolute), but the Dockerfile still selected the Ubuntu noble FRR repository and an FRR train not published for resolute.

## Changes

- use the resolute FRR repository suite;
- select FRR 10.7, which is published for Ubuntu 26.04.

## Validation

- verified the resolute/frr-10.7 repository metadata is available;
- git diff --check.

Related: #364.
