### PR TITLE
fix: validate Destination prefixes as CIDRs

### DIFF
--- a/api/v1alpha1/network-connector/destination_types.go
+++ b/api/v1alpha1/network-connector/destination_types.go
@@ -27,7 +27,11 @@ type DestinationSpec struct {
 	// References a VRF resource by name. Mutually exclusive with nextHop.
 	VRFRef *string `json:"vrfRef,omitempty"`
 
-	// Subnets reachable via this destination (CIDR notation).
+	// Subnets reachable via this destination. Each entry must use CIDR notation
+	// (e.g. "198.51.100.0/24" or "2001:db8::/32").
+	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:items:MaxLength=43
+	// +kubebuilder:validation:XValidation:rule="self.all(prefix, isCIDR(prefix))",message="each prefix must be a valid CIDR notation (e.g. 198.51.100.0/24 or 2001:db8::/32)"
 	Prefixes []string `json:"prefixes,omitempty"`
 
 	// Next-hop addresses for static routing. Mutually exclusive with vrfRef.

--- a/config/crd/bases/network-connector.sylvaproject.org_destinations.yaml
+++ b/config/crd/bases/network-connector.sylvaproject.org_destinations.yaml
@@ -125,10 +125,18 @@ spec:
                       && has(self.portRange))
                 type: array
               prefixes:
-                description: Subnets reachable via this destination (CIDR notation).
+                description: |-
+                  Subnets reachable via this destination. Each entry must use CIDR notation
+                  (e.g. "198.51.100.0/24" or "2001:db8::/32").
                 items:
+                  maxLength: 43
                   type: string
+                maxItems: 1000
                 type: array
+                x-kubernetes-validations:
+                - message: each prefix must be a valid CIDR notation (e.g. 198.51.100.0/24
+                    or 2001:db8::/32)
+                  rule: self.all(prefix, isCIDR(prefix))
               vrfRef:
                 description: References a VRF resource by name. Mutually exclusive
                   with nextHop.

--- a/docs/reference/crd-reference.md
+++ b/docs/reference/crd-reference.md
@@ -487,7 +487,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `vrfRef` _string_ | References a VRF resource by name. Mutually exclusive with nextHop. |  |  |
-| `prefixes` _string array_ | Subnets reachable via this destination (CIDR notation). |  |  |
+| `prefixes` _string array_ | Subnets reachable via this destination. Each entry must use CIDR notation<br />(e.g. "198.51.100.0/24" or "2001:db8::/32"). |  | MaxItems: 1000 <br />items:MaxLength: 43 <br /> |
 | `nextHop` _[NextHopConfig](#nexthopconfig)_ | Next-hop addresses for static routing. Mutually exclusive with vrfRef. |  |  |
 | `ports` _[DestinationPort](#destinationport) array_ | Port restrictions for egress NetworkPolicy. |  |  |
 


### PR DESCRIPTION
## Summary
- enforce valid CIDR notation for every `Destination.spec.prefixes` entry in the CRD schema
- retain webhook validation as defense in depth

## Validation
- `go test ./api/v1alpha1/network-connector` passes
- full `go test ./...` is currently blocked by the pre-existing missing `pkg/bpf` embedded object `nwopbpf_arm64_bpfel.o`