### PR TITLE
fix(intent): deterministic Layer2Attachment slot conflicts; e2e fixture cleanup; pin go-licenses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ envtest: ## Download setup-envtest locally if necessary.
 GO_LICENSES = $(shell pwd)/bin/go-licenses
 .PHONY: go-licenses
 go-licenses: ## Download go-licenses locally if necessary.
-	$(call go-get-tool,$(GO_LICENSES),github.com/google/go-licenses@latest)
+	$(call go-get-tool,$(GO_LICENSES),github.com/google/go-licenses@v1.6.0)
 
 CRD_REF_DOCS = $(shell pwd)/bin/crd-ref-docs
 .PHONY: crd-ref-docs

--- a/e2etests/tests/intent_l2_connectivity.go
+++ b/e2etests/tests/intent_l2_connectivity.go
@@ -36,6 +36,9 @@ var _ = Describe("Intent: L2 Connectivity", Label("intent", "l2"), func() {
 		l2, err := readTestdata("intent/l2/manifests.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.ApplyManifest(ctx, l2)).To(Succeed())
+		DeferCleanup(func() {
+			_ = f.DeleteManifest(context.Background(), l2)
+		})
 
 		By("Applying L2 NADs for macvlan pods")
 		nad, err := readTestdata("l2-connectivity/nad.yaml")

--- a/e2etests/tests/intent_l3_connectivity.go
+++ b/e2etests/tests/intent_l3_connectivity.go
@@ -35,6 +35,9 @@ var _ = Describe("Intent: L3 Connectivity", Label("intent", "l3"), func() {
 		l3, err := readTestdata("intent/l3/manifests.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.ApplyManifest(ctx, l3)).To(Succeed())
+		DeferCleanup(func() {
+			_ = f.DeleteManifest(context.Background(), l3)
+		})
 
 		By("Applying L2 NADs for VLAN 501 and 502")
 		nad, err := readTestdata("l2-connectivity/nad.yaml")

--- a/e2etests/tests/intent_vrf_isolation.go
+++ b/e2etests/tests/intent_vrf_isolation.go
@@ -34,6 +34,9 @@ var _ = Describe("Intent: VRF Isolation", Label("intent", "vrf"), func() {
 		vrf, err := readTestdata("intent/vrf/manifests.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.ApplyManifest(ctx, vrf)).To(Succeed())
+		DeferCleanup(func() {
+			_ = f.DeleteManifest(context.Background(), vrf)
+		})
 
 		By("Applying NADs for m2m (VLAN 501) and c2m (VLAN 503)")
 		nad501, err := readTestdata("l2-connectivity/nad.yaml")

--- a/pkg/reconciler/intent/builder/l2a.go
+++ b/pkg/reconciler/intent/builder/l2a.go
@@ -86,6 +86,10 @@ func (b *L2ABuilder) buildWithPlacements(
 	ifOwner := make(map[string]string)
 	routeOwner := make(map[string]staticRouteOwner)
 
+	// Ownership is first-come-first-served, so the iteration order decides which
+	// of two colliding L2As wins. The list comes from the informer cache in
+	// unspecified order; without a stable sort the winner — and therefore the
+	// NNC's attachmentRef — flaps between reconciles.
 	layer2Attachments := sortedLayer2Attachments(data.Layer2Attachments)
 	for i := range layer2Attachments {
 		l2a := &layer2Attachments[i]
@@ -136,10 +140,20 @@ func (b *L2ABuilder) buildWithPlacements(
 	return result, placements, placementErrors
 }
 
+// sortedLayer2Attachments returns a copy of items sorted so that ownership
+// conflicts resolve deterministically: the oldest L2A keeps its slot (a newly
+// created conflicting L2A must not displace a working one), ties are broken by
+// namespace/name.
 func sortedLayer2Attachments(items []nc.Layer2Attachment) []nc.Layer2Attachment {
 	sorted := slices.Clone(items)
-	slices.SortFunc(sorted, func(a, b nc.Layer2Attachment) int {
-		return strings.Compare(a.Namespace+"\x00"+a.Name, b.Namespace+"\x00"+b.Name)
+	slices.SortStableFunc(sorted, func(a, b nc.Layer2Attachment) int {
+		if ta, tb := a.CreationTimestamp, b.CreationTimestamp; !ta.Equal(&tb) {
+			if ta.Before(&tb) {
+				return -1
+			}
+			return 1
+		}
+		return strings.Compare(layer2AttachmentKey(a.Namespace, a.Name), layer2AttachmentKey(b.Namespace, b.Name))
 	})
 	return sorted
 }

--- a/pkg/reconciler/intent/builder/l2a_test.go
+++ b/pkg/reconciler/intent/builder/l2a_test.go
@@ -19,6 +19,7 @@ package builder
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,23 +61,28 @@ func TestL2ABuilder_Name(t *testing.T) {
 }
 
 func TestSortedLayer2Attachments(t *testing.T) {
+	older := metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	newer := metav1.NewTime(older.Add(time.Hour))
 	items := []nc.Layer2Attachment{
-		{ObjectMeta: metav1.ObjectMeta{Namespace: testTenantB, Name: "attachment-a"}},
-		{ObjectMeta: metav1.ObjectMeta{Namespace: testTenantA, Name: "attachment-b"}},
-		{ObjectMeta: metav1.ObjectMeta{Namespace: testTenantA, Name: "attachment-a"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: testTenantA, Name: "aaa-newest", CreationTimestamp: newer}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: testTenantB, Name: "attachment-a", CreationTimestamp: older}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: testTenantA, Name: "attachment-b", CreationTimestamp: older}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: testTenantA, Name: "attachment-a", CreationTimestamp: older}},
 	}
 
 	sorted := sortedLayer2Attachments(items)
+	got := make([]string, 0, len(sorted))
+	for _, item := range sorted {
+		got = append(got, item.Namespace+"/"+item.Name)
+	}
+	// Oldest first; equal timestamps fall back to namespace/name.
 	assert.Equal(t, []string{
 		testTenantA + "/attachment-a",
 		testTenantA + "/attachment-b",
 		testTenantB + "/attachment-a",
-	}, []string{
-		sorted[0].Namespace + "/" + sorted[0].Name,
-		sorted[1].Namespace + "/" + sorted[1].Name,
-		sorted[2].Namespace + "/" + sorted[2].Name,
-	})
-	assert.Equal(t, testTenantB, items[0].Namespace, "sorting must not mutate resolver input")
+		testTenantA + "/aaa-newest",
+	}, got)
+	assert.Equal(t, "aaa-newest", items[0].Name, "sorting must not mutate resolver input")
 }
 
 func TestL2ABuilder_EmptyData(t *testing.T) {
@@ -994,6 +1000,58 @@ func TestL2ABuilder_OwnershipConflictIdentifiesNamespaces(t *testing.T) {
 	assert.Equal(t, testTenantB, issues[0].Namespace)
 	assert.Contains(t, issues[0].Message, testTenantA+"/attachment")
 	assert.Contains(t, issues[0].Message, testTenantB+"/attachment")
+}
+
+func TestL2ABuilder_SlotConflictWinnerIsDeterministic(t *testing.T) {
+	vlan := int32(501)
+	vni := int32(10501)
+	older := metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	newer := metav1.NewTime(older.Add(time.Hour))
+
+	// Each L2A carries a distinct MTU so the winner is identifiable in the output.
+	mtus := map[string]int32{"l2a-old": 1400, "l2a-new": 1401, "l2a-a": 1402, "l2a-b": 1403}
+	mk := func(name string, ts metav1.Time) nc.Layer2Attachment {
+		return nc.Layer2Attachment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", CreationTimestamp: ts},
+			Spec:       nc.Layer2AttachmentSpec{NetworkRef: "net-vlan501", MTU: ptr(mtus[name])},
+		}
+	}
+	build := func(l2as ...nc.Layer2Attachment) string {
+		data := &resolver.ResolvedData{
+			Nodes: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}},
+			Networks: map[string]*resolver.ResolvedNetwork{
+				"net-vlan501": {Name: "net-vlan501", Spec: nc.NetworkSpec{VLAN: &vlan, VNI: &vni, IPv4: &nc.IPNetwork{CIDR: "10.0.1.1/24"}}},
+			},
+			Layer2Attachments: l2as,
+		}
+		result, err := NewL2ABuilder().Build(context.Background(), data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		l2, ok := result["node-1"].Layer2s["501"]
+		if !ok {
+			t.Fatalf("expected VLAN 501 to be configured, got %+v", result["node-1"].Layer2s)
+		}
+		for name, mtu := range mtus {
+			if int32(l2.MTU) == mtu {
+				return name
+			}
+		}
+		t.Fatalf("unexpected MTU %d in VLAN 501 config", l2.MTU)
+		return ""
+	}
+
+	// The input order (informer cache order) must not decide the winner.
+	if got := build(mk("l2a-new", newer), mk("l2a-old", older)); got != "l2a-old" {
+		t.Errorf("expected the older L2A to keep the slot, got %q", got)
+	}
+	if got := build(mk("l2a-old", older), mk("l2a-new", newer)); got != "l2a-old" {
+		t.Errorf("expected the older L2A to keep the slot, got %q", got)
+	}
+	// Equal timestamps fall back to the name.
+	if got := build(mk("l2a-b", older), mk("l2a-a", older)); got != "l2a-a" {
+		t.Errorf("expected name tie-break to pick l2a-a, got %q", got)
+	}
 }
 
 func TestL2ABuilder_DefaultVLANNameConflictsWithInterfaceName(t *testing.T) {


### PR DESCRIPTION
Follow-up to #380, addressing the remaining CI failures seen on the feat/* stack.

### fix(intent): resolve Layer2Attachment slot conflicts deterministically
The l2a-builder grants a netplan slot / device name to the first Layer2Attachment claiming it and skips later claimants (Ready=False). It iterates the informer-cache list in unspecified order, so with two L2As competing for one VLAN on a node the winner (and the NNC `layer2s[<vlan>]` content) flapped between reconciles. Observed in [E2E #344](https://github.com/telekom/das-schiff-network-operator/actions/runs/34375922189/job/102549818476): `l2a-vrf-vlan501` vs `l2a-base-vlan501` alternating every few seconds.

Now sorted by creationTimestamp (oldest keeps its slot), then namespace/name. Unit test added; it fails without the sort.

### test(e2e): clean up per-spec Layer2Attachment fixtures
`intent_vrf_isolation`, `intent_l2_connectivity`, `intent_l3_connectivity` applied their own L2As on VLAN 501/502/503 and never deleted them, so with random spec ordering they competed with `base-configs.yaml` in later specs. Added `DeferCleanup` deleting the fixture manifests, as the other intent specs already do.

### build: pin go-licenses to v1.6.0
`@latest` resolves via proxy+sumdb on every image build and produced random-cell "version constraints conflict / verifying go.mod" failures.
