### PR TITLE
fix(api): use int64 for BGP RemoteASN to avoid int32 CEL format rejection

### DIFF
--- a/api/v1alpha1/bgppeering_types.go
+++ b/api/v1alpha1/bgppeering_types.go
@@ -40,8 +40,15 @@ type BGPPeeringSpec struct {
 	// Loopback is the loopback interface used for the BGP peering
 	LoopbackPeer *BGPPeeringLoopback `json:"loopbackPeer,omitempty"`
 
-	// RemoteASN is the ASN of the remote BGP peer
-	RemoteASN uint32 `json:"remoteASN"`
+	// RemoteASN is the ASN of the remote BGP peer. Uses asplain notation;
+	// 4-byte ASNs (up to 4294967295) are common and exceed the signed int32
+	// range, so this is int64 (format: int64) rather than uint32/int32 —
+	// controller-gen maps uint32 to the OpenAPI "int32" format, whose CEL
+	// format-check enforces the *signed* int32 range (max 2147483647) and
+	// would reject legitimate large 4-byte ASNs.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=4294967295
+	RemoteASN int64 `json:"remoteASN"`
 	// EnableBFD is the flag to enable BFD for the BGP peering
 	EnableBFD bool `json:"enableBFD"`
 

--- a/api/v1alpha1/nodenetworkconfig_types.go
+++ b/api/v1alpha1/nodenetworkconfig_types.go
@@ -133,8 +133,15 @@ type BGPPeer struct {
 	Address *string `json:"address,omitempty"`
 	// ListenRange is the listen range for the BGP peer.
 	ListenRange *string `json:"listenRange,omitempty"`
-	// RemoteASN is the remote Autonomous System Number.
-	RemoteASN uint32 `json:"remoteAsn"`
+	// RemoteASN is the remote Autonomous System Number. Uses asplain notation;
+	// 4-byte ASNs (up to 4294967295) are common and exceed the signed int32
+	// range, so this is int64 (format: int64) rather than uint32/int32 —
+	// controller-gen maps uint32 to the OpenAPI "int32" format, whose CEL
+	// format-check enforces the *signed* int32 range (max 2147483647) and
+	// would reject legitimate large 4-byte ASNs.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=4294967295
+	RemoteASN int64 `json:"remoteAsn"`
 	// IPv4 is the IPv4 address family configuration.
 	IPv4 *AddressFamily `json:"ipv4,omitempty"`
 	// IPv6 is the IPv6 address family configuration.

--- a/config/crd/bases/network.t-caas.telekom.com_bgppeerings.yaml
+++ b/config/crd/bases/network.t-caas.telekom.com_bgppeerings.yaml
@@ -189,8 +189,16 @@ spec:
                 - name
                 type: object
               remoteASN:
-                description: RemoteASN is the ASN of the remote BGP peer
-                format: int32
+                description: |-
+                  RemoteASN is the ASN of the remote BGP peer. Uses asplain notation;
+                  4-byte ASNs (up to 4294967295) are common and exceed the signed int32
+                  range, so this is int64 (format: int64) rather than uint32/int32 —
+                  controller-gen maps uint32 to the OpenAPI "int32" format, whose CEL
+                  format-check enforces the *signed* int32 range (max 2147483647) and
+                  would reject legitimate large 4-byte ASNs.
+                format: int64
+                maximum: 4294967295
+                minimum: 1
                 type: integer
             required:
             - enableBFD

--- a/config/crd/bases/network.t-caas.telekom.com_networkconfigrevisions.yaml
+++ b/config/crd/bases/network.t-caas.telekom.com_networkconfigrevisions.yaml
@@ -216,8 +216,16 @@ spec:
                       - name
                       type: object
                     remoteASN:
-                      description: RemoteASN is the ASN of the remote BGP peer
-                      format: int32
+                      description: |-
+                        RemoteASN is the ASN of the remote BGP peer. Uses asplain notation;
+                        4-byte ASNs (up to 4294967295) are common and exceed the signed int32
+                        range, so this is int64 (format: int64) rather than uint32/int32 —
+                        controller-gen maps uint32 to the OpenAPI "int32" format, whose CEL
+                        format-check enforces the *signed* int32 range (max 2147483647) and
+                        would reject legitimate large 4-byte ASNs.
+                      format: int64
+                      maximum: 4294967295
+                      minimum: 1
                       type: integer
                   required:
                   - enableBFD

--- a/config/crd/bases/network.t-caas.telekom.com_nodenetworkconfigs.yaml
+++ b/config/crd/bases/network.t-caas.telekom.com_nodenetworkconfigs.yaml
@@ -667,8 +667,16 @@ spec:
                             (key "password") and inlined here so node agents do not need Secret RBAC.
                           type: string
                         remoteAsn:
-                          description: RemoteASN is the remote Autonomous System Number.
-                          format: int32
+                          description: |-
+                            RemoteASN is the remote Autonomous System Number. Uses asplain notation;
+                            4-byte ASNs (up to 4294967295) are common and exceed the signed int32
+                            range, so this is int64 (format: int64) rather than uint32/int32 —
+                            controller-gen maps uint32 to the OpenAPI "int32" format, whose CEL
+                            format-check enforces the *signed* int32 range (max 2147483647) and
+                            would reject legitimate large 4-byte ASNs.
+                          format: int64
+                          maximum: 4294967295
+                          minimum: 1
                           type: integer
                       required:
                       - remoteAsn
@@ -1884,9 +1892,16 @@ spec:
                               (key "password") and inlined here so node agents do not need Secret RBAC.
                             type: string
                           remoteAsn:
-                            description: RemoteASN is the remote Autonomous System
-                              Number.
-                            format: int32
+                            description: |-
+                              RemoteASN is the remote Autonomous System Number. Uses asplain notation;
+                              4-byte ASNs (up to 4294967295) are common and exceed the signed int32
+                              range, so this is int64 (format: int64) rather than uint32/int32 —
+                              controller-gen maps uint32 to the OpenAPI "int32" format, whose CEL
+                              format-check enforces the *signed* int32 range (max 2147483647) and
+                              would reject legitimate large 4-byte ASNs.
+                            format: int64
+                            maximum: 4294967295
+                            minimum: 1
                             type: integer
                         required:
                         - remoteAsn
@@ -3356,9 +3371,16 @@ spec:
                               (key "password") and inlined here so node agents do not need Secret RBAC.
                             type: string
                           remoteAsn:
-                            description: RemoteASN is the remote Autonomous System
-                              Number.
-                            format: int32
+                            description: |-
+                              RemoteASN is the remote Autonomous System Number. Uses asplain notation;
+                              4-byte ASNs (up to 4294967295) are common and exceed the signed int32
+                              range, so this is int64 (format: int64) rather than uint32/int32 —
+                              controller-gen maps uint32 to the OpenAPI "int32" format, whose CEL
+                              format-check enforces the *signed* int32 range (max 2147483647) and
+                              would reject legitimate large 4-byte ASNs.
+                            format: int64
+                            maximum: 4294967295
+                            minimum: 1
                             type: integer
                         required:
                         - remoteAsn

--- a/pkg/cra-vsr/cra_vsr_test.go
+++ b/pkg/cra-vsr/cra_vsr_test.go
@@ -535,7 +535,7 @@ var _ = Describe("CRA-VSR", func() {
 	})
 	It("Renders listen-range peers for the management VRF", func() {
 		listenRange := "192.168.100.0/24"
-		remoteASN := uint32(65099)
+		remoteASN := int64(65099)
 		maxPfx := uint32(10)
 
 		nodeSpec := &v1alpha1.NodeNetworkConfigSpec{

--- a/pkg/reconciler/intent/builder/bgp_announcement_test.go
+++ b/pkg/reconciler/intent/builder/bgp_announcement_test.go
@@ -458,6 +458,55 @@ func TestBGPPeeringBuilder_LoopbackPeer(t *testing.T) {
 	}
 }
 
+// TestBGPPeeringBuilder_LargeFourByteASN is a regression test for a bug where
+// BGPPeer.RemoteASN was declared uint32, which controller-gen maps to the
+// OpenAPI "int32" format (signed, max 2147483647). Kubernetes enforces that
+// format strictly, so 4-byte ASNs above the signed int32 limit (legitimate
+// values up to 4294967295 per RFC 6996) were rejected at apply time even
+// though workloadAS itself validated fine. RemoteASN must now be int64 and
+// must round-trip such values without truncation or overflow.
+func TestBGPPeeringBuilder_LargeFourByteASN(t *testing.T) {
+	b := NewBGPPeeringBuilder()
+
+	const largeASN = int64(4200011028) // > math.MaxInt32 (2147483647)
+
+	data := &resolver.ResolvedData{
+		Nodes: []corev1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+		},
+		BGPPeerings: []nc.BGPPeering{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "loopback-peer-large-asn"},
+				Spec: nc.BGPPeeringSpec{
+					Mode: nc.BGPPeeringModeLoopbackPeer,
+					Ref: nc.BGPPeeringRef{
+						InboundRefs: []string{"my-inbound"},
+					},
+					WorkloadAS: ptr(largeASN),
+				},
+			},
+		},
+	}
+
+	result, err := b.Build(context.Background(), data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	contrib, ok := result["node-1"]
+	if !ok {
+		t.Fatalf("expected contribution for node-1")
+	}
+	if contrib.ClusterVRF == nil || len(contrib.ClusterVRF.BGPPeers) != 1 {
+		t.Fatalf("expected 1 BGPPeer on ClusterVRF for node-1")
+	}
+
+	peer := contrib.ClusterVRF.BGPPeers[0]
+	if peer.RemoteASN != largeASN {
+		t.Errorf("expected RemoteASN %d, got %d (possible truncation/overflow)", largeASN, peer.RemoteASN)
+	}
+}
+
 // TestBGPPeeringBuilder_PasswordInjection verifies that buildBasePeer inlines
 // the resolved password from ResolvedData.BGPPasswords into every BGPPeer
 // produced for a BGPPeering with AuthSecretRef.

--- a/pkg/reconciler/intent/builder/bgppeering.go
+++ b/pkg/reconciler/intent/builder/bgppeering.go
@@ -318,7 +318,7 @@ func (*BGPPeeringBuilder) buildBasePeer(bp *nc.BGPPeering, data *resolver.Resolv
 	peer := networkv1alpha1.BGPPeer{}
 
 	if bp.Spec.WorkloadAS != nil {
-		peer.RemoteASN = uint32(*bp.Spec.WorkloadAS) //nolint:gosec // value validated by CRD schema: required, range [1, 4294967295]
+		peer.RemoteASN = *bp.Spec.WorkloadAS
 	}
 
 	peer.HoldTime = bp.Spec.HoldTime

--- a/pkg/reconciler/intent/reconciler_test.go
+++ b/pkg/reconciler/intent/reconciler_test.go
@@ -644,7 +644,7 @@ func TestBGPPeeringListenRange(t *testing.T) {
 	for _, peer := range fvrf.BGPPeers {
 		if peer.ListenRange != nil {
 			hasListenRange = true
-			assert.Equal(t, uint32(65100), peer.RemoteASN, "expected WorkloadAS as RemoteASN")
+			assert.Equal(t, int64(65100), peer.RemoteASN, "expected WorkloadAS as RemoteASN")
 		}
 	}
 	assert.True(t, hasListenRange, "expected at least one BGPPeer with ListenRange")
@@ -681,11 +681,59 @@ func TestBGPPeeringLoopbackPeer(t *testing.T) {
 	require.NotEmpty(t, nnc.Spec.ClusterVRF.BGPPeers, "expected BGPPeers on ClusterVRF")
 
 	peer := nnc.Spec.ClusterVRF.BGPPeers[0]
-	assert.Equal(t, uint32(65200), peer.RemoteASN, "expected WorkloadAS as RemoteASN")
+	assert.Equal(t, int64(65200), peer.RemoteASN, "expected WorkloadAS as RemoteASN")
 
 	// Dual-stack address families should be set
 	assert.NotNil(t, peer.IPv4, "expected IPv4 address family")
 	assert.NotNil(t, peer.IPv6, "expected IPv6 address family")
+}
+
+// TestBGPPeeringLoopbackPeerLargeFourByteASN is a regression test for a bug
+// where NodeNetworkConfig.spec.*.bgpPeers[].remoteAsn was declared uint32,
+// which controller-gen maps to the CRD's OpenAPI "int32" format (signed, max
+// 2147483647). The API server enforces that format strictly, so applying a
+// NodeNetworkConfig for a BGPPeering with a legitimate 4-byte ASN above the
+// signed int32 limit (up to 4294967295 per RFC 6996) was rejected with:
+//
+//	Checked value must be of type integer with format int32
+//
+// even though BGPPeering.spec.workloadAS itself validated fine (int64).
+// remoteAsn must now be int64 so the envtest API server accepts the create.
+func TestBGPPeeringLoopbackPeerLargeFourByteASN(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "node-bgp-lb-large-asn"
+
+	const largeASN = int64(4200011028) // > math.MaxInt32 (2147483647)
+
+	createNode(t, ctx, nodeName, nil)
+	createObj(t, ctx, makeVRF("vrf-bgp-lb-large", "bgplblg", 2002092, "65188:2092"))
+	createObj(t, ctx, makeNetwork("net-bgp-lb-large", 562, 4600003, "10.250.62.0/24", ""))
+	createObj(t, ctx, makeDestination("dest-bgp-lb-large", "vrf-bgp-lb-large", map[string]string{"type": "bgp-lb-large"}, []string{"10.102.0.0/16"}))
+	createObj(t, ctx, makeInbound("ib-bgp-lb-large", "net-bgp-lb-large", destSelector("bgp-lb-large"), []string{"10.250.62.10/32"}))
+
+	bgpPeering := &nc.BGPPeering{
+		ObjectMeta: metav1.ObjectMeta{Name: "bgpp-loopback-large-asn", Namespace: testNamespace},
+		Spec: nc.BGPPeeringSpec{
+			Mode: nc.BGPPeeringModeLoopbackPeer,
+			Ref: nc.BGPPeeringRef{
+				InboundRefs: []string{"ib-bgp-lb-large"},
+			},
+			WorkloadAS:      ptr(largeASN),
+			AddressFamilies: []nc.BGPAddressFamily{nc.BGPAddressFamilyIPv4Unicast, nc.BGPAddressFamilyIPv6Unicast},
+		},
+	}
+	createObj(t, ctx, bgpPeering)
+
+	// reconcileAndGetNNC creates the NodeNetworkConfig against the envtest API
+	// server, which is where the original bug surfaced: the server rejected
+	// the create/update due to the (then-)signed int32 format check.
+	nnc := reconcileAndGetNNC(t, ctx, nodeName)
+
+	require.NotNil(t, nnc.Spec.ClusterVRF, "expected ClusterVRF for loopbackPeer BGPPeering")
+	require.NotEmpty(t, nnc.Spec.ClusterVRF.BGPPeers, "expected BGPPeers on ClusterVRF")
+
+	peer := nnc.Spec.ClusterVRF.BGPPeers[0]
+	assert.Equal(t, largeASN, peer.RemoteASN, "expected large 4-byte WorkloadAS as RemoteASN without truncation")
 }
 
 // --- TrafficMirror Tests ---

--- a/pkg/reconciler/operator/bgp.go
+++ b/pkg/reconciler/operator/bgp.go
@@ -204,7 +204,8 @@ func buildNodeBgpPeers(node *corev1.Node, revision *v1alpha1.NetworkConfigRevisi
 
 func buildNetplanDummies(node *corev1.Node, revision *v1alpha1.NetworkConfigRevision) (map[string]netplan.Device, error) {
 	dummies := make(map[string]netplan.Device)
-	for _, bgp := range revision.Spec.BGP {
+	for i := range revision.Spec.BGP {
+		bgp := &revision.Spec.BGP[i]
 		if !matchSelector(node, bgp.NodeSelector) {
 			continue
 		}

--- a/pkg/reconciler/operator/bgp_test.go
+++ b/pkg/reconciler/operator/bgp_test.go
@@ -102,7 +102,7 @@ var _ = Describe("BGP building", func() {
 			Expect(bgpPeer.Address).To(Equal(&loopbackIP))
 			Expect(bgpPeer.Multihop).ToNot(BeNil())
 			Expect(*bgpPeer.Multihop).To(Equal(bgpMultihop))
-			Expect(bgpPeer.RemoteASN).To(Equal(uint32(65000)))
+			Expect(bgpPeer.RemoteASN).To(Equal(int64(65000)))
 			Expect(bgpPeer.IPv4).ToNot(BeNil())
 			Expect(bgpPeer.IPv6).To(BeNil())
 		})


### PR DESCRIPTION
## Problem

Applying a `NodeNetworkConfig` failed with:

```
NodeNetworkConfig.network.t-caas.telekom.com "<node>" is invalid: [<nil>: Invalid value: "": Checked value must be of type integer with format int32 in spec.fabricVRFs.p_ipmb_public.bgpPeers[0].remoteAsn, ...]
```

for well-formed `BGPPeering` objects (e.g. `workloadAS: 4200011028`, a valid 4-byte ASN in the RFC 6996 private range) that passed CRD validation on the `BGPPeering` resource itself.

## Root cause

OpenAPI/JSON Schema only defines *signed* numeric formats (`int32`, `int64`) — there is no `uint32` format. `controller-gen` maps Go's `uint32` to `format: int32`, which is a **signed** 32-bit range (max `2147483647`). Newer Kubernetes API servers strictly enforce this format via CEL, so any legitimate 4-byte ASN above `2147483647` (well within `uint32`'s actual range, up to `4294967295`) gets rejected once it's copied from `BGPPeering.spec.workloadAS` (correctly typed `*int64`) into `NodeNetworkConfig...bgpPeers[].remoteAsn` (incorrectly typed `uint32`).

## Fix

- `BGPPeer.RemoteASN` (`api/v1alpha1/nodenetworkconfig_types.go`) and the legacy `BGPPeeringSpec.RemoteASN` (`api/v1alpha1/bgppeering_types.go`) changed from `uint32` to `int64`, with explicit `+kubebuilder:validation:Minimum=1`/`Maximum=4294967295` markers — the same pattern already used correctly for `BGPPeering.spec.workloadAS`.
- Regenerated CRDs (`format: int64`, explicit min/max bounds).
- Updated the one call site that copied `workloadAS` into `RemoteASN` (no cast needed anymore) and adjusted test expectations from `uint32` to `int64`.

## Testing
- `go build ./...` (GOOS=linux)
- `go vet ./...` (GOOS=linux)
- `go test` for `api/...`, `pkg/reconciler/...`, `pkg/cra-vsr/...`, `cmd/kubectl-nnc/...` (including envtest-backed intent reconciler tests) — all pass
- `golangci-lint run` on changed packages — no new findings

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>