### PR TITLE
fix(intent): route multi-VRF L2As through combo VRF

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -277,7 +277,13 @@ func setupReconcilers(mgr manager.Manager, cfg *operatorConfig) error {
 }
 
 func setupIntentReconciler(mgr manager.Manager, apiTimeout time.Duration, cfg *operatorConfig) error {
-	ir, err := intentreconciler.NewReconciler(mgr.GetClient(), mgr.GetLogger().WithName("IntentReconciler"), apiTimeout, cfg.intentNamespace)
+	ir, err := intentreconciler.NewReconciler(
+		mgr.GetClient(),
+		mgr.GetLogger().WithName("IntentReconciler"),
+		apiTimeout,
+		cfg.intentNamespace,
+		mgr.GetEventRecorder("intent-reconciler"),
+	)
 	if err != nil {
 		return fmt.Errorf("unable to create intent reconciler: %w", err)
 	}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,6 +35,14 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations

--- a/controllers/intent/intent_controller.go
+++ b/controllers/intent/intent_controller.go
@@ -41,6 +41,8 @@ type Controller struct {
 	Reconciler *intentreconciler.Reconciler
 }
 
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=network-connector.sylvaproject.org,resources=vrfs,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=network-connector.sylvaproject.org,resources=vrfs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=network-connector.sylvaproject.org,resources=vrfs/finalizers,verbs=update

--- a/controllers/sync/sync_controller.go
+++ b/controllers/sync/sync_controller.go
@@ -739,8 +739,9 @@ func (r *Controller) reconcileIPAM(ctx context.Context, namespace string) (*ipam
 		Layer2Attachments: l2aList.Items,
 	}
 	networks := resolver.ResolveNetworks(fetched.Networks)
+	resolved := &resolver.ResolvedData{Networks: networks}
 
-	if err := r.IPAMAllocator.ReconcileAllocations(ctx, fetched, networks); err != nil {
+	if err := r.IPAMAllocator.ReconcileAllocations(ctx, fetched, resolved); err != nil {
 		return nil, fmt.Errorf("IPAM allocation: %w", err)
 	}
 

--- a/docs/guides/layer2-attachment.md
+++ b/docs/guides/layer2-attachment.md
@@ -121,6 +121,21 @@ spec:
       type: gateway
 ```
 
+### One attachment in multiple VRFs
+
+When a `destinations` selector matches Destinations in multiple VRFs, the
+operator places the attachment's IRB in a deterministic local combo VRF. The
+combo VRF routes each selected Destination prefix through its Fabric VRF, and
+each Fabric VRF routes the attached Network back through the combo VRF for EVPN
+export. Because the L2 segment is directly attached to the combo VRF, this does
+not require source-based policy routes in the cluster VRF.
+
+Multi-VRF attachments require HBN mode with the anycast gateway enabled. A
+pure-L2 Network or `disableAnycast: true` cannot attach the segment to the combo
+VRF and is therefore rejected. A `listenRange` BGPPeering referencing a
+multi-VRF attachment terminates in the combo VRF; accepted routes are imported
+into every selected Fabric VRF for EVPN export.
+
 !!! tip "Anycast gateway"
     In HBN mode the operator provisions an anycast gateway for the segment; its
     MAC and gateway addresses are surfaced in `status.anycast`. Disable it with

--- a/e2etests/framework/intent.go
+++ b/e2etests/framework/intent.go
@@ -298,6 +298,12 @@ func NNCHasLayer2(nnc *unstructured.Unstructured, l2Key string) bool {
 	return err == nil && found && l2 != nil
 }
 
+// NNCLayer2IRBVRF returns the VRF assigned to a Layer2 IRB.
+func NNCLayer2IRBVRF(nnc *unstructured.Unstructured, l2Key string) string {
+	vrf, _, _ := unstructured.NestedString(nnc.Object, "spec", "layer2s", l2Key, "irb", "vrf")
+	return vrf
+}
+
 // WaitForNNCVRFs waits until the NNC for the given node contains all specified fabricVRFs.
 func (f *Framework) WaitForNNCVRFs(ctx context.Context, nodeName string, vrfNames []string, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
@@ -373,6 +379,16 @@ func NNCFabricVRFHasAggregateRoute(nnc *unstructured.Unstructured, vrfName, pref
 	return false
 }
 
+// NNCFabricVRFStaticRouteTarget checks if a FabricVRF has a static route for the
+// given prefix pointing to the expected target VRF via nextHop.vrf.
+func NNCFabricVRFStaticRouteTarget(nnc *unstructured.Unstructured, vrfName, prefix, targetVRF string) bool {
+	routes, found, err := unstructured.NestedSlice(nnc.Object, "spec", "fabricVRFs", vrfName, "staticRoutes")
+	if err != nil || !found {
+		return false
+	}
+	return staticRouteTargetsVRF(routes, prefix, targetVRF)
+}
+
 // NNCHasLocalVRF checks if a NNC has a localVRF entry with the given name.
 func NNCHasLocalVRF(nnc *unstructured.Unstructured, vrfName string) bool {
 	vrf, found, err := unstructured.NestedMap(nnc.Object, "spec", "localVRFs", vrfName)
@@ -399,6 +415,10 @@ func NNCLocalVRFStaticRouteTarget(nnc *unstructured.Unstructured, localVRFName, 
 	if err != nil || !found {
 		return false
 	}
+	return staticRouteTargetsVRF(routes, prefix, targetVRF)
+}
+
+func staticRouteTargetsVRF(routes []interface{}, prefix, targetVRF string) bool {
 	for _, r := range routes {
 		m, ok := r.(map[string]interface{})
 		if !ok {
@@ -439,6 +459,26 @@ func NNCClusterVRFHasPolicyRoute(nnc *unstructured.Unstructured, srcPrefix, targ
 			continue
 		}
 		if tm["srcPrefix"] == srcPrefix && nh["vrf"] == targetVRF {
+			return true
+		}
+	}
+	return false
+}
+
+// NNCClusterVRFHasPolicyRouteTarget checks if any cluster VRF policy route
+// points to the given target VRF.
+func NNCClusterVRFHasPolicyRouteTarget(nnc *unstructured.Unstructured, targetVRF string) bool {
+	routes, found, err := unstructured.NestedSlice(nnc.Object, "spec", "clusterVRF", "policyRoutes")
+	if err != nil || !found {
+		return false
+	}
+	for _, r := range routes {
+		m, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		nh, ok := m["nextHop"].(map[string]interface{})
+		if ok && nh["vrf"] == targetVRF {
 			return true
 		}
 	}

--- a/e2etests/testdata/intent/l2a-multi-vrf/manifests.yaml
+++ b/e2etests/testdata/intent/l2a-multi-vrf/manifests.yaml
@@ -1,0 +1,47 @@
+apiVersion: network-connector.sylvaproject.org/v1alpha1
+kind: Destination
+metadata:
+  name: multi-vrf-destination-a
+  namespace: default
+  labels:
+    scenario: l2a-multi-vrf
+spec:
+  vrfRef: "vrf-m2m"
+  prefixes:
+    - "198.51.100.0/24"
+---
+apiVersion: network-connector.sylvaproject.org/v1alpha1
+kind: Destination
+metadata:
+  name: multi-vrf-destination-b
+  namespace: default
+  labels:
+    scenario: l2a-multi-vrf
+spec:
+  vrfRef: "vrf-c2m"
+  prefixes:
+    - "203.0.113.0/24"
+---
+apiVersion: network-connector.sylvaproject.org/v1alpha1
+kind: Network
+metadata:
+  name: net-multi-vrf
+  namespace: default
+spec:
+  vlan: 591
+  vni: 4000091
+  ipv4:
+    cidr: "192.0.2.128/27"
+  ipv6:
+    cidr: "2001:db8:590::/64"
+---
+apiVersion: network-connector.sylvaproject.org/v1alpha1
+kind: Layer2Attachment
+metadata:
+  name: l2a-multi-vrf
+  namespace: default
+spec:
+  networkRef: "net-multi-vrf"
+  destinations:
+    matchLabels:
+      scenario: l2a-multi-vrf

--- a/e2etests/tests/intent_destination_nnc.go
+++ b/e2etests/tests/intent_destination_nnc.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/telekom/das-schiff-network-operator/e2etests/framework"
+	"github.com/telekom/das-schiff-network-operator/pkg/vrfname"
 )
 
 // Intent Destination NNC Validation — checks that Destinations produce correct
@@ -202,6 +203,37 @@ var _ = Describe("Intent: Destination NNC Validation", Label("intent", "destinat
 				"FabricVRF c2m should have aggregate route for net-vlan503 IPv4 CIDR")
 
 			_ = f.DeleteManifest(ctx, manifest)
+		})
+	})
+
+	Context("one Layer2Attachment targeting multiple VRFs", func() {
+		It("should attach the IRB to a combo VRF without policy routing", func() {
+			cfg := f.Config
+
+			manifest, err := readTestdata("intent/l2a-multi-vrf/manifests.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(f.ApplyManifest(ctx, manifest)).To(Succeed())
+			DeferCleanup(func() {
+				_ = f.DeleteManifest(context.Background(), manifest)
+			})
+
+			comboName := vrfname.L2AName("default/multi-vrf-destination-a+default/multi-vrf-destination-b")
+			var nnc *unstructured.Unstructured
+			Eventually(func() bool {
+				var getErr error
+				nnc, getErr = f.GetNNC(ctx, cfg.WorkerNode1)
+				return getErr == nil &&
+					framework.NNCLayer2IRBVRF(nnc, "591") == comboName &&
+					framework.NNCHasLocalVRF(nnc, comboName)
+			}).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(BeTrue(),
+				"NNC should attach the multi-VRF Layer2 IRB to a combo LocalVRF")
+
+			Expect(framework.NNCLocalVRFStaticRouteTarget(nnc, comboName, "198.51.100.0/24", "m2m")).To(BeTrue())
+			Expect(framework.NNCLocalVRFStaticRouteTarget(nnc, comboName, "203.0.113.0/24", "c2m")).To(BeTrue())
+			Expect(framework.NNCFabricVRFStaticRouteTarget(nnc, "m2m", "192.0.2.128/27", comboName)).To(BeTrue())
+			Expect(framework.NNCFabricVRFStaticRouteTarget(nnc, "c2m", "192.0.2.128/27", comboName)).To(BeTrue())
+			Expect(framework.NNCClusterVRFHasPolicyRouteTarget(nnc, comboName)).To(BeFalse(),
+				"directly attached combo VRF should not require cluster policy routing")
 		})
 	})
 })

--- a/pkg/reconciler/intent/assembler/assembler.go
+++ b/pkg/reconciler/intent/assembler/assembler.go
@@ -17,9 +17,14 @@ limitations under the License.
 package assembler
 
 import (
+	"fmt"
+	"slices"
+
 	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
 	"github.com/telekom/das-schiff-network-operator/pkg/reconciler/intent/builder"
 )
+
+const reservedClusterVRFName = "cluster"
 
 // AssembleResult contains the assembled NNC spec and merged origin tracking data.
 type AssembleResult struct {
@@ -80,7 +85,7 @@ func Assemble(contributions []*builder.NodeContribution) (*AssembleResult, error
 				continue
 			}
 			existing.BGPPeers = append(existing.BGPPeers, v.BGPPeers...)
-			existing.StaticRoutes = append(existing.StaticRoutes, v.StaticRoutes...)
+			existing.StaticRoutes = mergeStaticRoutes(existing.StaticRoutes, v.StaticRoutes)
 			existing.PolicyRoutes = append(existing.PolicyRoutes, v.PolicyRoutes...)
 			existing.MirrorACLs = append(existing.MirrorACLs, v.MirrorACLs...)
 
@@ -123,7 +128,7 @@ func Assemble(contributions []*builder.NodeContribution) (*AssembleResult, error
 				continue
 			}
 			existing.BGPPeers = append(existing.BGPPeers, v.BGPPeers...)
-			existing.StaticRoutes = append(existing.StaticRoutes, v.StaticRoutes...)
+			existing.StaticRoutes = mergeStaticRoutes(existing.StaticRoutes, v.StaticRoutes)
 			existing.VRFImports = append(existing.VRFImports, v.VRFImports...)
 			spec.LocalVRFs[k] = existing
 		}
@@ -135,7 +140,7 @@ func Assemble(contributions []*builder.NodeContribution) (*AssembleResult, error
 				spec.ClusterVRF = &vrfCopy
 			} else {
 				spec.ClusterVRF.BGPPeers = append(spec.ClusterVRF.BGPPeers, c.ClusterVRF.BGPPeers...)
-				spec.ClusterVRF.StaticRoutes = append(spec.ClusterVRF.StaticRoutes, c.ClusterVRF.StaticRoutes...)
+				spec.ClusterVRF.StaticRoutes = mergeStaticRoutes(spec.ClusterVRF.StaticRoutes, c.ClusterVRF.StaticRoutes)
 				spec.ClusterVRF.PolicyRoutes = append(spec.ClusterVRF.PolicyRoutes, c.ClusterVRF.PolicyRoutes...)
 				spec.ClusterVRF.VRFImports = append(spec.ClusterVRF.VRFImports, c.ClusterVRF.VRFImports...)
 			}
@@ -152,6 +157,13 @@ func Assemble(contributions []*builder.NodeContribution) (*AssembleResult, error
 		}
 	}
 
+	if err := validateVRFNames(spec); err != nil {
+		return nil, err
+	}
+	if err := validateStaticRoutes(spec); err != nil {
+		return nil, err
+	}
+
 	// Drop orphan Layer2 entries that never received a base config (VLAN stays
 	// 0). These arise when a mirror-only contribution keys a VLAN whose L2A base
 	// entry does not exist on this node — e.g. a non-HBN source, a node outside
@@ -165,6 +177,66 @@ func Assemble(contributions []*builder.NodeContribution) (*AssembleResult, error
 	}
 
 	return &AssembleResult{Spec: spec, Origins: origins, NetplanNodeIPs: netplanNodeIPs}, nil
+}
+
+func validateVRFNames(spec *networkv1alpha1.NodeNetworkConfigSpec) error {
+	if _, exists := spec.FabricVRFs[reservedClusterVRFName]; exists {
+		return fmt.Errorf("FabricVRF %q collides with the reserved cluster VRF", reservedClusterVRFName)
+	}
+	for name := range spec.LocalVRFs {
+		if name == reservedClusterVRFName {
+			return fmt.Errorf("LocalVRF %q collides with the reserved cluster VRF", name)
+		}
+		if _, exists := spec.FabricVRFs[name]; exists {
+			return fmt.Errorf("VRF name %q is used by both a FabricVRF and a LocalVRF", name)
+		}
+	}
+	return nil
+}
+
+func validateStaticRoutes(spec *networkv1alpha1.NodeNetworkConfigSpec) error {
+	if spec.ClusterVRF != nil {
+		if err := validateVRFStaticRoutes(reservedClusterVRFName, spec.ClusterVRF.StaticRoutes); err != nil {
+			return err
+		}
+	}
+	fabricNames := make([]string, 0, len(spec.FabricVRFs))
+	for name := range spec.FabricVRFs {
+		fabricNames = append(fabricNames, name)
+	}
+	slices.Sort(fabricNames)
+	for _, name := range fabricNames {
+		if err := validateVRFStaticRoutes(name, spec.FabricVRFs[name].StaticRoutes); err != nil {
+			return err
+		}
+	}
+	localNames := make([]string, 0, len(spec.LocalVRFs))
+	for name := range spec.LocalVRFs {
+		localNames = append(localNames, name)
+	}
+	slices.Sort(localNames)
+	for _, name := range localNames {
+		if err := validateVRFStaticRoutes(name, spec.LocalVRFs[name].StaticRoutes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateVRFStaticRoutes(vrfName string, routes []networkv1alpha1.StaticRoute) error {
+	nextVRFs := make(map[string]string)
+	for i := range routes {
+		if routes[i].NextHop == nil || routes[i].NextHop.Vrf == nil {
+			continue
+		}
+		nextVRF := *routes[i].NextHop.Vrf
+		if existing, found := nextVRFs[routes[i].Prefix]; found && existing != nextVRF {
+			return fmt.Errorf("VRF %q has conflicting next-hop VRFs %q and %q for prefix %q",
+				vrfName, existing, nextVRF, routes[i].Prefix)
+		}
+		nextVRFs[routes[i].Prefix] = nextVRF
+	}
+	return nil
 }
 
 // mergeStringSlice merges two string slices, deduplicating entries.
@@ -183,6 +255,55 @@ func mergeStringSlice(a, b []string) []string {
 		}
 	}
 	return a
+}
+
+// mergeStaticRoutes deduplicates identical routes and prefers an explicit
+// next-hop over a blackhole aggregate for the same prefix. This keeps
+// cross-VRF forwarding routes usable when another contribution also announces
+// the prefix as an aggregate.
+func mergeStaticRoutes(existing, incoming []networkv1alpha1.StaticRoute) []networkv1alpha1.StaticRoute {
+	for _, route := range incoming {
+		merged := false
+		for i := range existing {
+			if existing[i].Prefix != route.Prefix {
+				continue
+			}
+			switch {
+			case sameStaticRoute(existing[i], route):
+				merged = true
+			case existing[i].NextHop == nil && route.NextHop != nil:
+				existing[i] = route
+				merged = true
+			case existing[i].NextHop != nil && route.NextHop == nil:
+				merged = true
+			}
+			if merged {
+				break
+			}
+		}
+		if !merged {
+			existing = append(existing, route)
+		}
+	}
+	return existing
+}
+
+func sameStaticRoute(a, b networkv1alpha1.StaticRoute) bool {
+	if a.Prefix != b.Prefix {
+		return false
+	}
+	if a.NextHop == nil || b.NextHop == nil {
+		return a.NextHop == nil && b.NextHop == nil
+	}
+	return equalStringPtr(a.NextHop.Address, b.NextHop.Address) &&
+		equalStringPtr(a.NextHop.Vrf, b.NextHop.Vrf)
+}
+
+func equalStringPtr(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
 }
 
 // mergeVRFImports merges VRFImport slices, deduplicating by FromVRF and merging filter items.

--- a/pkg/reconciler/intent/assembler/assembler_test.go
+++ b/pkg/reconciler/intent/assembler/assembler_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package assembler
 
 import (
+	"strings"
 	"testing"
 
 	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
 	"github.com/telekom/das-schiff-network-operator/pkg/reconciler/intent/builder"
 )
+
+const testRoutePrefix = "192.0.2.0/27"
 
 func TestAssemble_Nil(t *testing.T) {
 	result, err := Assemble(nil)
@@ -164,6 +167,73 @@ func TestAssemble_MergeFabricVRFs(t *testing.T) {
 	}
 }
 
+func TestAssemble_StaticRoutePrefersExplicitNextHop(t *testing.T) {
+	combo := "s-combo"
+	routed := builder.NewNodeContribution()
+	routed.FabricVRFs["edge"] = networkv1alpha1.FabricVRF{
+		VRF: networkv1alpha1.VRF{
+			StaticRoutes: []networkv1alpha1.StaticRoute{{
+				Prefix:  testRoutePrefix,
+				NextHop: &networkv1alpha1.NextHop{Vrf: &combo},
+			}},
+		},
+	}
+	aggregate := builder.NewNodeContribution()
+	aggregate.FabricVRFs["edge"] = networkv1alpha1.FabricVRF{
+		VRF: networkv1alpha1.VRF{
+			StaticRoutes: []networkv1alpha1.StaticRoute{{Prefix: testRoutePrefix}},
+		},
+	}
+
+	for _, contributions := range [][]*builder.NodeContribution{
+		{routed, aggregate},
+		{aggregate, routed},
+	} {
+		result, err := Assemble(contributions)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		routes := result.Spec.FabricVRFs["edge"].StaticRoutes
+		if len(routes) != 1 {
+			t.Fatalf("expected one merged route, got %#v", routes)
+		}
+		if routes[0].NextHop == nil || routes[0].NextHop.Vrf == nil || *routes[0].NextHop.Vrf != combo {
+			t.Errorf("expected explicit combo VRF next-hop to win, got %#v", routes[0])
+		}
+	}
+}
+
+func TestAssemble_RejectsConflictingExplicitVRFNextHops(t *testing.T) {
+	firstCombo := "l-first"
+	secondCombo := "l-second"
+	first := builder.NewNodeContribution()
+	first.FabricVRFs["edge"] = networkv1alpha1.FabricVRF{
+		VRF: networkv1alpha1.VRF{
+			StaticRoutes: []networkv1alpha1.StaticRoute{{
+				Prefix:  testRoutePrefix,
+				NextHop: &networkv1alpha1.NextHop{Vrf: &firstCombo},
+			}},
+		},
+	}
+	second := builder.NewNodeContribution()
+	second.FabricVRFs["edge"] = networkv1alpha1.FabricVRF{
+		VRF: networkv1alpha1.VRF{
+			StaticRoutes: []networkv1alpha1.StaticRoute{{
+				Prefix:  testRoutePrefix,
+				NextHop: &networkv1alpha1.NextHop{Vrf: &secondCombo},
+			}},
+		},
+	}
+
+	_, err := Assemble([]*builder.NodeContribution{first, second})
+	if err == nil {
+		t.Fatal("expected conflicting explicit VRF next-hop error")
+	}
+	if !strings.Contains(err.Error(), `VRF "edge" has conflicting next-hop VRFs`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestAssemble_MergeClusterVRF(t *testing.T) {
 	c1 := builder.NewNodeContribution()
 	c1.ClusterVRF = &networkv1alpha1.VRF{
@@ -208,6 +278,36 @@ func TestAssemble_SkipsNilContributions(t *testing.T) {
 	}
 	if len(result.Spec.Layer2s) != 1 {
 		t.Errorf("expected 1 Layer2, got %d", len(result.Spec.Layer2s))
+	}
+}
+
+func TestAssemble_RejectsFabricLocalVRFNameCollision(t *testing.T) {
+	c := builder.NewNodeContribution()
+	c.FabricVRFs["shared-name"] = networkv1alpha1.FabricVRF{}
+	c.LocalVRFs["shared-name"] = networkv1alpha1.VRF{}
+
+	_, err := Assemble([]*builder.NodeContribution{c})
+	if err == nil {
+		t.Fatal("expected FabricVRF/LocalVRF name collision error")
+	}
+}
+
+func TestAssemble_RejectsReservedLocalVRFName(t *testing.T) {
+	c := builder.NewNodeContribution()
+	c.LocalVRFs["cluster"] = networkv1alpha1.VRF{}
+
+	_, err := Assemble([]*builder.NodeContribution{c})
+	if err == nil {
+		t.Fatal("expected reserved LocalVRF name error")
+	}
+}
+
+func TestAssemble_RejectsReservedFabricVRFName(t *testing.T) {
+	contrib := builder.NewNodeContribution()
+	contrib.FabricVRFs["cluster"] = networkv1alpha1.FabricVRF{}
+
+	if _, err := Assemble([]*builder.NodeContribution{contrib}); err == nil {
+		t.Fatal("expected reserved FabricVRF name error")
 	}
 }
 

--- a/pkg/reconciler/intent/builder/bgp_announcement_test.go
+++ b/pkg/reconciler/intent/builder/bgp_announcement_test.go
@@ -22,12 +22,27 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
 	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
 	"github.com/telekom/das-schiff-network-operator/pkg/reconciler/intent/resolver"
+	"github.com/telekom/das-schiff-network-operator/pkg/vrfname"
+)
+
+const (
+	testNode1     = "node-1"
+	testNode2     = "node-2"
+	testRackLabel = "rack"
+	testSelected  = "selected"
+	testOther     = "other"
+	testDocCIDR   = "192.0.2.0/24"
+	testDMZVRFRef = "dmz-vrf"
+	testDMZName   = "dmz"
+	testEdgeDest  = "edge-dest"
 )
 
 // ---------------------------------------------------------------------------
@@ -57,7 +72,8 @@ func TestBGPPeeringBuilder_ListenRange(t *testing.T) { //nolint:funlen // table-
 
 	data := &resolver.ResolvedData{
 		Nodes: []corev1.Node{
-			{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: testNode1, Labels: map[string]string{testRackLabel: testSelected}}},
+			{ObjectMeta: metav1.ObjectMeta{Name: testNode2, Labels: map[string]string{testRackLabel: testOther}}},
 		},
 		Networks: map[string]*resolver.ResolvedNetwork{
 			"transfer-net": {
@@ -104,6 +120,9 @@ func TestBGPPeeringBuilder_ListenRange(t *testing.T) { //nolint:funlen // table-
 					Destinations: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"env": "prod"},
 					},
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{testRackLabel: testSelected},
+					},
 				},
 			},
 		},
@@ -127,11 +146,11 @@ func TestBGPPeeringBuilder_ListenRange(t *testing.T) { //nolint:funlen // table-
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(result) != 1 {
-		t.Fatalf("expected 1 node contribution, got %d", len(result))
+	if len(result) != 2 {
+		t.Fatalf("expected single-VRF listener on all 2 nodes, got %d contributions", len(result))
 	}
 
-	contrib, ok := result["node-1"]
+	contrib, ok := result[testNode1]
 	if !ok {
 		t.Fatal("expected contribution for node-1")
 	}
@@ -146,6 +165,8 @@ func TestBGPPeeringBuilder_ListenRange(t *testing.T) { //nolint:funlen // table-
 	if len(fvrf.BGPPeers) != 2 {
 		t.Fatalf("expected 2 BGPPeers (IPv4 + IPv6), got %d", len(fvrf.BGPPeers))
 	}
+	require.Len(t, result[testNode2].FabricVRFs["prod"].BGPPeers, 2,
+		"single-VRF listener placement must remain independent of the L2A node selector")
 
 	// Check IPv4 peer.
 	p4 := fvrf.BGPPeers[0]
@@ -323,9 +344,88 @@ func assertImportAllows(t *testing.T, af *networkv1alpha1.AddressFamily, prefix 
 	}
 }
 
-// TestBGPPeeringBuilder_ListenRangeFanOut verifies that when a Layer2Attachment
-// destinations selector matches multiple Destinations across multiple VRFs,
-// the listen-range peer is installed on each matched VRF. Persona review C2.
+func TestBGPPeeringBuilder_ListenRangeSkipsOwnershipConflictedL2A(t *testing.T) {
+	data := &resolver.ResolvedData{
+		Nodes: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: testNode1}}},
+		Networks: map[string]*resolver.ResolvedNetwork{
+			"transfer-net": {
+				Name: "transfer-net",
+				Spec: nc.NetworkSpec{
+					VLAN: ptr(int32(100)),
+					VNI:  ptr(int32(10100)),
+					IPv4: &nc.IPNetwork{CIDR: testDocCIDR},
+				},
+			},
+		},
+		VRFs: map[string]*resolver.ResolvedVRF{
+			"prod-vrf": {
+				Name: "prod-vrf",
+				Spec: nc.VRFSpec{VRF: "prod", VNI: ptr(int32(5001)), RouteTarget: ptr("65000:5001")},
+			},
+			testDMZVRFRef: {
+				Name: testDMZVRFRef,
+				Spec: nc.VRFSpec{VRF: testDMZName, VNI: ptr(int32(5002)), RouteTarget: ptr("65000:5002")},
+			},
+		},
+		Destinations: map[string]*resolver.ResolvedDestination{
+			"dc-dest": {
+				Name:    "dc-dest",
+				Spec:    nc.DestinationSpec{VRFRef: ptr("prod-vrf")},
+				VRFSpec: &nc.VRFSpec{VRF: "prod", VNI: ptr(int32(5001)), RouteTarget: ptr("65000:5001")},
+			},
+			testEdgeDest: {
+				Name:    testEdgeDest,
+				Spec:    nc.DestinationSpec{VRFRef: ptr(testDMZVRFRef)},
+				VRFSpec: &nc.VRFSpec{VRF: testDMZName, VNI: ptr(int32(5002)), RouteTarget: ptr("65000:5002")},
+			},
+		},
+		RawDestinations: []nc.Destination{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "dc-dest", Labels: map[string]string{"env": "prod"}},
+				Spec:       nc.DestinationSpec{VRFRef: ptr("prod-vrf")},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: testEdgeDest, Labels: map[string]string{"env": "prod"}},
+				Spec:       nc.DestinationSpec{VRFRef: ptr(testDMZVRFRef)},
+			},
+		},
+		Layer2Attachments: []nc.Layer2Attachment{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "owner-l2a"},
+				Spec: nc.Layer2AttachmentSpec{
+					NetworkRef: "transfer-net",
+					Destinations: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "prod"},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "transfer-l2a"},
+				Spec: nc.Layer2AttachmentSpec{
+					NetworkRef: "transfer-net",
+					Destinations: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "prod"},
+					},
+				},
+			},
+		},
+		BGPPeerings: []nc.BGPPeering{{
+			ObjectMeta: metav1.ObjectMeta{Name: "listen-peer"},
+			Spec: nc.BGPPeeringSpec{
+				Mode: nc.BGPPeeringModeListenRange,
+				Ref:  nc.BGPPeeringRef{AttachmentRef: ptr("transfer-l2a")},
+			},
+		}},
+	}
+
+	result, err := NewBGPPeeringBuilder().Build(context.Background(), data)
+	require.NoError(t, err)
+	require.Empty(t, result, "listener must not be emitted when the referenced L2A loses ownership placement")
+}
+
+// TestBGPPeeringBuilder_ListenRangeComboVRF verifies that the listener follows
+// a multi-VRF L2A's IRB into the combo VRF. Learned routes are imported into
+// each selected FabricVRF and exported through EVPN.
 func TestBGPPeeringBuilder_ListenRangeFanOut(t *testing.T) {
 	b := NewBGPPeeringBuilder()
 
@@ -333,7 +433,10 @@ func TestBGPPeeringBuilder_ListenRangeFanOut(t *testing.T) {
 	dmzSpec := &nc.VRFSpec{VRF: "dmz", VNI: ptr(int32(5002)), RouteTarget: ptr("65000:5002")}
 
 	data := &resolver.ResolvedData{
-		Nodes: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}},
+		Nodes: []corev1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Name: testNode1, Labels: map[string]string{testRackLabel: testSelected}}},
+			{ObjectMeta: metav1.ObjectMeta{Name: testNode2, Labels: map[string]string{testRackLabel: testOther}}},
+		},
 		Networks: map[string]*resolver.ResolvedNetwork{
 			"transfer-net": {
 				Name: "transfer-net",
@@ -342,6 +445,10 @@ func TestBGPPeeringBuilder_ListenRangeFanOut(t *testing.T) {
 					VNI:  ptr(int32(10100)),
 					IPv4: &nc.IPNetwork{CIDR: "10.100.0.0/24"},
 				},
+			},
+			"allowed-net": {
+				Name: "allowed-net",
+				Spec: nc.NetworkSpec{IPv4: &nc.IPNetwork{CIDR: "10.200.0.0/24"}},
 			},
 		},
 		VRFs: map[string]*resolver.ResolvedVRF{
@@ -364,6 +471,7 @@ func TestBGPPeeringBuilder_ListenRangeFanOut(t *testing.T) {
 				Spec: nc.Layer2AttachmentSpec{
 					NetworkRef:   "transfer-net",
 					Destinations: &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "shared"}},
+					NodeSelector: &metav1.LabelSelector{MatchLabels: map[string]string{testRackLabel: testSelected}},
 				},
 			},
 		},
@@ -376,6 +484,14 @@ func TestBGPPeeringBuilder_ListenRangeFanOut(t *testing.T) {
 					WorkloadAS: ptr(int64(65100)),
 				},
 			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "lp-allowed"},
+				Spec: nc.BGPPeeringSpec{
+					Mode:       nc.BGPPeeringModeListenRange,
+					Ref:        nc.BGPPeeringRef{AttachmentRef: ptr("transfer-l2a"), NetworkRefs: []string{"allowed-net"}},
+					WorkloadAS: ptr(int64(65101)),
+				},
+			},
 		},
 	}
 
@@ -384,18 +500,98 @@ func TestBGPPeeringBuilder_ListenRangeFanOut(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	contrib := result["node-1"]
-	if contrib == nil {
-		t.Fatal("expected node-1 contribution")
+	require.NotNil(t, contrib)
+	assert.NotContains(t, result, testNode2)
+
+	comboName := vrfname.L2AName("dmz-dest+prod-dest")
+	combo, ok := contrib.LocalVRFs[comboName]
+	if !ok {
+		t.Fatalf("expected combo LocalVRF %q, got keys %v", comboName, keys(contrib.LocalVRFs))
 	}
+	if len(combo.BGPPeers) != 2 {
+		t.Fatalf("expected 2 BGPPeers in combo VRF, got %d", len(combo.BGPPeers))
+	}
+
 	for _, vrf := range []string{"prod", "dmz"} {
 		fvrf, ok := contrib.FabricVRFs[vrf]
 		if !ok {
-			t.Fatalf("expected listen-range peer fanned out to FabricVRF %q, got keys %v", vrf, keys(contrib.FabricVRFs))
+			t.Fatalf("expected FabricVRF %q, got keys %v", vrf, keys(contrib.FabricVRFs))
 		}
-		if len(fvrf.BGPPeers) != 1 {
-			t.Errorf("VRF %q: expected 1 BGPPeer, got %d", vrf, len(fvrf.BGPPeers))
+		if len(fvrf.BGPPeers) != 0 {
+			t.Errorf("VRF %q: listener must be in combo VRF, got %d FabricVRF peers", vrf, len(fvrf.BGPPeers))
 		}
+		var comboImport *networkv1alpha1.VRFImport
+		for i := range fvrf.VRFImports {
+			if fvrf.VRFImports[i].FromVRF == comboName {
+				comboImport = &fvrf.VRFImports[i]
+				break
+			}
+		}
+		require.NotNil(t, comboImport)
+		require.Len(t, comboImport.Filter.Items, 2)
+		assert.Equal(t, "10.100.0.0/24", comboImport.Filter.Items[0].Matcher.Prefix.Prefix)
+		assert.Equal(t, "10.200.0.0/24", comboImport.Filter.Items[1].Matcher.Prefix.Prefix)
+		require.NotNil(t, fvrf.EVPNExportFilter)
+		require.Len(t, fvrf.EVPNExportFilter.Items, 2)
+		assert.Equal(t, "10.100.0.0/24", fvrf.EVPNExportFilter.Items[0].Matcher.Prefix.Prefix)
+		assert.Equal(t, "10.200.0.0/24", fvrf.EVPNExportFilter.Items[1].Matcher.Prefix.Prefix)
 	}
+}
+
+func TestBGPPeeringBuilder_ListenRangeMultiVRFRequiresIRB(t *testing.T) {
+	edgeASpec := &nc.VRFSpec{VRF: "edge-a", VNI: ptr(int32(5001)), RouteTarget: ptr("65000:5001")}
+	edgeBSpec := &nc.VRFSpec{VRF: "edge-b", VNI: ptr(int32(5002)), RouteTarget: ptr("65000:5002")}
+	data := &resolver.ResolvedData{
+		Nodes: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}},
+		Networks: map[string]*resolver.ResolvedNetwork{
+			"transfer-net": {
+				Name: "transfer-net",
+				Spec: nc.NetworkSpec{
+					VLAN: ptr(int32(100)),
+					VNI:  ptr(int32(10100)),
+					IPv4: &nc.IPNetwork{CIDR: "192.0.2.0/24"},
+				},
+			},
+		},
+		Destinations: map[string]*resolver.ResolvedDestination{
+			testMultiVRFDestA: {Name: testMultiVRFDestA, Spec: nc.DestinationSpec{VRFRef: ptr("edge-a-ref")}, VRFSpec: edgeASpec},
+			testMultiVRFDestB: {Name: testMultiVRFDestB, Spec: nc.DestinationSpec{VRFRef: ptr("edge-b-ref")}, VRFSpec: edgeBSpec},
+		},
+		RawDestinations: []nc.Destination{
+			{ObjectMeta: metav1.ObjectMeta{Name: testMultiVRFDestA, Labels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+				Spec: nc.DestinationSpec{VRFRef: ptr("edge-a-ref")}},
+			{ObjectMeta: metav1.ObjectMeta{Name: testMultiVRFDestB, Labels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+				Spec: nc.DestinationSpec{VRFRef: ptr("edge-b-ref")}},
+		},
+		Layer2Attachments: []nc.Layer2Attachment{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "transfer-l2a"},
+				Spec: nc.Layer2AttachmentSpec{
+					NetworkRef:     "transfer-net",
+					DisableAnycast: ptr(true),
+					Destinations:   &metav1.LabelSelector{MatchLabels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+				},
+			},
+		},
+		BGPPeerings: []nc.BGPPeering{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "listener"},
+				Spec: nc.BGPPeeringSpec{
+					Mode:       nc.BGPPeeringModeListenRange,
+					Ref:        nc.BGPPeeringRef{AttachmentRef: ptr("transfer-l2a"), NetworkRefs: []string{"transfer-net"}},
+					WorkloadAS: ptr(int64(65100)),
+				},
+			},
+		},
+	}
+
+	report := NewBuildReport()
+	result, err := NewBGPPeeringBuilder().Build(WithReport(context.Background(), report), data)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+	require.Len(t, report.Issues(), 1)
+	assert.Equal(t, "ListenRangeUnresolved", report.Issues()[0].Reason)
+	assert.Contains(t, report.Issues()[0].Message, "multiple destination VRFs require an enabled HBN IRB")
 }
 
 func TestBGPPeeringBuilder_LoopbackPeer(t *testing.T) {
@@ -743,7 +939,7 @@ func TestFindMatchingAP_NoMatch(t *testing.T) {
 			},
 		},
 	}
-	ap, err := findMatchingAP(map[string]string{"env": "prod"}, "prod", data)
+	ap, err := findMatchingAP("", map[string]string{"env": "prod"}, "prod", data)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -769,7 +965,7 @@ func TestFindMatchingAP_SingleMatch(t *testing.T) {
 			},
 		},
 	}
-	ap, err := findMatchingAP(map[string]string{"env": "prod"}, "prod", data)
+	ap, err := findMatchingAP("", map[string]string{"env": "prod"}, "prod", data)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -794,7 +990,7 @@ func TestFindMatchingAP_MultipleMatchError(t *testing.T) {
 			},
 		},
 	}
-	_, err := findMatchingAP(map[string]string{}, "prod", data)
+	_, err := findMatchingAP("", map[string]string{}, "prod", data)
 	if err == nil {
 		t.Fatal("expected error for multiple matching APs, got nil")
 	}

--- a/pkg/reconciler/intent/builder/bgppeering.go
+++ b/pkg/reconciler/intent/builder/bgppeering.go
@@ -19,8 +19,8 @@ package builder
 import (
 	"context"
 	"fmt"
-	"sort"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -46,13 +46,14 @@ func (*BGPPeeringBuilder) Name() string {
 func (b *BGPPeeringBuilder) Build(ctx context.Context, data *resolver.ResolvedData) (map[string]*NodeContribution, error) {
 	logger := log.FromContext(ctx).WithName("bgppeering-builder")
 	result := make(map[string]*NodeContribution)
+	_, l2aPlacements, l2aPlacementErrors := NewL2ABuilder().buildWithPlacements(ctx, data, false)
 
 	for i := range data.BGPPeerings {
 		bp := &data.BGPPeerings[i]
 
 		switch bp.Spec.Mode {
 		case nc.BGPPeeringModeListenRange:
-			if err := b.buildListenRange(bp, data, result); err != nil {
+			if err := b.buildListenRange(bp, data, l2aPlacements, l2aPlacementErrors, result); err != nil {
 				logger.Info("skipping BGPPeering with unresolvable listenRange",
 					"bgppeering", bp.Name, "error", err.Error())
 				reportSkip(ctx, "BGPPeering", bp.Namespace, bp.Name, "ListenRangeUnresolved", err.Error())
@@ -73,7 +74,13 @@ func (b *BGPPeeringBuilder) Build(ctx context.Context, data *resolver.ResolvedDa
 }
 
 // buildListenRange creates BGPPeer entries with ListenRange on the IRB VRF.
-func (b *BGPPeeringBuilder) buildListenRange(bp *nc.BGPPeering, data *resolver.ResolvedData, result map[string]*NodeContribution) error {
+func (b *BGPPeeringBuilder) buildListenRange(
+	bp *nc.BGPPeering,
+	data *resolver.ResolvedData,
+	l2aPlacements map[string][]string,
+	l2aPlacementErrors map[string]error,
+	result map[string]*NodeContribution,
+) error {
 	if bp.Spec.Ref.AttachmentRef == nil {
 		return fmt.Errorf("listenRange mode requires attachmentRef")
 	}
@@ -81,7 +88,8 @@ func (b *BGPPeeringBuilder) buildListenRange(bp *nc.BGPPeering, data *resolver.R
 	// Look up the L2A by name.
 	var l2a *nc.Layer2Attachment
 	for j := range data.Layer2Attachments {
-		if data.Layer2Attachments[j].Name == *bp.Spec.Ref.AttachmentRef {
+		if data.Layer2Attachments[j].Namespace == bp.Namespace &&
+			data.Layer2Attachments[j].Name == *bp.Spec.Ref.AttachmentRef {
 			l2a = &data.Layer2Attachments[j]
 			break
 		}
@@ -91,19 +99,20 @@ func (b *BGPPeeringBuilder) buildListenRange(bp *nc.BGPPeering, data *resolver.R
 	}
 
 	// Resolve the L2A's Network to get the CIDR for listen range.
-	net, ok := data.Networks[l2a.Spec.NetworkRef]
+	net, ok := data.Network(l2a.Namespace, l2a.Spec.NetworkRef)
 	if !ok {
 		return fmt.Errorf("Layer2Attachment %q references unknown Network %q", l2a.Name, l2a.Spec.NetworkRef)
 	}
 
-	// Resolve the L2A's destination VRFs for the IRB. The Destinations
-	// LabelSelector may match multiple Destinations across multiple VRFs; the
-	// listen-range peer + EVPN export must be installed on every matched VRF.
-	vrfs := b.resolveL2AVRFs(l2a, data)
-	if len(vrfs) == 0 {
+	// Resolve the same IRB topology as the L2A builder. A multi-VRF attachment
+	// owns its IRB in a combo LocalVRF, so the listener must terminate there.
+	routing, err := NewL2ABuilder().resolveDestinationVRFs(l2a, data)
+	if err != nil {
+		return fmt.Errorf("Layer2Attachment %q destinations cannot be resolved: %w", l2a.Name, err)
+	}
+	if len(routing.vrfSpecs) == 0 {
 		return fmt.Errorf("Layer2Attachment %q has no VRF for IRB", l2a.Name)
 	}
-
 	// Resolve networkRefs to get the CIDRs L2 clients may announce. These
 	// form the import allow-list and the EVPN export set. The listen-range
 	// CIDR itself comes from the L2A's Network (net), not from here.
@@ -114,41 +123,68 @@ func (b *BGPPeeringBuilder) buildListenRange(bp *nc.BGPPeering, data *resolver.R
 	peers := b.buildListenRangePeers(bp, net, allowIPv4, allowIPv6, data)
 	evpnExportItems := b.evpnExportItems(allowIPv4, allowIPv6, bp.Spec.Export)
 
-	// Sorted iteration for deterministic output.
-	vrfNames := make([]string, 0, len(vrfs))
-	for n := range vrfs {
-		vrfNames = append(vrfNames, n)
-	}
-	sort.Strings(vrfNames)
+	vrfNames := sortedVRFNames(routing.vrfSpecs)
 
-	// Apply to all nodes (no nodeSelector on BGPPeering).
-	for i := range data.Nodes {
-		node := &data.Nodes[i]
-		contrib, ok := result[node.Name]
+	nodeNames := allNodeNames(data.Nodes)
+	if len(vrfNames) > 1 {
+		var placed bool
+		key := layer2AttachmentKey(l2a.Namespace, l2a.Name)
+		nodeNames, placed = l2aPlacements[key]
+		if !placed {
+			if err := l2aPlacementErrors[key]; err != nil {
+				return fmt.Errorf("Layer2Attachment %q was not successfully placed: %w", l2a.Name, err)
+			}
+			return fmt.Errorf("Layer2Attachment %q was not successfully placed", l2a.Name)
+		}
+	}
+	for _, nodeName := range nodeNames {
+		contrib, ok := result[nodeName]
 		if !ok {
 			contrib = NewNodeContribution()
-			result[node.Name] = contrib
+			result[nodeName] = contrib
 		}
 
-		for _, vrfName := range vrfNames {
+		if len(vrfNames) == 1 {
+			vrfName := vrfNames[0]
 			fvrf, exists := contrib.FabricVRFs[vrfName]
 			if !exists {
-				fvrf = buildFabricVRF(vrfs[vrfName])
+				fvrf = buildFabricVRF(routing.vrfSpecs[vrfName])
 			}
 
 			fvrf.BGPPeers = append(fvrf.BGPPeers, peers...)
-			// Add Inbound addresses to EVPN export so the fabric distributes them.
-			if fvrf.EVPNExportFilter == nil {
-				fvrf.EVPNExportFilter = &networkv1alpha1.Filter{
-					DefaultAction: networkv1alpha1.Action{Type: networkv1alpha1.Reject},
-				}
+			appendEVPNExportItems(&fvrf, evpnExportItems)
+			contrib.FabricVRFs[vrfName] = fvrf
+			continue
+		}
+
+		combo := contrib.LocalVRFs[routing.irbVRF]
+		combo.BGPPeers = append(combo.BGPPeers, peers...)
+		contrib.LocalVRFs[routing.irbVRF] = combo
+
+		importFilter := networkv1alpha1.Filter{
+			DefaultAction: networkv1alpha1.Action{Type: networkv1alpha1.Reject},
+			Items:         b.evpnExportItems(allowIPv4, allowIPv6, nil),
+		}
+		for _, vrfName := range vrfNames {
+			fvrf, exists := contrib.FabricVRFs[vrfName]
+			if !exists {
+				fvrf = buildFabricVRF(routing.vrfSpecs[vrfName])
 			}
-			fvrf.EVPNExportFilter.Items = append(fvrf.EVPNExportFilter.Items, evpnExportItems...)
+			fvrf.VRFImports = appendVRFImport(fvrf.VRFImports, routing.irbVRF, importFilter.Items)
+			appendEVPNExportItems(&fvrf, evpnExportItems)
 			contrib.FabricVRFs[vrfName] = fvrf
 		}
 	}
 
 	return nil
+}
+
+func allNodeNames(nodes []corev1.Node) []string {
+	names := make([]string, 0, len(nodes))
+	for i := range nodes {
+		names = append(names, nodes[i].Name)
+	}
+	return names
 }
 
 // buildLoopbackPeer creates BGPPeer entries with Address on the ClusterVRF.
@@ -175,15 +211,13 @@ func (b *BGPPeeringBuilder) buildLoopbackPeer(bp *nc.BGPPeering, data *resolver.
 	}
 }
 
-// resolveL2AVRFs returns ALL VRFs (name → spec) matched by the
-// Layer2Attachment's Destinations selector. Returning a multi-VRF map lets the
-// caller fan out the listen-range peer and EVPN export items across every
-// matched VRF.
-func (*BGPPeeringBuilder) resolveL2AVRFs(l2a *nc.Layer2Attachment, data *resolver.ResolvedData) map[string]*nc.VRFSpec {
-	if l2a.Spec.Destinations == nil {
-		return nil
+func appendEVPNExportItems(fvrf *networkv1alpha1.FabricVRF, items []networkv1alpha1.FilterItem) {
+	if fvrf.EVPNExportFilter == nil {
+		fvrf.EVPNExportFilter = &networkv1alpha1.Filter{
+			DefaultAction: networkv1alpha1.Action{Type: networkv1alpha1.Reject},
+		}
 	}
-	return resolveSelectorVRFs(l2a.Spec.Destinations, data)
+	fvrf.EVPNExportFilter.Items = append(fvrf.EVPNExportFilter.Items, items...)
 }
 
 // buildListenRangePeers creates BGPPeer entries with ListenRange from the L2A
@@ -218,7 +252,7 @@ func (b *BGPPeeringBuilder) buildListenRangePeers(bp *nc.BGPPeering, net *resolv
 // EVPN export set.
 func (*BGPPeeringBuilder) resolveNetworkCIDRs(bp *nc.BGPPeering, data *resolver.ResolvedData) (ipv4, ipv6 []string) {
 	for _, ref := range bp.Spec.Ref.NetworkRefs {
-		net, ok := data.Networks[ref]
+		net, ok := data.Network(bp.Namespace, ref)
 		if !ok {
 			continue
 		}

--- a/pkg/reconciler/intent/builder/collector.go
+++ b/pkg/reconciler/intent/builder/collector.go
@@ -53,7 +53,7 @@ func (*CollectorBuilder) Build(ctx context.Context, data *resolver.ResolvedData)
 
 		// Resolve mirror VRF.
 		vrfName := col.Spec.MirrorVRF.Name
-		resolvedVRF, ok := data.VRFs[vrfName]
+		resolvedVRF, ok := data.VRF(col.Namespace, vrfName)
 		if !ok {
 			logger.Info("skipping Collector with unknown VRF reference",
 				"collector", col.Name, "vrf", vrfName)

--- a/pkg/reconciler/intent/builder/helpers.go
+++ b/pkg/reconciler/intent/builder/helpers.go
@@ -33,6 +33,8 @@ import (
 )
 
 const (
+	clusterVRFName = "cluster"
+
 	// mirrorProtocolL2GRE is the Collector GRE encapsulation type for Layer 2 (GRE TAP).
 	mirrorProtocolL2GRE = "l2gre"
 )
@@ -41,7 +43,7 @@ const (
 // for a Collector. The same name is referenced by the MirrorACL.MirrorDestination
 // emitted by the MirrorBuilder, so both builders must derive it identically.
 func mirrorGREName(col *nc.Collector) string {
-	sum := sha256.Sum256([]byte(col.Name))
+	sum := sha256.Sum256([]byte(layer2AttachmentDisplayName(col.Namespace, col.Name)))
 	h := hex.EncodeToString(sum[:])[:8]
 	if col.Spec.Protocol == mirrorProtocolL2GRE {
 		return "gtap-" + h
@@ -84,7 +86,7 @@ func buildFabricVRF(vrfSpec *nc.VRFSpec) networkv1alpha1.FabricVRF {
 		VRF: networkv1alpha1.VRF{
 			VRFImports: []networkv1alpha1.VRFImport{
 				{
-					FromVRF: "cluster",
+					FromVRF: clusterVRFName,
 					Filter: networkv1alpha1.Filter{
 						DefaultAction: networkv1alpha1.Action{Type: networkv1alpha1.Reject},
 					},
@@ -108,13 +110,21 @@ func buildFabricVRF(vrfSpec *nc.VRFSpec) networkv1alpha1.FabricVRF {
 // findMatchingAP resolves the single AnnouncementPolicy that applies to a usage CRD.
 // It matches by VRF backbone name AND the AP's label selector against the usage CRD's labels.
 // Returns nil,nil if no AP matches. Returns an error if more than one matches.
-func findMatchingAP(usageCRDLabels map[string]string, vrfName string, data *resolver.ResolvedData) (*nc.AnnouncementPolicy, error) {
+func findMatchingAP(
+	namespace string,
+	usageCRDLabels map[string]string,
+	vrfName string,
+	data *resolver.ResolvedData,
+) (*nc.AnnouncementPolicy, error) {
 	var matches []*nc.AnnouncementPolicy
 
 	for i := range data.AnnouncementPolicies {
 		ap := &data.AnnouncementPolicies[i]
+		if ap.Namespace != namespace {
+			continue
+		}
 
-		resolved, ok := data.VRFs[ap.Spec.VRFRef]
+		resolved, ok := data.VRF(namespace, ap.Spec.VRFRef)
 		if !ok || resolved.Spec.VRF != vrfName {
 			continue
 		}
@@ -151,9 +161,23 @@ func findMatchingAP(usageCRDLabels map[string]string, vrfName string, data *reso
 // host-route/aggregate splitting on the EVPN export side. The cluster VRFImport
 // always uses plain (community-free) filter items.
 func addNetworkToFabricVRF(fvrf *networkv1alpha1.FabricVRF, net *resolver.ResolvedNetwork, ap *nc.AnnouncementPolicy) networkv1alpha1.FabricVRF {
+	addNetworkToEVPNExport(fvrf, net, ap)
+
+	// Add to cluster VRFImport filter (plain, no AP communities).
+	plainItems := networkCIDRFilterItems(net, nil)
+	if len(fvrf.VRFImports) > 0 {
+		fvrf.VRFImports[0].Filter.Items = append(fvrf.VRFImports[0].Filter.Items, plainItems...)
+	}
+
+	return *fvrf
+}
+
+// addNetworkToEVPNExport allows a Network's routes to be advertised from a
+// FabricVRF without assuming where those routes originate.
+func addNetworkToEVPNExport(fvrf *networkv1alpha1.FabricVRF, net *resolver.ResolvedNetwork, ap *nc.AnnouncementPolicy) {
 	evpnItems := networkCIDRFilterItems(net, ap)
 	if len(evpnItems) == 0 {
-		return *fvrf
+		return
 	}
 
 	// Add to EVPN export filter (with AP communities).
@@ -163,14 +187,6 @@ func addNetworkToFabricVRF(fvrf *networkv1alpha1.FabricVRF, net *resolver.Resolv
 		}
 	}
 	fvrf.EVPNExportFilter.Items = append(fvrf.EVPNExportFilter.Items, evpnItems...)
-
-	// Add to cluster VRFImport filter (plain, no AP communities).
-	plainItems := networkCIDRFilterItems(net, nil)
-	if len(fvrf.VRFImports) > 0 {
-		fvrf.VRFImports[0].Filter.Items = append(fvrf.VRFImports[0].Filter.Items, plainItems...)
-	}
-
-	return *fvrf
 }
 
 // networkCIDRFilterItems creates FilterItems for a Network's IPv4 and IPv6 CIDRs.
@@ -309,6 +325,23 @@ func matchNodes(nodes []corev1.Node, selector *metav1.LabelSelector) ([]corev1.N
 // By default, the covering prefix is always added so the fabric can export it via EVPN.
 // When an AP is provided its aggregate config controls prefix length and suppression.
 func addAggregateRoutes(fvrf *networkv1alpha1.FabricVRF, net *resolver.ResolvedNetwork, ap *nc.AnnouncementPolicy) {
+	addAggregateRoutesWithNextHop(fvrf, net, ap, nil)
+}
+
+// addAggregateRoutesViaVRF adds aggregate routes that forward through another
+// VRF instead of blackholing locally. Multi-VRF L2 attachments use this so a
+// more-specific aggregate cannot override the return route to their combo VRF.
+func addAggregateRoutesViaVRF(fvrf *networkv1alpha1.FabricVRF, net *resolver.ResolvedNetwork, ap *nc.AnnouncementPolicy, vrfName string) {
+	nextVRF := vrfName
+	addAggregateRoutesWithNextHop(fvrf, net, ap, &networkv1alpha1.NextHop{Vrf: &nextVRF})
+}
+
+func addAggregateRoutesWithNextHop(
+	fvrf *networkv1alpha1.FabricVRF,
+	net *resolver.ResolvedNetwork,
+	ap *nc.AnnouncementPolicy,
+	nextHop *networkv1alpha1.NextHop,
+) {
 	if ap != nil && ap.Spec.Aggregate != nil && ap.Spec.Aggregate.Enabled != nil && !*ap.Spec.Aggregate.Enabled {
 		return
 	}
@@ -334,7 +367,8 @@ func addAggregateRoutes(fvrf *networkv1alpha1.FabricVRF, net *resolver.ResolvedN
 		}
 		prefix := computeAggregatePrefix(net.Spec.IPv4.CIDR, overrideLen)
 		fvrf.StaticRoutes = appendUniqueStaticRoute(fvrf.StaticRoutes, networkv1alpha1.StaticRoute{
-			Prefix: prefix,
+			Prefix:  prefix,
+			NextHop: nextHop,
 		})
 		if fvrf.EVPNExportFilter != nil {
 			fvrf.EVPNExportFilter.Items = appendUniqueFilterItem(fvrf.EVPNExportFilter.Items, networkv1alpha1.FilterItem{
@@ -350,7 +384,8 @@ func addAggregateRoutes(fvrf *networkv1alpha1.FabricVRF, net *resolver.ResolvedN
 		}
 		prefix := computeAggregatePrefix(net.Spec.IPv6.CIDR, overrideLen)
 		fvrf.StaticRoutes = appendUniqueStaticRoute(fvrf.StaticRoutes, networkv1alpha1.StaticRoute{
-			Prefix: prefix,
+			Prefix:  prefix,
+			NextHop: nextHop,
 		})
 		if fvrf.EVPNExportFilter != nil {
 			fvrf.EVPNExportFilter.Items = appendUniqueFilterItem(fvrf.EVPNExportFilter.Items, networkv1alpha1.FilterItem{
@@ -403,20 +438,49 @@ func computeAggregatePrefix(cidr string, overrideLen *int32) string {
 	return fmt.Sprintf("%s/%d", masked.String(), newLen)
 }
 
-// appendUniqueStaticRoute appends a static route only if no route with the same prefix exists.
+// appendUniqueStaticRoute deduplicates identical routes and prefers an explicit
+// next hop over a blackhole for the same prefix. Conflicting explicit routes
+// remain visible for downstream validation instead of being silently discarded.
 func appendUniqueStaticRoute(routes []networkv1alpha1.StaticRoute, route networkv1alpha1.StaticRoute) []networkv1alpha1.StaticRoute {
-	for _, r := range routes {
-		if r.Prefix == route.Prefix {
+	for i := range routes {
+		if routes[i].Prefix != route.Prefix {
+			continue
+		}
+		switch {
+		case sameBuilderStaticRoute(routes[i], route):
+			return routes
+		case routes[i].NextHop == nil && route.NextHop != nil:
+			routes[i] = route
+			return routes
+		case routes[i].NextHop != nil && route.NextHop == nil:
 			return routes
 		}
 	}
 	return append(routes, route)
 }
 
+func sameBuilderStaticRoute(a, b networkv1alpha1.StaticRoute) bool {
+	if a.Prefix != b.Prefix {
+		return false
+	}
+	if a.NextHop == nil || b.NextHop == nil {
+		return a.NextHop == nil && b.NextHop == nil
+	}
+	return equalBuilderStringPtr(a.NextHop.Address, b.NextHop.Address) &&
+		equalBuilderStringPtr(a.NextHop.Vrf, b.NextHop.Vrf)
+}
+
+func equalBuilderStringPtr(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
 // resolveSelectorVRFs returns ALL VRFs (name → spec) matched by a Destination
 // LabelSelector. Used by consumers (Inbound, Outbound, Layer2Attachment) that
 // must fan out to every matched VRF rather than picking the first match.
-func resolveSelectorVRFs(sel *metav1.LabelSelector, data *resolver.ResolvedData) map[string]*nc.VRFSpec {
+func resolveSelectorVRFs(namespace string, sel *metav1.LabelSelector, data *resolver.ResolvedData) map[string]*nc.VRFSpec {
 	if sel == nil {
 		return nil
 	}
@@ -427,13 +491,13 @@ func resolveSelectorVRFs(sel *metav1.LabelSelector, data *resolver.ResolvedData)
 	out := map[string]*nc.VRFSpec{}
 	for i := range data.RawDestinations {
 		rawDest := &data.RawDestinations[i]
-		if !selector.Matches(labels.Set(rawDest.Labels)) {
+		if rawDest.Namespace != namespace || !selector.Matches(labels.Set(rawDest.Labels)) {
 			continue
 		}
 		if rawDest.Spec.VRFRef == nil {
 			continue
 		}
-		resolved, ok := data.Destinations[rawDest.Name]
+		resolved, ok := data.Destination(namespace, rawDest.Name)
 		if !ok || resolved.VRFSpec == nil {
 			continue
 		}
@@ -445,7 +509,7 @@ func resolveSelectorVRFs(sel *metav1.LabelSelector, data *resolver.ResolvedData)
 // groupDestinationsByVRF resolves a label selector against raw destinations and
 // groups ALL matching destinations by their vrfRef. Destinations without vrfRef
 // (using nextHop instead) are skipped.
-func groupDestinationsByVRF(sel *metav1.LabelSelector, data *resolver.ResolvedData) map[string][]nc.Destination {
+func groupDestinationsByVRF(namespace string, sel *metav1.LabelSelector, data *resolver.ResolvedData) map[string][]nc.Destination {
 	selector, err := metav1.LabelSelectorAsSelector(sel)
 	if err != nil {
 		return nil
@@ -454,7 +518,7 @@ func groupDestinationsByVRF(sel *metav1.LabelSelector, data *resolver.ResolvedDa
 	grouped := make(map[string][]nc.Destination)
 	for i := range data.RawDestinations {
 		rawDest := &data.RawDestinations[i]
-		if !selector.Matches(labels.Set(rawDest.Labels)) {
+		if rawDest.Namespace != namespace || !selector.Matches(labels.Set(rawDest.Labels)) {
 			continue
 		}
 		if rawDest.Spec.VRFRef == nil {
@@ -462,7 +526,7 @@ func groupDestinationsByVRF(sel *metav1.LabelSelector, data *resolver.ResolvedDa
 		}
 		// Resolve VRFRef → backbone VRF name (spec.vrf) to match the FabricVRF
 		// map key convention used by all builders.
-		resolved, ok := data.Destinations[rawDest.Name]
+		resolved, ok := data.Destination(namespace, rawDest.Name)
 		if !ok || resolved.VRFSpec == nil {
 			continue
 		}

--- a/pkg/reconciler/intent/builder/helpers_test.go
+++ b/pkg/reconciler/intent/builder/helpers_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
+	"github.com/telekom/das-schiff-network-operator/pkg/reconciler/intent/resolver"
+)
+
+func TestResolveSelectorVRFsStaysWithinNamespace(t *testing.T) {
+	const (
+		roleLabelKey = "role"
+		roleClient   = "client"
+	)
+	ref := "shared-vrf"
+	selector := &metav1.LabelSelector{MatchLabels: map[string]string{roleLabelKey: roleClient}}
+	vrfs := []nc.VRF{
+		{ObjectMeta: metav1.ObjectMeta{Namespace: testTenantA, Name: ref}, Spec: nc.VRFSpec{VRF: "fabric-a"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: testTenantB, Name: ref}, Spec: nc.VRFSpec{VRF: "fabric-b"}},
+	}
+	destinations := []nc.Destination{
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testTenantA, Name: "shared-destination", Labels: map[string]string{roleLabelKey: roleClient}},
+			Spec:       nc.DestinationSpec{VRFRef: &ref},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testTenantB, Name: "shared-destination", Labels: map[string]string{roleLabelKey: roleClient}},
+			Spec:       nc.DestinationSpec{VRFRef: &ref},
+		},
+	}
+	vrfsByKey := resolver.ResolveVRFsByKey(vrfs)
+	data := &resolver.ResolvedData{
+		RawDestinations:   destinations,
+		DestinationsByKey: resolver.ResolveDestinationsByKey(destinations, vrfsByKey),
+	}
+
+	got := resolveSelectorVRFs(testTenantA, selector, data)
+	if len(got) != 1 || got["fabric-a"] == nil {
+		t.Fatalf("resolveSelectorVRFs() = %#v, want only fabric-a", got)
+	}
+}

--- a/pkg/reconciler/intent/builder/inbound.go
+++ b/pkg/reconciler/intent/builder/inbound.go
@@ -51,7 +51,7 @@ func (b *InboundBuilder) Build(ctx context.Context, data *resolver.ResolvedData)
 		ib := &data.Inbounds[i]
 
 		// Resolve the referenced Network.
-		net, ok := data.Networks[ib.Spec.NetworkRef]
+		net, ok := data.Network(ib.Namespace, ib.Spec.NetworkRef)
 		if !ok {
 			logger.Info("skipping Inbound with unknown Network reference",
 				"inbound", ib.Name, "networkRef", ib.Spec.NetworkRef)
@@ -64,7 +64,7 @@ func (b *InboundBuilder) Build(ctx context.Context, data *resolver.ResolvedData)
 			continue
 		}
 
-		grouped := groupDestinationsByVRF(ib.Spec.Destinations, data)
+		grouped := groupDestinationsByVRF(ib.Namespace, ib.Spec.Destinations, data)
 		if len(grouped) == 0 {
 			continue
 		}
@@ -75,7 +75,7 @@ func (b *InboundBuilder) Build(ctx context.Context, data *resolver.ResolvedData)
 		aps := make(map[string]*nc.AnnouncementPolicy, len(grouped))
 		ambiguous := false
 		for vrfName := range grouped {
-			ap, err := findMatchingAP(ib.Labels, vrfName, data)
+			ap, err := findMatchingAP(ib.Namespace, ib.Labels, vrfName, data)
 			if err != nil {
 				logger.Info("skipping Inbound with ambiguous announcement policy",
 					"inbound", ib.Name, "error", err.Error())
@@ -156,7 +156,7 @@ func (*InboundBuilder) resolveVRFSpec(vrfName string, grouped map[string][]nc.De
 	if len(dests) == 0 {
 		return nil
 	}
-	resolved, ok := data.Destinations[dests[0].Name]
+	resolved, ok := data.Destination(dests[0].Namespace, dests[0].Name)
 	if !ok || resolved.VRFSpec == nil {
 		return nil
 	}

--- a/pkg/reconciler/intent/builder/l2a.go
+++ b/pkg/reconciler/intent/builder/l2a.go
@@ -21,7 +21,8 @@ import (
 	"errors"
 	"fmt"
 	stdnet "net"
-	"sort"
+	"slices"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,12 +33,27 @@ import (
 	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
 	"github.com/telekom/das-schiff-network-operator/pkg/reconciler/intent/ipmath"
 	"github.com/telekom/das-schiff-network-operator/pkg/reconciler/intent/resolver"
+	"github.com/telekom/das-schiff-network-operator/pkg/vrfname"
 )
 
 const defaultMTU = 1500
 
 // L2ABuilder transforms Layer2Attachment intent CRDs into NNC Layer2 configs.
 type L2ABuilder struct{}
+
+type validatedL2A struct {
+	matchingNodes []corev1.Node
+	layer2        *networkv1alpha1.Layer2
+	aps           map[string]*nc.AnnouncementPolicy
+	routes        []NetplanRoute
+}
+
+type staticRouteOwner struct {
+	l2a     string
+	nextVRF string
+}
+
+const reasonConflictingStaticRoute = "ConflictingStaticRoute"
 
 // NewL2ABuilder creates a new L2ABuilder.
 func NewL2ABuilder() *L2ABuilder {
@@ -51,46 +67,92 @@ func (*L2ABuilder) Name() string {
 
 // Build produces per-node Layer2 configurations from Layer2Attachment resources.
 func (b *L2ABuilder) Build(ctx context.Context, data *resolver.ResolvedData) (map[string]*NodeContribution, error) {
+	result, _, _ := b.buildWithPlacements(ctx, data, true)
+	return result, nil
+}
+
+func (b *L2ABuilder) buildWithPlacements(
+	ctx context.Context,
+	data *resolver.ResolvedData,
+	reportSkips bool,
+) (map[string]*NodeContribution, map[string][]string, map[string]error) {
 	logger := log.FromContext(ctx).WithName("l2a-builder")
 	result := make(map[string]*NodeContribution)
+	placements := make(map[string][]string)
+	placementErrors := make(map[string]error)
 	// Track which L2A owns each per-node netplan slot and device name.
 	// Keys are namespaced: "<node>\x00slot\x00<mapKey>" and
 	// "<node>\x00dev\x00<deviceName>"; value is the owning L2A name.
 	ifOwner := make(map[string]string)
+	routeOwner := make(map[string]staticRouteOwner)
 
-	for i := range data.Layer2Attachments {
-		l2a := &data.Layer2Attachments[i]
+	layer2Attachments := sortedLayer2Attachments(data.Layer2Attachments)
+	for i := range layer2Attachments {
+		l2a := &layer2Attachments[i]
 
 		// Resolve the referenced Network — skip L2As with dangling refs.
-		net, ok := data.Networks[l2a.Spec.NetworkRef]
+		net, ok := data.Network(l2a.Namespace, l2a.Spec.NetworkRef)
 		if !ok {
+			err := fmt.Errorf("Layer2Attachment %q references unknown Network %q", l2a.Name, l2a.Spec.NetworkRef)
+			placementErrors[layer2AttachmentKey(l2a.Namespace, l2a.Name)] = err
 			logger.Info("skipping Layer2Attachment with unknown Network reference",
 				"l2a", l2a.Name, "networkRef", l2a.Spec.NetworkRef)
+			if reportSkips {
+				reportSkip(ctx, "Layer2Attachment", l2a.Namespace, l2a.Name, "NetworkNotFound", err.Error())
+			}
 			continue
 		}
 
-		// Resolve destinations to find VRF for IRB — skip on resolution errors.
-		vrfName, vrfSpec, err := b.resolveDestinationVRF(l2a, data)
+		// Resolve every selected destination VRF. A single VRF receives the IRB
+		// directly; multiple VRFs are connected through a combo LocalVRF.
+		routing, err := b.resolveDestinationVRFs(l2a, data)
 		if err != nil {
+			placementErrors[layer2AttachmentKey(l2a.Namespace, l2a.Name)] = err
 			// Surface the misconfiguration (e.g. an invalid destinations
 			// selector) as Ready=False, not just a log line.
 			logger.Info("skipping Layer2Attachment with unresolvable destinations",
 				"l2a", l2a.Name, "error", err.Error())
-			reportSkip(ctx, "Layer2Attachment", l2a.Namespace, l2a.Name, skipReason(err), err.Error())
+			if reportSkips {
+				reportSkip(ctx, "Layer2Attachment", l2a.Namespace, l2a.Name, skipReason(err), err.Error())
+			}
 			continue
 		}
 
-		if err := b.applyL2AToNodes(l2a, net, vrfName, vrfSpec, data, result, ifOwner); err != nil {
+		nodes, err := b.applyL2AToNodes(l2a, net, routing, data, result, ifOwner, routeOwner)
+		if err != nil {
+			placementErrors[layer2AttachmentKey(l2a.Namespace, l2a.Name)] = err
 			// Never abort the reconcile for one bad L2A: skip it and surface the
 			// failure as a Ready=False condition (with a specific reason) so it
 			// is visible in the resource status, not only the controller log.
 			logger.Info("skipping Layer2Attachment", "l2a", l2a.Name, "error", err.Error())
-			reportSkip(ctx, "Layer2Attachment", l2a.Namespace, l2a.Name, skipReason(err), err.Error())
+			if reportSkips {
+				reportSkip(ctx, "Layer2Attachment", l2a.Namespace, l2a.Name, skipReason(err), err.Error())
+			}
 			continue
 		}
+		placements[layer2AttachmentKey(l2a.Namespace, l2a.Name)] = nodes
 	}
 
-	return result, nil
+	return result, placements, placementErrors
+}
+
+func sortedLayer2Attachments(items []nc.Layer2Attachment) []nc.Layer2Attachment {
+	sorted := slices.Clone(items)
+	slices.SortFunc(sorted, func(a, b nc.Layer2Attachment) int {
+		return strings.Compare(a.Namespace+"\x00"+a.Name, b.Namespace+"\x00"+b.Name)
+	})
+	return sorted
+}
+
+func layer2AttachmentKey(namespace, name string) string {
+	return namespace + "\x00" + name
+}
+
+func layer2AttachmentDisplayName(namespace, name string) string {
+	if namespace == "" {
+		return name
+	}
+	return namespace + "/" + name
 }
 
 // applyL2AToNodes fans out a single L2A to every matching node.
@@ -104,33 +166,18 @@ func (b *L2ABuilder) Build(ctx context.Context, data *resolver.ResolvedData) (ma
 func (b *L2ABuilder) applyL2AToNodes(
 	l2a *nc.Layer2Attachment,
 	net *resolver.ResolvedNetwork,
-	vrfName string,
-	vrfSpec *nc.VRFSpec,
+	routing *l2aVRFRouting,
 	data *resolver.ResolvedData,
 	result map[string]*NodeContribution,
 	ifOwner map[string]string,
-) error {
+	routeOwner map[string]staticRouteOwner,
+) ([]string, error) {
 	vlanID := b.vlanID(net)
 	mapKey := netplanMapKey(vlanID, l2a)
 
-	matchingNodes, err := matchNodes(data.Nodes, l2a.Spec.NodeSelector)
+	validated, err := b.validateL2A(l2a, net, routing, data)
 	if err != nil {
-		return fmt.Errorf("Layer2Attachment %q node selector error: %w", l2a.Name, err)
-	}
-
-	// Layer2 config is node-independent; this guards the L2/L3 route-target collision.
-	layer2, err := b.buildLayer2(l2a, net, vrfName, vrfSpec)
-	if err != nil {
-		return fmt.Errorf("Layer2Attachment %q config build failed: %w", l2a.Name, err)
-	}
-
-	// Resolve the IRB AnnouncementPolicy once (node-independent).
-	var ap *nc.AnnouncementPolicy
-	if vrfName != "" && vrfSpec != nil {
-		ap, err = findMatchingAP(l2a.Labels, vrfName, data)
-		if err != nil {
-			return fmt.Errorf("Layer2Attachment %q: %w", l2a.Name, err)
-		}
+		return nil, err
 	}
 
 	// Detect ownership conflicts across L2As before claiming any. Two kinds of
@@ -143,11 +190,129 @@ func (b *L2ABuilder) applyL2AToNodes(
 	//     parent interfaceRef in native mode, or the InterfaceName override for a
 	//     tagged VLAN). Two L2As on different VLANs but the same device name also
 	//     collide.
-	claims := ownershipClaims(matchingNodes, mapKey, netplanClaimName(net, l2a))
+	claims := ownershipClaims(validated.matchingNodes, mapKey, netplanClaimName(net, l2a))
+	l2aDisplayName := layer2AttachmentDisplayName(l2a.Namespace, l2a.Name)
 	for i := range claims {
 		if prev, exists := ifOwner[claims[i].key]; exists {
-			return fmt.Errorf("Layer2Attachments %q and %q both configure %s on node %q",
-				prev, l2a.Name, claims[i].what, claims[i].node)
+			return nil, fmt.Errorf("Layer2Attachments %q and %q both configure %s on node %q",
+				prev, l2aDisplayName, claims[i].what, claims[i].node)
+		}
+	}
+	routeClaims, err := multiVRFRouteClaims(l2a, net, routing, validated, routeOwner)
+	if err != nil {
+		return nil, err
+	}
+
+	// Mutation phase — validation passed, so nothing below can fail.
+	for i := range claims {
+		ifOwner[claims[i].key] = l2aDisplayName
+	}
+	for key, owner := range routeClaims {
+		routeOwner[key] = owner
+	}
+
+	for i := range validated.matchingNodes {
+		node := &validated.matchingNodes[i]
+		contrib := ensureContrib(result, node.Name)
+		if validated.layer2 != nil {
+			contrib.Layer2s[mapKey] = *validated.layer2
+		}
+
+		// Carry netplan-only device info for this VLAN (interface name/parent
+		// overrides plus, when enabled, per-node IPs). Kept off the NNC API.
+		if dev, ok := buildNetplanDevice(l2a, net, node.Name, validated.routes); ok {
+			contrib.NetplanNodeIPs[mapKey] = dev
+		}
+
+		switch len(routing.vrfSpecs) {
+		case 0:
+			// No VRF plumbing requested.
+		case 1:
+			vrfName := sortedVRFNames(routing.vrfSpecs)[0]
+			b.applyVRFContrib(net, vrfName, routing.vrfSpecs[vrfName], contrib, validated.aps[vrfName])
+		default:
+			b.applyMultiVRFContrib(net, routing, contrib, validated.aps)
+		}
+	}
+
+	nodeNames := make([]string, 0, len(validated.matchingNodes))
+	for i := range validated.matchingNodes {
+		nodeNames = append(nodeNames, validated.matchingNodes[i].Name)
+	}
+	return nodeNames, nil
+}
+
+func multiVRFRouteClaims(
+	l2a *nc.Layer2Attachment,
+	net *resolver.ResolvedNetwork,
+	routing *l2aVRFRouting,
+	validated *validatedL2A,
+	owners map[string]staticRouteOwner,
+) (map[string]staticRouteOwner, error) {
+	claims := make(map[string]staticRouteOwner)
+	if len(routing.vrfSpecs) <= 1 {
+		return claims, nil
+	}
+
+	contrib := NewNodeContribution()
+	(&L2ABuilder{}).applyMultiVRFContrib(net, routing, contrib, validated.aps)
+	for i := range validated.matchingNodes {
+		nodeName := validated.matchingNodes[i].Name
+		for vrfName := range contrib.FabricVRFs {
+			for _, route := range contrib.FabricVRFs[vrfName].StaticRoutes {
+				if route.NextHop == nil || route.NextHop.Vrf == nil {
+					continue
+				}
+				key := nodeName + "\x00" + vrfName + "\x00" + route.Prefix
+				claim := staticRouteOwner{
+					l2a:     layer2AttachmentDisplayName(l2a.Namespace, l2a.Name),
+					nextVRF: *route.NextHop.Vrf,
+				}
+				if previous, exists := owners[key]; exists && previous.nextVRF != claim.nextVRF {
+					return nil, &skipReasonError{
+						reason: reasonConflictingStaticRoute,
+						err: fmt.Errorf(
+							"Layer2Attachments %q and %q route prefix %q in VRF %q through different intermediate VRFs on node %q",
+							previous.l2a, layer2AttachmentDisplayName(l2a.Namespace, l2a.Name),
+							route.Prefix, vrfName, nodeName,
+						),
+					}
+				}
+				claims[key] = claim
+			}
+		}
+	}
+	return claims, nil
+}
+
+// validateL2A resolves all node-independent and selector-dependent inputs used
+// by both the L2A and listen-range BGPPeering builders.
+func (b *L2ABuilder) validateL2A(
+	l2a *nc.Layer2Attachment,
+	net *resolver.ResolvedNetwork,
+	routing *l2aVRFRouting,
+	data *resolver.ResolvedData,
+) (*validatedL2A, error) {
+	matchingNodes, err := matchNodes(data.Nodes, l2a.Spec.NodeSelector)
+	if err != nil {
+		return nil, fmt.Errorf("Layer2Attachment %q node selector error: %w", l2a.Name, err)
+	}
+
+	// Layer2 config is node-independent; this guards the L2/L3 route-target collision.
+	layer2, err := b.buildLayer2(l2a, net, routing.irbVRF, routing.irbVRFSpec)
+	if err != nil {
+		return nil, fmt.Errorf("Layer2Attachment %q config build failed: %w", l2a.Name, err)
+	}
+	if err := validateMultiVRFIRB(l2a, layer2, routing); err != nil {
+		return nil, err
+	}
+
+	// Resolve AnnouncementPolicies for every selected FabricVRF up front.
+	aps := make(map[string]*nc.AnnouncementPolicy, len(routing.vrfSpecs))
+	for _, vrfName := range sortedVRFNames(routing.vrfSpecs) {
+		aps[vrfName], err = findMatchingAP(l2a.Namespace, l2a.Labels, vrfName, data)
+		if err != nil {
+			return nil, fmt.Errorf("Layer2Attachment %q: %w", l2a.Name, err)
 		}
 	}
 
@@ -156,33 +321,15 @@ func (b *L2ABuilder) applyL2AToNodes(
 	// (Ready=False), so validate it here before the mutation phase.
 	routes, err := destinationRoutes(l2a, data)
 	if err != nil {
-		return fmt.Errorf("Layer2Attachment %q: %w", l2a.Name, err)
+		return nil, fmt.Errorf("Layer2Attachment %q: %w", l2a.Name, err)
 	}
 
-	// Mutation phase — validation passed, so nothing below can fail.
-	for i := range claims {
-		ifOwner[claims[i].key] = l2a.Name
-	}
-
-	for i := range matchingNodes {
-		node := &matchingNodes[i]
-		contrib := ensureContrib(result, node.Name)
-		if layer2 != nil {
-			contrib.Layer2s[mapKey] = *layer2
-		}
-
-		// Carry netplan-only device info for this VLAN (interface name/parent
-		// overrides plus, when enabled, per-node IPs). Kept off the NNC API.
-		if dev, ok := buildNetplanDevice(l2a, net, node.Name, routes); ok {
-			contrib.NetplanNodeIPs[mapKey] = dev
-		}
-
-		if vrfName != "" && vrfSpec != nil {
-			b.applyVRFContrib(net, vrfName, vrfSpec, contrib, ap)
-		}
-	}
-
-	return nil
+	return &validatedL2A{
+		matchingNodes: matchingNodes,
+		layer2:        layer2,
+		aps:           aps,
+		routes:        routes,
+	}, nil
 }
 
 // applyVRFContrib updates the FabricVRF entry for a single node from an L2A.
@@ -202,30 +349,218 @@ func (*L2ABuilder) applyVRFContrib(
 	contrib.FabricVRFs[vrfName] = fvrf
 }
 
-// resolveDestinationVRF finds the VRF for IRB plumbing by selecting Destinations
-// matching the L2A's destination selector.
-func (*L2ABuilder) resolveDestinationVRF(l2a *nc.Layer2Attachment, data *resolver.ResolvedData) (string, *nc.VRFSpec, error) {
+// l2aVRFRouting contains the resolved routing topology for one L2A.
+type l2aVRFRouting struct {
+	irbVRF       string
+	irbVRFSpec   *nc.VRFSpec
+	vrfSpecs     map[string]*nc.VRFSpec
+	destinations map[string][]nc.Destination
+	comboRoutes  []networkv1alpha1.StaticRoute
+}
+
+// resolveDestinationVRFs finds all FabricVRFs selected by an L2A. A single
+// FabricVRF owns the IRB directly. For multiple FabricVRFs, the IRB is placed
+// in a deterministic combo LocalVRF and routes are leaked in both directions.
+func (*L2ABuilder) resolveDestinationVRFs(l2a *nc.Layer2Attachment, data *resolver.ResolvedData) (*l2aVRFRouting, error) {
+	routing := &l2aVRFRouting{
+		vrfSpecs:     make(map[string]*nc.VRFSpec),
+		destinations: make(map[string][]nc.Destination),
+	}
 	if l2a.Spec.Destinations == nil {
-		return "", nil, nil // no VRF plumbing requested
+		return routing, nil
 	}
 
 	selector, err := metav1.LabelSelectorAsSelector(l2a.Spec.Destinations)
 	if err != nil {
-		return "", nil, fmt.Errorf("invalid destination selector: %w", err)
+		return nil, fmt.Errorf("invalid destination selector: %w", err)
 	}
 
-	// Match against raw Destination CRDs using their labels.
+	var destinationNames []string
 	for i := range data.RawDestinations {
 		rawDest := &data.RawDestinations[i]
-		if selector.Matches(labels.Set(rawDest.Labels)) {
-			resolved, ok := data.Destinations[rawDest.Name]
-			if ok && resolved.VRFSpec != nil {
-				return resolved.VRFSpec.VRF, resolved.VRFSpec, nil
+		if rawDest.Namespace != l2a.Namespace || !selector.Matches(labels.Set(rawDest.Labels)) {
+			continue
+		}
+		resolved, ok := data.Destination(l2a.Namespace, rawDest.Name)
+		if !ok || resolved.VRFSpec == nil || resolved.Spec.VRFRef == nil {
+			continue
+		}
+		vrfName := resolved.VRFSpec.VRF
+		routing.vrfSpecs[vrfName] = resolved.VRFSpec
+		routing.destinations[vrfName] = append(routing.destinations[vrfName], *rawDest)
+		destinationNames = append(destinationNames, layer2AttachmentDisplayName(rawDest.Namespace, rawDest.Name))
+	}
+
+	switch len(routing.vrfSpecs) {
+	case 0:
+		return routing, nil
+	case 1:
+		routing.irbVRF = sortedVRFNames(routing.vrfSpecs)[0]
+		routing.irbVRFSpec = routing.vrfSpecs[routing.irbVRF]
+	default:
+		slices.Sort(destinationNames)
+		routing.irbVRF = vrfname.L2AName(strings.Join(destinationNames, "+"))
+		if err := validateIntermediateVRFName(routing.irbVRF, data); err != nil {
+			return nil, err
+		}
+		routing.comboRoutes, err = destinationVRFRoutes(routing.destinations)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return routing, nil
+}
+
+const (
+	reasonIntermediateVRFNameCollision = "IntermediateVRFNameCollision"
+	reasonMultiVRFRequiresIRB          = "MultiVRFRequiresIRB"
+)
+
+func validateIntermediateVRFName(name string, data *resolver.ResolvedData) error {
+	if name == clusterVRFName {
+		return &skipReasonError{
+			reason: reasonIntermediateVRFNameCollision,
+			err:    fmt.Errorf("generated intermediate VRF name %q collides with a reserved VRF", name),
+		}
+	}
+	vrfs := data.VRFsByKey
+	if vrfs == nil {
+		vrfs = data.VRFs
+	}
+	for _, resolvedVRF := range vrfs {
+		if resolvedVRF != nil && vrfname.Reduce(resolvedVRF.Spec.VRF) == name {
+			return &skipReasonError{
+				reason: reasonIntermediateVRFNameCollision,
+				err: fmt.Errorf("generated intermediate VRF name %q collides with FabricVRF %q after name reduction",
+					name, layer2AttachmentDisplayName(resolvedVRF.Namespace, resolvedVRF.Name)),
+			}
+		}
+	}
+	return nil
+}
+
+func validateMultiVRFIRB(
+	l2a *nc.Layer2Attachment,
+	layer2 *networkv1alpha1.Layer2,
+	routing *l2aVRFRouting,
+) error {
+	if len(routing.vrfSpecs) <= 1 {
+		return nil
+	}
+	if layer2 != nil && layer2.IRB != nil && (l2a.Spec.SRIOV == nil || !l2a.Spec.SRIOV.Enabled) {
+		return nil
+	}
+	return &skipReasonError{
+		reason: reasonMultiVRFRequiresIRB,
+		err:    fmt.Errorf("multiple destination VRFs require an enabled HBN IRB"),
+	}
+}
+
+// applyMultiVRFContrib connects an L2 network to multiple FabricVRFs through a
+// combo LocalVRF. Static VRF nexthops provide bidirectional routing without
+// ClusterVRF policy routes: destination prefixes point from the combo VRF to
+// their FabricVRF, while each FabricVRF points the attached Network back to the
+// combo VRF and exports it through EVPN.
+func (*L2ABuilder) applyMultiVRFContrib(
+	net *resolver.ResolvedNetwork,
+	routing *l2aVRFRouting,
+	contrib *NodeContribution,
+	aps map[string]*nc.AnnouncementPolicy,
+) {
+	combo := contrib.LocalVRFs[routing.irbVRF]
+	for _, route := range routing.comboRoutes {
+		combo.StaticRoutes = appendUniqueVRFStaticRoute(combo.StaticRoutes, route)
+	}
+	contrib.LocalVRFs[routing.irbVRF] = combo
+
+	for _, vrfName := range sortedVRFNames(routing.vrfSpecs) {
+		fvrf, exists := contrib.FabricVRFs[vrfName]
+		if !exists {
+			fvrf = buildFabricVRF(routing.vrfSpecs[vrfName])
+		}
+		addNetworkToEVPNExport(&fvrf, net, aps[vrfName])
+		addNetworkRoutesToVRF(&fvrf, net, routing.irbVRF)
+		addAggregateRoutesViaVRF(&fvrf, net, aps[vrfName], routing.irbVRF)
+		contrib.FabricVRFs[vrfName] = fvrf
+	}
+}
+
+func sortedVRFNames(vrfs map[string]*nc.VRFSpec) []string {
+	names := make([]string, 0, len(vrfs))
+	for name := range vrfs {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+func destinationVRFRoutes(grouped map[string][]nc.Destination) ([]networkv1alpha1.StaticRoute, error) {
+	routes := make(map[string]networkv1alpha1.StaticRoute)
+	prefixVRFs := make(map[string]string)
+	for vrfName, destinations := range grouped {
+		for i := range destinations {
+			for _, prefix := range destinations[i].Spec.Prefixes {
+				_, network, err := stdnet.ParseCIDR(prefix)
+				if err != nil {
+					return nil, fmt.Errorf("invalid destination prefix %q: %w", prefix, err)
+				}
+				canonicalPrefix := network.String()
+				if existingVRF, exists := prefixVRFs[canonicalPrefix]; exists && existingVRF != vrfName {
+					return nil, fmt.Errorf("destination prefix %q is assigned to multiple VRFs %q and %q",
+						canonicalPrefix, existingVRF, vrfName)
+				}
+				prefixVRFs[canonicalPrefix] = vrfName
+				nextVRF := vrfName
+				key := canonicalPrefix + "\x00" + vrfName
+				routes[key] = networkv1alpha1.StaticRoute{
+					Prefix:  canonicalPrefix,
+					NextHop: &networkv1alpha1.NextHop{Vrf: &nextVRF},
+				}
 			}
 		}
 	}
 
-	return "", nil, nil // no matching destination with VRF
+	keys := make([]string, 0, len(routes))
+	for key := range routes {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	result := make([]networkv1alpha1.StaticRoute, 0, len(keys))
+	for _, key := range keys {
+		result = append(result, routes[key])
+	}
+	return result, nil
+}
+
+func addNetworkRoutesToVRF(fvrf *networkv1alpha1.FabricVRF, net *resolver.ResolvedNetwork, vrfName string) {
+	if net.Spec.IPv4 != nil && net.Spec.IPv4.CIDR != "" {
+		nextVRF := vrfName
+		fvrf.StaticRoutes = appendUniqueStaticRoute(fvrf.StaticRoutes, networkv1alpha1.StaticRoute{
+			Prefix:  net.Spec.IPv4.CIDR,
+			NextHop: &networkv1alpha1.NextHop{Vrf: &nextVRF},
+		})
+	}
+	if net.Spec.IPv6 != nil && net.Spec.IPv6.CIDR != "" {
+		nextVRF := vrfName
+		fvrf.StaticRoutes = appendUniqueStaticRoute(fvrf.StaticRoutes, networkv1alpha1.StaticRoute{
+			Prefix:  net.Spec.IPv6.CIDR,
+			NextHop: &networkv1alpha1.NextHop{Vrf: &nextVRF},
+		})
+	}
+}
+
+func appendUniqueVRFStaticRoute(routes []networkv1alpha1.StaticRoute, route networkv1alpha1.StaticRoute) []networkv1alpha1.StaticRoute {
+	for i := range routes {
+		if routes[i].Prefix != route.Prefix || routes[i].NextHop == nil || route.NextHop == nil {
+			continue
+		}
+		if routes[i].NextHop.Vrf != nil && route.NextHop.Vrf != nil && *routes[i].NextHop.Vrf == *route.NextHop.Vrf {
+			return routes
+		}
+	}
+	return append(routes, route)
 }
 
 // buildLayer2 creates a NNC Layer2 from a Layer2Attachment and its resolved Network.
@@ -514,10 +849,13 @@ func destinationRoutes(l2a *nc.Layer2Attachment, data *resolver.ResolvedData) ([
 	var routes []NetplanRoute
 	for i := range data.RawDestinations {
 		destination := &data.RawDestinations[i]
+		if destination.Namespace != l2a.Namespace {
+			continue
+		}
 		if !selector.Matches(labels.Set(destination.Labels)) {
 			continue
 		}
-		resolved, ok := data.Destinations[destination.Name]
+		resolved, ok := data.Destination(l2a.Namespace, destination.Name)
 		if !ok || resolved.Spec.NextHop == nil {
 			continue
 		}
@@ -534,11 +872,11 @@ func destinationRoutes(l2a *nc.Layer2Attachment, data *resolver.ResolvedData) ([
 			routes = append(routes, route)
 		}
 	}
-	sort.Slice(routes, func(i, j int) bool {
-		if routes[i].To != routes[j].To {
-			return routes[i].To < routes[j].To
+	slices.SortFunc(routes, func(a, b NetplanRoute) int {
+		if byDestination := strings.Compare(a.To, b.To); byDestination != 0 {
+			return byDestination
 		}
-		return routes[i].Via < routes[j].Via
+		return strings.Compare(a.Via, b.Via)
 	})
 	return routes, nil
 }

--- a/pkg/reconciler/intent/builder/l2a_test.go
+++ b/pkg/reconciler/intent/builder/l2a_test.go
@@ -25,19 +25,58 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	networkv1alpha1 "github.com/telekom/das-schiff-network-operator/api/v1alpha1"
 	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
 	"github.com/telekom/das-schiff-network-operator/pkg/reconciler/intent/resolver"
+	"github.com/telekom/das-schiff-network-operator/pkg/vrfname"
 )
 
 func ptr[T any](v T) *T { return &v }
 
-const testInterfaceRef = "eth1"
+const (
+	testInterfaceRef       = "eth1"
+	testMultiVRFNetworkV4  = "192.0.2.0/27"
+	testMultiVRFDestAV4    = "198.51.100.0/24"
+	testMultiVRFDestBV4    = "203.0.113.0/24"
+	testMultiVRFNetwork    = "workload-segment"
+	testMultiVRFDestA      = "destination-a"
+	testMultiVRFDestB      = "destination-b"
+	testMultiVRFLabelKey   = "scope"
+	testMultiVRFLabelValue = "shared"
+	testMultiVRFEdgeA      = "edge-a"
+	testMultiVRFEdgeB      = "edge-b"
+	testMultiVRFRefA       = "edge-a-ref"
+	testMultiVRFRefB       = "edge-b-ref"
+	testWorkerA            = "worker-a"
+	testTenantA            = "tenant-a"
+	testTenantB            = "tenant-b"
+)
 
 func TestL2ABuilder_Name(t *testing.T) {
 	b := NewL2ABuilder()
 	if b.Name() != "l2a" {
 		t.Errorf("expected name 'l2a', got %q", b.Name())
 	}
+}
+
+func TestSortedLayer2Attachments(t *testing.T) {
+	items := []nc.Layer2Attachment{
+		{ObjectMeta: metav1.ObjectMeta{Namespace: testTenantB, Name: "attachment-a"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: testTenantA, Name: "attachment-b"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: testTenantA, Name: "attachment-a"}},
+	}
+
+	sorted := sortedLayer2Attachments(items)
+	assert.Equal(t, []string{
+		testTenantA + "/attachment-a",
+		testTenantA + "/attachment-b",
+		testTenantB + "/attachment-a",
+	}, []string{
+		sorted[0].Namespace + "/" + sorted[0].Name,
+		sorted[1].Namespace + "/" + sorted[1].Name,
+		sorted[2].Namespace + "/" + sorted[2].Name,
+	})
+	assert.Equal(t, testTenantB, items[0].Namespace, "sorting must not mutate resolver input")
 }
 
 func TestL2ABuilder_EmptyData(t *testing.T) {
@@ -256,6 +295,362 @@ func TestL2ABuilder_WithDestinationVRF(t *testing.T) {
 	if fvrf.VNI != 5001 {
 		t.Errorf("expected FabricVRF VNI 5001, got %d", fvrf.VNI)
 	}
+}
+
+func TestL2ABuilder_MultipleDestinationVRFsUseComboVRF(t *testing.T) {
+	b := NewL2ABuilder()
+
+	edgeASpec := &nc.VRFSpec{VRF: testMultiVRFEdgeA, VNI: ptr(int32(5101)), RouteTarget: ptr("64512:5101")}
+	edgeBSpec := &nc.VRFSpec{VRF: testMultiVRFEdgeB, VNI: ptr(int32(5102)), RouteTarget: ptr("64512:5102")}
+	data := &resolver.ResolvedData{
+		Nodes: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: testWorkerA}}},
+		Networks: map[string]*resolver.ResolvedNetwork{
+			testMultiVRFNetwork: {
+				Name: testMultiVRFNetwork,
+				Spec: nc.NetworkSpec{
+					VLAN: ptr(int32(210)),
+					VNI:  ptr(int32(30210)),
+					IPv4: &nc.IPNetwork{CIDR: testMultiVRFNetworkV4},
+					IPv6: &nc.IPNetwork{CIDR: "2001:db8:100::/64"},
+				},
+			},
+		},
+		VRFs: map[string]*resolver.ResolvedVRF{
+			testMultiVRFRefA: {Name: testMultiVRFRefA, Spec: *edgeASpec},
+			testMultiVRFRefB: {Name: testMultiVRFRefB, Spec: *edgeBSpec},
+		},
+		Destinations: map[string]*resolver.ResolvedDestination{
+			testMultiVRFDestA: {
+				Name:    testMultiVRFDestA,
+				Spec:    nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefA), Prefixes: []string{testMultiVRFDestAV4, "2001:db8:200::/48"}},
+				VRFSpec: edgeASpec,
+			},
+			testMultiVRFDestB: {
+				Name:    testMultiVRFDestB,
+				Spec:    nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefB), Prefixes: []string{testMultiVRFDestBV4, "2001:db8:300::/48"}},
+				VRFSpec: edgeBSpec,
+			},
+		},
+		// Reverse order verifies that combo naming and routes do not depend on
+		// Kubernetes list order.
+		RawDestinations: []nc.Destination{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: testMultiVRFDestB, Labels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+				Spec:       nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefB), Prefixes: []string{testMultiVRFDestBV4, "2001:db8:300::/48"}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: testMultiVRFDestA, Labels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+				Spec:       nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefA), Prefixes: []string{testMultiVRFDestAV4, "2001:db8:200::/48"}},
+			},
+		},
+		Layer2Attachments: []nc.Layer2Attachment{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "shared-segment"},
+				Spec: nc.Layer2AttachmentSpec{
+					NetworkRef:   testMultiVRFNetwork,
+					Destinations: &metav1.LabelSelector{MatchLabels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+				},
+			},
+		},
+		AnnouncementPolicies: []nc.AnnouncementPolicy{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "edge-a-policy"},
+				Spec: nc.AnnouncementPolicySpec{
+					VRFRef: testMultiVRFRefA,
+					Aggregate: &nc.AggregateConfig{
+						PrefixLengthV4: ptr(int32(28)),
+						PrefixLengthV6: ptr(int32(80)),
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "edge-b-policy"},
+				Spec: nc.AnnouncementPolicySpec{
+					VRFRef: testMultiVRFRefB,
+					Aggregate: &nc.AggregateConfig{
+						PrefixLengthV4: ptr(int32(28)),
+						PrefixLengthV6: ptr(int32(80)),
+					},
+				},
+			},
+		},
+	}
+
+	result, err := b.Build(context.Background(), data)
+	require.NoError(t, err)
+
+	contrib := result[testWorkerA]
+	require.NotNil(t, contrib)
+
+	comboName := vrfname.L2AName(testMultiVRFDestA + "+" + testMultiVRFDestB)
+	layer2 := contrib.Layer2s["210"]
+	require.NotNil(t, layer2.IRB)
+	assert.Equal(t, comboName, layer2.IRB.VRF)
+	assert.Empty(t, contrib.ClusterVRF, "directly attached combo VRF must not require policy routing")
+
+	combo, ok := contrib.LocalVRFs[comboName]
+	require.True(t, ok)
+	require.Len(t, combo.StaticRoutes, 4)
+	assertVRFRoute(t, combo.StaticRoutes, testMultiVRFDestAV4, testMultiVRFEdgeA)
+	assertVRFRoute(t, combo.StaticRoutes, "2001:db8:200::/48", testMultiVRFEdgeA)
+	assertVRFRoute(t, combo.StaticRoutes, testMultiVRFDestBV4, testMultiVRFEdgeB)
+	assertVRFRoute(t, combo.StaticRoutes, "2001:db8:300::/48", testMultiVRFEdgeB)
+
+	for _, vrfName := range []string{testMultiVRFEdgeA, testMultiVRFEdgeB} {
+		fabric, ok := contrib.FabricVRFs[vrfName]
+		require.True(t, ok)
+		assertVRFRoute(t, fabric.StaticRoutes, testMultiVRFNetworkV4, comboName)
+		assertVRFRoute(t, fabric.StaticRoutes, "2001:db8:100::/64", comboName)
+		assertVRFRoute(t, fabric.StaticRoutes, "192.0.2.0/28", comboName)
+		assertVRFRoute(t, fabric.StaticRoutes, "2001:db8:100::/80", comboName)
+		assertNoBlackholeRoute(t, fabric.StaticRoutes, "192.0.2.0/28")
+		assertNoBlackholeRoute(t, fabric.StaticRoutes, "2001:db8:100::/80")
+		assertFilterPrefix(t, fabric.EVPNExportFilter, testMultiVRFNetworkV4)
+		assertFilterPrefix(t, fabric.EVPNExportFilter, "2001:db8:100::/64")
+		require.Len(t, fabric.VRFImports, 1)
+		assert.Empty(t, fabric.VRFImports[0].Filter.Items, "multi-VRF network must return through the combo VRF, not cluster")
+	}
+}
+
+func TestAddNetworkRoutesToVRFReplacesBlackhole(t *testing.T) {
+	fvrf := networkv1alpha1.FabricVRF{
+		VRF: networkv1alpha1.VRF{
+			StaticRoutes: []networkv1alpha1.StaticRoute{{Prefix: testMultiVRFNetworkV4}},
+		},
+	}
+	net := &resolver.ResolvedNetwork{
+		Spec: nc.NetworkSpec{IPv4: &nc.IPNetwork{CIDR: testMultiVRFNetworkV4}},
+	}
+
+	addNetworkRoutesToVRF(&fvrf, net, "combo")
+
+	require.Len(t, fvrf.StaticRoutes, 1)
+	assertVRFRoute(t, fvrf.StaticRoutes, testMultiVRFNetworkV4, "combo")
+}
+
+func TestMultiVRFRouteClaimsRejectConflictingNextHop(t *testing.T) {
+	routing := &l2aVRFRouting{
+		irbVRF: "l-second",
+		vrfSpecs: map[string]*nc.VRFSpec{
+			testMultiVRFEdgeA: {VRF: testMultiVRFEdgeA},
+			testMultiVRFEdgeB: {VRF: testMultiVRFEdgeB},
+		},
+	}
+	validated := &validatedL2A{
+		matchingNodes: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: testWorkerA}}},
+		aps:           map[string]*nc.AnnouncementPolicy{},
+	}
+	net := &resolver.ResolvedNetwork{
+		Spec: nc.NetworkSpec{IPv4: &nc.IPNetwork{CIDR: testMultiVRFNetworkV4}},
+	}
+	owners := map[string]staticRouteOwner{
+		testWorkerA + "\x00" + testMultiVRFEdgeA + "\x00" + testMultiVRFNetworkV4: {
+			l2a:     "first-attachment",
+			nextVRF: "l-first",
+		},
+	}
+
+	_, err := multiVRFRouteClaims(
+		&nc.Layer2Attachment{ObjectMeta: metav1.ObjectMeta{Name: "second-attachment"}},
+		net,
+		routing,
+		validated,
+		owners,
+	)
+	require.Error(t, err)
+	assert.Equal(t, reasonConflictingStaticRoute, skipReason(err))
+	assert.Contains(t, err.Error(), "first-attachment")
+	assert.Contains(t, err.Error(), "second-attachment")
+}
+
+func TestL2ABuilder_MultipleDestinationVRFsRequireIRB(t *testing.T) {
+	edgeASpec := &nc.VRFSpec{VRF: testMultiVRFEdgeA, VNI: ptr(int32(5101)), RouteTarget: ptr("64512:5101")}
+	edgeBSpec := &nc.VRFSpec{VRF: testMultiVRFEdgeB, VNI: ptr(int32(5102)), RouteTarget: ptr("64512:5102")}
+
+	tests := []struct {
+		name           string
+		vni            *int32
+		disableAnycast *bool
+		interfaceRef   *string
+		sriov          *nc.SRIOVConfig
+	}{
+		{name: "anycast disabled", vni: ptr(int32(30211)), disableAnycast: ptr(true)},
+		{name: "pure L2 network", interfaceRef: ptr(testInterfaceRef)},
+		{name: "SR-IOV attachment", vni: ptr(int32(30211)), sriov: &nc.SRIOVConfig{Enabled: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := &resolver.ResolvedData{
+				Nodes: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: testWorkerA}}},
+				Networks: map[string]*resolver.ResolvedNetwork{
+					testMultiVRFNetwork: {
+						Name: testMultiVRFNetwork,
+						Spec: nc.NetworkSpec{
+							VLAN: ptr(int32(211)),
+							VNI:  tt.vni,
+							IPv4: &nc.IPNetwork{CIDR: testMultiVRFNetworkV4},
+						},
+					},
+				},
+				Destinations: map[string]*resolver.ResolvedDestination{
+					testMultiVRFDestA: {
+						Name:    testMultiVRFDestA,
+						Spec:    nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefA), Prefixes: []string{testMultiVRFDestAV4}},
+						VRFSpec: edgeASpec,
+					},
+					testMultiVRFDestB: {
+						Name:    testMultiVRFDestB,
+						Spec:    nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefB), Prefixes: []string{testMultiVRFDestBV4}},
+						VRFSpec: edgeBSpec,
+					},
+				},
+				RawDestinations: []nc.Destination{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: testMultiVRFDestA, Labels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+						Spec:       nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefA), Prefixes: []string{testMultiVRFDestAV4}},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: testMultiVRFDestB, Labels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+						Spec:       nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefB), Prefixes: []string{testMultiVRFDestBV4}},
+					},
+				},
+				Layer2Attachments: []nc.Layer2Attachment{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "shared-segment"},
+						Spec: nc.Layer2AttachmentSpec{
+							NetworkRef:     testMultiVRFNetwork,
+							DisableAnycast: tt.disableAnycast,
+							InterfaceRef:   tt.interfaceRef,
+							SRIOV:          tt.sriov,
+							Destinations:   &metav1.LabelSelector{MatchLabels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+						},
+					},
+				},
+			}
+
+			report := NewBuildReport()
+			result, err := NewL2ABuilder().Build(WithReport(context.Background(), report), data)
+			require.NoError(t, err)
+			assert.Empty(t, result, "invalid multi-VRF attachment must not leave partial routing")
+			require.Len(t, report.Issues(), 1)
+			assert.Equal(t, reasonMultiVRFRequiresIRB, report.Issues()[0].Reason)
+		})
+	}
+}
+
+func TestL2ABuilder_MultipleDestinationVRFsRejectAmbiguousPrefix(t *testing.T) {
+	b := NewL2ABuilder()
+	sharedPrefix := testMultiVRFDestAV4
+	data := &resolver.ResolvedData{
+		Destinations: map[string]*resolver.ResolvedDestination{
+			testMultiVRFDestA: {
+				Name:    testMultiVRFDestA,
+				Spec:    nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefA), Prefixes: []string{sharedPrefix}},
+				VRFSpec: &nc.VRFSpec{VRF: testMultiVRFEdgeA},
+			},
+			testMultiVRFDestB: {
+				Name:    testMultiVRFDestB,
+				Spec:    nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefB), Prefixes: []string{"198.51.100.1/24"}},
+				VRFSpec: &nc.VRFSpec{VRF: testMultiVRFEdgeB},
+			},
+		},
+		RawDestinations: []nc.Destination{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: testMultiVRFDestA, Labels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+				Spec:       nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefA), Prefixes: []string{sharedPrefix}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: testMultiVRFDestB, Labels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+				Spec:       nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefB), Prefixes: []string{"198.51.100.1/24"}},
+			},
+		},
+	}
+	l2a := &nc.Layer2Attachment{
+		Spec: nc.Layer2AttachmentSpec{
+			Destinations: &metav1.LabelSelector{MatchLabels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+		},
+	}
+
+	_, err := b.resolveDestinationVRFs(l2a, data)
+	require.ErrorContains(t, err, `destination prefix "198.51.100.0/24" is assigned to multiple VRFs`)
+}
+
+func TestL2ABuilder_MultipleDestinationVRFsRejectNameCollision(t *testing.T) {
+	comboName := vrfname.L2AName(testMultiVRFDestA + "+" + testMultiVRFDestB)
+	collidingFabricName := comboName[:3] + "a" + comboName[3:]
+	require.Equal(t, comboName, vrfname.Reduce(collidingFabricName))
+	edgeASpec := &nc.VRFSpec{VRF: testMultiVRFEdgeA}
+	edgeBSpec := &nc.VRFSpec{VRF: testMultiVRFEdgeB}
+	data := &resolver.ResolvedData{
+		VRFs: map[string]*resolver.ResolvedVRF{
+			"colliding-vrf": {Name: "colliding-vrf", Spec: nc.VRFSpec{VRF: collidingFabricName}},
+		},
+		Destinations: map[string]*resolver.ResolvedDestination{
+			testMultiVRFDestA: {
+				Name:    testMultiVRFDestA,
+				Spec:    nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefA)},
+				VRFSpec: edgeASpec,
+			},
+			testMultiVRFDestB: {
+				Name:    testMultiVRFDestB,
+				Spec:    nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefB)},
+				VRFSpec: edgeBSpec,
+			},
+		},
+		RawDestinations: []nc.Destination{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: testMultiVRFDestA, Labels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+				Spec:       nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefA)},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: testMultiVRFDestB, Labels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+				Spec:       nc.DestinationSpec{VRFRef: ptr(testMultiVRFRefB)},
+			},
+		},
+	}
+	l2a := &nc.Layer2Attachment{
+		Spec: nc.Layer2AttachmentSpec{
+			Destinations: &metav1.LabelSelector{MatchLabels: map[string]string{testMultiVRFLabelKey: testMultiVRFLabelValue}},
+		},
+	}
+
+	_, err := NewL2ABuilder().resolveDestinationVRFs(l2a, data)
+	require.ErrorContains(t, err, `collides with FabricVRF "colliding-vrf" after name reduction`)
+	assert.Equal(t, reasonIntermediateVRFNameCollision, skipReason(err))
+}
+
+func assertVRFRoute(t *testing.T, routes []networkv1alpha1.StaticRoute, prefix, vrf string) {
+	t.Helper()
+	for i := range routes {
+		if routes[i].Prefix != prefix || routes[i].NextHop == nil || routes[i].NextHop.Vrf == nil {
+			continue
+		}
+		if *routes[i].NextHop.Vrf == vrf {
+			return
+		}
+	}
+	t.Errorf("expected route %s via VRF %s, got %#v", prefix, vrf, routes)
+}
+
+func assertNoBlackholeRoute(t *testing.T, routes []networkv1alpha1.StaticRoute, prefix string) {
+	t.Helper()
+	for i := range routes {
+		if routes[i].Prefix == prefix && routes[i].NextHop == nil {
+			t.Errorf("unexpected blackhole route %s, got %#v", prefix, routes)
+		}
+	}
+}
+
+func assertFilterPrefix(t *testing.T, filter *networkv1alpha1.Filter, prefix string) {
+	t.Helper()
+	require.NotNil(t, filter)
+	for i := range filter.Items {
+		if filter.Items[i].Matcher.Prefix != nil && filter.Items[i].Matcher.Prefix.Prefix == prefix {
+			return
+		}
+	}
+	t.Errorf("expected filter prefix %s, got %#v", prefix, filter.Items)
 }
 
 func TestL2ABuilder_RejectsSharedL2L3RouteTarget(t *testing.T) {
@@ -561,6 +956,44 @@ func TestL2ABuilder_DuplicateInterfaceNameOnSameNode(t *testing.T) {
 	if _, ok := contrib.Layer2s["502"]; ok {
 		t.Error("expected conflicting L2A (VLAN 502) to be skipped")
 	}
+}
+
+func TestL2ABuilder_OwnershipConflictIdentifiesNamespaces(t *testing.T) {
+	b := NewL2ABuilder()
+	const (
+		networkName  = "net"
+		networkACIDR = "10.0.1.0/24"
+		networkBCIDR = "10.0.2.0/24"
+	)
+	ifName := "shared-interface"
+	data := &resolver.ResolvedData{
+		Nodes: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}},
+		NetworksByKey: map[string]*resolver.ResolvedNetwork{
+			resolver.NamespacedKey(testTenantA, networkName): {
+				Namespace: testTenantA,
+				Name:      networkName,
+				Spec:      nc.NetworkSpec{VLAN: ptr(int32(501)), VNI: ptr(int32(10501)), IPv4: &nc.IPNetwork{CIDR: networkACIDR}},
+			},
+			resolver.NamespacedKey(testTenantB, networkName): {
+				Namespace: testTenantB,
+				Name:      networkName,
+				Spec:      nc.NetworkSpec{VLAN: ptr(int32(502)), VNI: ptr(int32(10502)), IPv4: &nc.IPNetwork{CIDR: networkBCIDR}},
+			},
+		},
+		Layer2Attachments: []nc.Layer2Attachment{
+			{ObjectMeta: metav1.ObjectMeta{Namespace: testTenantA, Name: "attachment"}, Spec: nc.Layer2AttachmentSpec{NetworkRef: networkName, InterfaceName: &ifName}},
+			{ObjectMeta: metav1.ObjectMeta{Namespace: testTenantB, Name: "attachment"}, Spec: nc.Layer2AttachmentSpec{NetworkRef: networkName, InterfaceName: &ifName}},
+		},
+	}
+
+	report := NewBuildReport()
+	_, err := b.Build(WithReport(context.Background(), report), data)
+	require.NoError(t, err)
+	issues := report.Issues()
+	require.Len(t, issues, 1)
+	assert.Equal(t, testTenantB, issues[0].Namespace)
+	assert.Contains(t, issues[0].Message, testTenantA+"/attachment")
+	assert.Contains(t, issues[0].Message, testTenantB+"/attachment")
 }
 
 func TestL2ABuilder_DefaultVLANNameConflictsWithInterfaceName(t *testing.T) {

--- a/pkg/reconciler/intent/builder/mirror.go
+++ b/pkg/reconciler/intent/builder/mirror.go
@@ -63,7 +63,7 @@ func (b *MirrorBuilder) Build(ctx context.Context, data *resolver.ResolvedData) 
 		tm := &data.TrafficMirrors[i]
 
 		// Resolve collector.
-		col, err := b.resolveCollector(tm.Spec.Collector, data)
+		col, err := b.resolveCollector(tm.Namespace, tm.Spec.Collector, data)
 		if err != nil {
 			logger.Info("skipping TrafficMirror with unresolvable collector",
 				"trafficmirror", tm.Name, "error", err.Error())
@@ -140,20 +140,20 @@ func mirrorDirections(direction string) []networkv1alpha1.MirrorDirection {
 func (b *MirrorBuilder) attachToSource(tm *nc.TrafficMirror, acl *networkv1alpha1.MirrorACL, data *resolver.ResolvedData, result map[string]*NodeContribution) error {
 	switch tm.Spec.Source.Kind {
 	case mirrorSourceLayer2Attachment:
-		return b.addToLayer2(tm.Spec.Source.Name, acl, data, result)
+		return b.addToLayer2(tm.Namespace, tm.Spec.Source.Name, acl, data, result)
 	case mirrorSourceInbound:
-		return b.addToInboundVRF(tm.Spec.Source.Name, acl, data, result)
+		return b.addToInboundVRF(tm.Namespace, tm.Spec.Source.Name, acl, data, result)
 	case mirrorSourceOutbound:
-		return b.addToOutboundVRF(tm.Spec.Source.Name, acl, data, result)
+		return b.addToOutboundVRF(tm.Namespace, tm.Spec.Source.Name, acl, data, result)
 	default:
 		return fmt.Errorf("unknown source kind %q", tm.Spec.Source.Kind)
 	}
 }
 
 // resolveCollector finds a Collector by name.
-func (*MirrorBuilder) resolveCollector(name string, data *resolver.ResolvedData) (*nc.Collector, error) {
+func (*MirrorBuilder) resolveCollector(namespace, name string, data *resolver.ResolvedData) (*nc.Collector, error) {
 	for i := range data.Collectors {
-		if data.Collectors[i].Name == name {
+		if data.Collectors[i].Namespace == namespace && data.Collectors[i].Name == name {
 			return &data.Collectors[i], nil
 		}
 	}
@@ -183,11 +183,17 @@ func (*MirrorBuilder) convertTrafficMatch(tm *nc.TrafficMatch) networkv1alpha1.T
 }
 
 // addToLayer2 adds MirrorACL to a Layer2 entry identified by L2A name on all nodes.
-func (*MirrorBuilder) addToLayer2(l2aName string, acl *networkv1alpha1.MirrorACL, data *resolver.ResolvedData, result map[string]*NodeContribution) error {
+func (*MirrorBuilder) addToLayer2(
+	namespace,
+	l2aName string,
+	acl *networkv1alpha1.MirrorACL,
+	data *resolver.ResolvedData,
+	result map[string]*NodeContribution,
+) error {
 	// Find the L2A.
 	var l2a *nc.Layer2Attachment
 	for j := range data.Layer2Attachments {
-		if data.Layer2Attachments[j].Name == l2aName {
+		if data.Layer2Attachments[j].Namespace == namespace && data.Layer2Attachments[j].Name == l2aName {
 			l2a = &data.Layer2Attachments[j]
 			break
 		}
@@ -197,7 +203,7 @@ func (*MirrorBuilder) addToLayer2(l2aName string, acl *networkv1alpha1.MirrorACL
 	}
 
 	// Resolve Network to get the VLAN for the map key.
-	net, ok := data.Networks[l2a.Spec.NetworkRef]
+	net, ok := data.Network(namespace, l2a.Spec.NetworkRef)
 	if !ok {
 		return fmt.Errorf("Layer2Attachment %q references unknown Network %q", l2a.Name, l2a.Spec.NetworkRef)
 	}
@@ -238,8 +244,8 @@ func (*MirrorBuilder) addToLayer2(l2aName string, acl *networkv1alpha1.MirrorACL
 // addToInboundVRF adds MirrorACL to every VRF associated with an Inbound's
 // Destinations selector, on all nodes. When the selector matches multiple
 // Destinations across different VRFs, the ACL is fanned out to each VRF.
-func (b *MirrorBuilder) addToInboundVRF(ibName string, acl *networkv1alpha1.MirrorACL, data *resolver.ResolvedData, result map[string]*NodeContribution) error {
-	vrfs, err := b.resolveInboundVRFs(ibName, data)
+func (b *MirrorBuilder) addToInboundVRF(namespace, ibName string, acl *networkv1alpha1.MirrorACL, data *resolver.ResolvedData, result map[string]*NodeContribution) error {
+	vrfs, err := b.resolveInboundVRFs(namespace, ibName, data)
 	if err != nil {
 		return err
 	}
@@ -252,8 +258,8 @@ func (b *MirrorBuilder) addToInboundVRF(ibName string, acl *networkv1alpha1.Mirr
 
 // addToOutboundVRF adds MirrorACL to every VRF associated with an Outbound's
 // Destinations selector, on all nodes.
-func (b *MirrorBuilder) addToOutboundVRF(obName string, acl *networkv1alpha1.MirrorACL, data *resolver.ResolvedData, result map[string]*NodeContribution) error {
-	vrfs, err := b.resolveOutboundVRFs(obName, data)
+func (b *MirrorBuilder) addToOutboundVRF(namespace, obName string, acl *networkv1alpha1.MirrorACL, data *resolver.ResolvedData, result map[string]*NodeContribution) error {
+	vrfs, err := b.resolveOutboundVRFs(namespace, obName, data)
 	if err != nil {
 		return err
 	}
@@ -295,32 +301,32 @@ func (*MirrorBuilder) applyMirrorACLToVRFs(vrfs map[string]*nc.VRFSpec, acl *net
 // resolveInboundVRFs returns every VRF (name → spec) matched by the Inbound's
 // Destinations selector. An empty map means the Inbound has no Destinations,
 // which is valid (consumer is purely informational).
-func (*MirrorBuilder) resolveInboundVRFs(name string, data *resolver.ResolvedData) (map[string]*nc.VRFSpec, error) {
+func (*MirrorBuilder) resolveInboundVRFs(namespace, name string, data *resolver.ResolvedData) (map[string]*nc.VRFSpec, error) {
 	for i := range data.Inbounds {
-		if data.Inbounds[i].Name != name {
+		if data.Inbounds[i].Namespace != namespace || data.Inbounds[i].Name != name {
 			continue
 		}
 		ib := &data.Inbounds[i]
 		if ib.Spec.Destinations == nil {
 			return nil, nil
 		}
-		return resolveSelectorVRFs(ib.Spec.Destinations, data), nil
+		return resolveSelectorVRFs(namespace, ib.Spec.Destinations, data), nil
 	}
 	return nil, fmt.Errorf("inbound %q not found", name)
 }
 
 // resolveOutboundVRFs returns every VRF (name → spec) matched by the Outbound's
 // Destinations selector.
-func (*MirrorBuilder) resolveOutboundVRFs(name string, data *resolver.ResolvedData) (map[string]*nc.VRFSpec, error) {
+func (*MirrorBuilder) resolveOutboundVRFs(namespace, name string, data *resolver.ResolvedData) (map[string]*nc.VRFSpec, error) {
 	for i := range data.Outbounds {
-		if data.Outbounds[i].Name != name {
+		if data.Outbounds[i].Namespace != namespace || data.Outbounds[i].Name != name {
 			continue
 		}
 		ob := &data.Outbounds[i]
 		if ob.Spec.Destinations == nil {
 			return nil, nil
 		}
-		return resolveSelectorVRFs(ob.Spec.Destinations, data), nil
+		return resolveSelectorVRFs(namespace, ob.Spec.Destinations, data), nil
 	}
 	return nil, fmt.Errorf("outbound %q not found", name)
 }

--- a/pkg/reconciler/intent/builder/nodeattachment.go
+++ b/pkg/reconciler/intent/builder/nodeattachment.go
@@ -52,7 +52,7 @@ func (b *NodeAttachmentBuilder) Build(ctx context.Context, data *resolver.Resolv
 		na := &data.NodeAttachments[i]
 
 		// Resolve VRF spec via destination selector (same pattern as other builders).
-		grouped := groupDestinationsByVRF(na.Spec.Destinations, data)
+		grouped := groupDestinationsByVRF(na.Namespace, na.Spec.Destinations, data)
 		if len(grouped) == 0 {
 			continue
 		}
@@ -183,7 +183,7 @@ func (*NodeAttachmentBuilder) resolveVRFSpec(vrfName string, grouped map[string]
 	if len(dests) == 0 {
 		return nil
 	}
-	resolved, ok := data.Destinations[dests[0].Name]
+	resolved, ok := data.Destination(dests[0].Namespace, dests[0].Name)
 	if !ok || resolved.VRFSpec == nil {
 		return nil
 	}

--- a/pkg/reconciler/intent/builder/outbound.go
+++ b/pkg/reconciler/intent/builder/outbound.go
@@ -50,8 +50,10 @@ func (b *OutboundBuilder) Build(ctx context.Context, data *resolver.ResolvedData
 	for i := range data.Outbounds {
 		ob := &data.Outbounds[i]
 
-		net, ok := data.Networks[ob.Spec.NetworkRef]
+		net, ok := data.Network(ob.Namespace, ob.Spec.NetworkRef)
 		if !ok {
+			reportSkip(ctx, "Outbound", ob.Namespace, ob.Name, "NetworkNotFound",
+				fmt.Sprintf("referenced Network %q not found", ob.Spec.NetworkRef))
 			continue
 		}
 
@@ -89,7 +91,7 @@ func (b *OutboundBuilder) applyOutbound(
 	data *resolver.ResolvedData,
 	result map[string]*NodeContribution,
 ) error {
-	grouped := groupDestinationsByVRF(ob.Spec.Destinations, data)
+	grouped := groupDestinationsByVRF(ob.Namespace, ob.Spec.Destinations, data)
 	if len(grouped) == 0 {
 		return nil
 	}
@@ -99,7 +101,7 @@ func (b *OutboundBuilder) applyOutbound(
 	// Validate and resolve every VRF before mutating any node contribution.
 	contribs := make([]outboundVRFContrib, 0, len(grouped))
 	for vrfName, dests := range grouped {
-		ap, err := findMatchingAP(ob.Labels, vrfName, data)
+		ap, err := findMatchingAP(ob.Namespace, ob.Labels, vrfName, data)
 		if err != nil {
 			return fmt.Errorf("outbound %q: %w", ob.Name, err)
 		}
@@ -148,7 +150,7 @@ func (*OutboundBuilder) resolveVRFSpec(dests []nc.Destination, data *resolver.Re
 	if len(dests) == 0 {
 		return nil
 	}
-	resolved, ok := data.Destinations[dests[0].Name]
+	resolved, ok := data.Destination(dests[0].Namespace, dests[0].Name)
 	if !ok || resolved.VRFSpec == nil {
 		return nil
 	}

--- a/pkg/reconciler/intent/builder/podnetwork.go
+++ b/pkg/reconciler/intent/builder/podnetwork.go
@@ -51,7 +51,7 @@ func (b *PodNetworkBuilder) Build(ctx context.Context, data *resolver.ResolvedDa
 		pn := &data.PodNetworks[i]
 
 		// Resolve the referenced Network.
-		net, ok := data.Networks[pn.Spec.NetworkRef]
+		net, ok := data.Network(pn.Namespace, pn.Spec.NetworkRef)
 		if !ok {
 			logger.Info("skipping PodNetwork with unknown Network reference",
 				"podnetwork", pn.Name, "networkRef", pn.Spec.NetworkRef)
@@ -74,7 +74,7 @@ func (b *PodNetworkBuilder) Build(ctx context.Context, data *resolver.ResolvedDa
 		}
 
 		// Resolve matching announcement policy for this PodNetwork.
-		ap, err := findMatchingAP(pn.Labels, vrfName, data)
+		ap, err := findMatchingAP(pn.Namespace, pn.Labels, vrfName, data)
 		if err != nil {
 			logger.Info("skipping PodNetwork with ambiguous announcement policy",
 				"podnetwork", pn.Name, "error", err.Error())
@@ -123,8 +123,8 @@ func (*PodNetworkBuilder) resolveDestinationVRF(pn *nc.PodNetwork, data *resolve
 
 	for i := range data.RawDestinations {
 		rawDest := &data.RawDestinations[i]
-		if selector.Matches(labels.Set(rawDest.Labels)) {
-			resolved, ok := data.Destinations[rawDest.Name]
+		if rawDest.Namespace == pn.Namespace && selector.Matches(labels.Set(rawDest.Labels)) {
+			resolved, ok := data.Destination(pn.Namespace, rawDest.Name)
 			if ok && resolved.VRFSpec != nil && resolved.Spec.VRFRef != nil {
 				return resolved.VRFSpec.VRF, resolved.VRFSpec, nil
 			}

--- a/pkg/reconciler/intent/builder/sbr.go
+++ b/pkg/reconciler/intent/builder/sbr.go
@@ -18,6 +18,9 @@ package builder
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net"
 	"sort"
 	"strings"
 
@@ -59,10 +62,27 @@ type sbrGroup struct {
 	key            string              // sorted destination names joined by "+" (dedup key)
 	vrfRoutes      map[string][]string // vrfName → destination prefixes
 	sourcePrefixes []string            // consumer source addresses that need SBR
+	consumers      []sbrConsumer
+}
+
+type sbrConsumer struct {
+	kind      string
+	namespace string
+	name      string
 }
 
 // Build produces per-node LocalVRFs and ClusterVRF PolicyRoutes for SBR.
-func (b *SBRBuilder) Build(_ context.Context, data *resolver.ResolvedData) (map[string]*NodeContribution, error) {
+func (b *SBRBuilder) Build(ctx context.Context, data *resolver.ResolvedData) (map[string]*NodeContribution, error) {
+	groups := b.collectGroups(data)
+	removeInvalidSBRGroups(ctx, groups, data)
+	if len(groups) == 0 {
+		return nil, nil
+	}
+
+	return b.buildContributions(groups, data), nil
+}
+
+func (b *SBRBuilder) collectGroups(data *resolver.ResolvedData) map[string]*sbrGroup {
 	// groups maps a VRF-set key → sbrGroup.
 	// Consumers targeting the same VRF combination share a group.
 	groups := make(map[string]*sbrGroup)
@@ -74,7 +94,7 @@ func (b *SBRBuilder) Build(_ context.Context, data *resolver.ResolvedData) (map[
 		if len(sources) == 0 {
 			continue
 		}
-		b.addConsumerToGroups(inb.Spec.Destinations, sources, data, groups)
+		b.addConsumerToGroups(sbrConsumer{mirrorSourceInbound, inb.Namespace, inb.Name}, inb.Spec.Destinations, sources, data, groups)
 	}
 
 	// Scan Outbound consumers.
@@ -84,23 +104,40 @@ func (b *SBRBuilder) Build(_ context.Context, data *resolver.ResolvedData) (map[
 		if len(sources) == 0 {
 			continue
 		}
-		b.addConsumerToGroups(outb.Spec.Destinations, sources, data, groups)
+		b.addConsumerToGroups(sbrConsumer{mirrorSourceOutbound, outb.Namespace, outb.Name}, outb.Spec.Destinations, sources, data, groups)
 	}
 
 	// Scan PodNetwork consumers.
 	for i := range data.PodNetworks {
 		pnet := &data.PodNetworks[i]
-		sources := collectPodNetworkSources(pnet, data.Networks)
+		sources := collectPodNetworkSources(pnet, data)
 		if len(sources) == 0 {
 			continue
 		}
-		b.addConsumerToGroups(pnet.Spec.Destinations, sources, data, groups)
+		b.addConsumerToGroups(sbrConsumer{"PodNetwork", pnet.Namespace, pnet.Name}, pnet.Spec.Destinations, sources, data, groups)
 	}
+	return groups
+}
 
-	if len(groups) == 0 {
-		return nil, nil
+func removeInvalidSBRGroups(ctx context.Context, groups map[string]*sbrGroup, data *resolver.ResolvedData) {
+	for key, group := range groups {
+		err := validateSBRGroup(group, data)
+		if err == nil {
+			continue
+		}
+		reason := "ConflictingStaticRoute"
+		var skipErr *skipReasonError
+		if errors.As(err, &skipErr) {
+			reason = skipErr.reason
+		}
+		for _, consumer := range group.consumers {
+			reportSkip(ctx, consumer.kind, consumer.namespace, consumer.name, reason, err.Error())
+		}
+		delete(groups, key)
 	}
+}
 
+func (b *SBRBuilder) buildContributions(groups map[string]*sbrGroup, data *resolver.ResolvedData) map[string]*NodeContribution {
 	// Build per-node contributions.
 	result := make(map[string]*NodeContribution)
 	for i := range data.Nodes {
@@ -143,7 +180,7 @@ func (b *SBRBuilder) Build(_ context.Context, data *resolver.ResolvedData) (map[
 		}
 	}
 
-	return result, nil
+	return result
 }
 
 // addConsumerToGroups resolves a consumer's destination selector and adds its
@@ -153,6 +190,7 @@ func (b *SBRBuilder) Build(_ context.Context, data *resolver.ResolvedData) (map[
 // Multi-VRF consumers get a combo group keyed by sorted destination names → "s-<hash>".
 // Two consumers selecting the same destinations share the same combo group.
 func (*SBRBuilder) addConsumerToGroups(
+	consumer sbrConsumer,
 	destSelector *metav1.LabelSelector,
 	sourcePrefixes []string,
 	data *resolver.ResolvedData,
@@ -162,7 +200,7 @@ func (*SBRBuilder) addConsumerToGroups(
 		return
 	}
 
-	grouped := groupDestinationsByVRF(destSelector, data)
+	grouped := groupDestinationsByVRF(consumer.namespace, destSelector, data)
 	if len(grouped) == 0 {
 		return
 	}
@@ -179,6 +217,7 @@ func (*SBRBuilder) addConsumerToGroups(
 				groups[vrfName] = group
 			}
 			group.sourcePrefixes = appendUnique(group.sourcePrefixes, sourcePrefixes...)
+			group.consumers = appendUniqueSBRConsumer(group.consumers, consumer)
 			for di := range dests {
 				group.vrfRoutes[vrfName] = appendUnique(group.vrfRoutes[vrfName], dests[di].Spec.Prefixes...)
 			}
@@ -188,7 +227,7 @@ func (*SBRBuilder) addConsumerToGroups(
 
 	// Multi-VRF — key by sorted destination names so consumers selecting the
 	// same set of destinations share a single combo VRF.
-	key := destinationSetKey(destSelector, data)
+	key := destinationSetKey(consumer.namespace, destSelector, data)
 	group, ok := groups[key]
 	if !ok {
 		group = &sbrGroup{
@@ -199,6 +238,7 @@ func (*SBRBuilder) addConsumerToGroups(
 	}
 
 	group.sourcePrefixes = appendUnique(group.sourcePrefixes, sourcePrefixes...)
+	group.consumers = appendUniqueSBRConsumer(group.consumers, consumer)
 	for vrfName, dests := range grouped {
 		for di := range dests {
 			group.vrfRoutes[vrfName] = appendUnique(group.vrfRoutes[vrfName], dests[di].Spec.Prefixes...)
@@ -206,17 +246,49 @@ func (*SBRBuilder) addConsumerToGroups(
 	}
 }
 
+func appendUniqueSBRConsumer(consumers []sbrConsumer, consumer sbrConsumer) []sbrConsumer {
+	for i := range consumers {
+		if consumers[i] == consumer {
+			return consumers
+		}
+	}
+	return append(consumers, consumer)
+}
+
+func validateSBRGroup(group *sbrGroup, data *resolver.ResolvedData) error {
+	if err := validateIntermediateVRFName(intermediateVRFName(group), data); err != nil {
+		return err
+	}
+	prefixVRFs := make(map[string]string)
+	for vrfName, prefixes := range group.vrfRoutes {
+		for _, prefix := range prefixes {
+			_, network, err := net.ParseCIDR(prefix)
+			if err != nil {
+				return fmt.Errorf("invalid destination prefix %q: %w", prefix, err)
+			}
+			canonical := network.String()
+			if existingVRF, exists := prefixVRFs[canonical]; exists && existingVRF != vrfName {
+				return fmt.Errorf("destination prefix %q is assigned to multiple VRFs %q and %q",
+					canonical, existingVRF, vrfName)
+			}
+			prefixVRFs[canonical] = vrfName
+		}
+	}
+	return nil
+}
+
 // destinationSetKey produces a deterministic key from the sorted names of all
 // Destination resources matched by a selector.
-func destinationSetKey(sel *metav1.LabelSelector, data *resolver.ResolvedData) string {
+func destinationSetKey(namespace string, sel *metav1.LabelSelector, data *resolver.ResolvedData) string {
 	selector, err := metav1.LabelSelectorAsSelector(sel)
 	if err != nil {
 		return ""
 	}
 	var names []string
 	for i := range data.RawDestinations {
-		if selector.Matches(labels.Set(data.RawDestinations[i].Labels)) {
-			names = append(names, data.RawDestinations[i].Name)
+		if data.RawDestinations[i].Namespace == namespace &&
+			selector.Matches(labels.Set(data.RawDestinations[i].Labels)) {
+			names = append(names, layer2AttachmentDisplayName(namespace, data.RawDestinations[i].Name))
 		}
 	}
 	sort.Strings(names)
@@ -238,7 +310,7 @@ func (*SBRBuilder) buildComboVRF(group *sbrGroup) networkv1alpha1.VRF {
 	vrf := networkv1alpha1.VRF{
 		VRFImports: []networkv1alpha1.VRFImport{
 			{
-				FromVRF: "cluster",
+				FromVRF: clusterVRFName,
 				Filter: networkv1alpha1.Filter{
 					DefaultAction: networkv1alpha1.Action{
 						Type: networkv1alpha1.Accept,
@@ -281,18 +353,18 @@ func collectOutboundSources(outb *nc.Outbound) []string {
 }
 
 // collectPodNetworkSources extracts source CIDRs from a PodNetwork's referenced Network.
-func collectPodNetworkSources(pnet *nc.PodNetwork, networks map[string]*resolver.ResolvedNetwork) []string {
-	net, ok := networks[pnet.Spec.NetworkRef]
+func collectPodNetworkSources(pnet *nc.PodNetwork, data *resolver.ResolvedData) []string {
+	network, ok := data.Network(pnet.Namespace, pnet.Spec.NetworkRef)
 	if !ok {
 		return nil
 	}
 
 	var sources []string
-	if net.Spec.IPv4 != nil {
-		sources = append(sources, net.Spec.IPv4.CIDR)
+	if network.Spec.IPv4 != nil {
+		sources = append(sources, network.Spec.IPv4.CIDR)
 	}
-	if net.Spec.IPv6 != nil {
-		sources = append(sources, net.Spec.IPv6.CIDR)
+	if network.Spec.IPv6 != nil {
+		sources = append(sources, network.Spec.IPv6.CIDR)
 	}
 	return sources
 }

--- a/pkg/reconciler/intent/builder/sbr_test.go
+++ b/pkg/reconciler/intent/builder/sbr_test.go
@@ -111,6 +111,58 @@ func TestSBRBuilder_BasicOutbound(t *testing.T) {
 	assert.Equal(t, vrfname.SBRName("internet"), *pr.NextHop.Vrf)
 }
 
+func TestSBRBuilder_ReportsConflictingDestinationPrefixes(t *testing.T) {
+	const otherVRF = "other"
+	data := baseSBRData()
+	otherRef := "other-vrf"
+	data.Destinations["other-dest"] = &resolver.ResolvedDestination{
+		Name:    "other-dest",
+		Spec:    nc.DestinationSpec{VRFRef: &otherRef, Prefixes: []string{"0.0.0.0/0"}},
+		VRFSpec: &nc.VRFSpec{VRF: otherVRF, VNI: ptrInt32(1001)},
+	}
+	data.RawDestinations = append(data.RawDestinations, nc.Destination{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-dest", Labels: map[string]string{"role": "external"}},
+		Spec:       nc.DestinationSpec{VRFRef: &otherRef, Prefixes: []string{"0.0.0.0/0"}},
+	})
+	data.Outbounds = []nc.Outbound{{
+		ObjectMeta: metav1.ObjectMeta{Name: "egress"},
+		Spec: nc.OutboundSpec{
+			Addresses:    &nc.AddressAllocation{IPv4: []string{"198.51.100.10"}},
+			Destinations: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "external"}},
+		},
+	}}
+
+	report := NewBuildReport()
+	result, err := NewSBRBuilder().Build(WithReport(context.Background(), report), data)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+	require.Len(t, report.Issues(), 1)
+	assert.Equal(t, "ConflictingStaticRoute", report.Issues()[0].Reason)
+}
+
+func TestSBRBuilder_ReportsIntermediateVRFNameCollision(t *testing.T) {
+	data := baseSBRData()
+	comboName := vrfname.SBRName("internet")
+	data.VRFs["collision"] = &resolver.ResolvedVRF{
+		Name: "collision",
+		Spec: nc.VRFSpec{VRF: comboName},
+	}
+	data.Outbounds = []nc.Outbound{{
+		ObjectMeta: metav1.ObjectMeta{Name: "egress"},
+		Spec: nc.OutboundSpec{
+			Addresses:    &nc.AddressAllocation{IPv4: []string{"198.51.100.10"}},
+			Destinations: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "external"}},
+		},
+	}}
+
+	report := NewBuildReport()
+	result, err := NewSBRBuilder().Build(WithReport(context.Background(), report), data)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+	require.Len(t, report.Issues(), 1)
+	assert.Equal(t, reasonIntermediateVRFNameCollision, report.Issues()[0].Reason)
+}
+
 func TestSBRBuilder_InboundWithStatusAddresses(t *testing.T) {
 	data := baseSBRData()
 	data.Inbounds = []nc.Inbound{

--- a/pkg/reconciler/intent/finalizer/finalizer.go
+++ b/pkg/reconciler/intent/finalizer/finalizer.go
@@ -67,13 +67,13 @@ func (m *Manager) reconcileVRFFinalizers(ctx context.Context, fetched *resolver.
 	referencedVRFs := make(map[string]bool)
 	for i := range fetched.Destinations {
 		if fetched.Destinations[i].Spec.VRFRef != nil {
-			referencedVRFs[*fetched.Destinations[i].Spec.VRFRef] = true
+			referencedVRFs[resolver.NamespacedKey(fetched.Destinations[i].Namespace, *fetched.Destinations[i].Spec.VRFRef)] = true
 		}
 	}
 
 	for i := range fetched.AllVRFs {
 		vrf := &fetched.AllVRFs[i]
-		if referencedVRFs[vrf.Name] {
+		if referencedVRFs[resolver.NamespacedKey(vrf.Namespace, vrf.Name)] {
 			if !controllerutil.ContainsFinalizer(vrf, nc.FinalizerVRFInUse) {
 				controllerutil.AddFinalizer(vrf, nc.FinalizerVRFInUse)
 				if err := m.client.Update(ctx, vrf); err != nil {
@@ -100,21 +100,21 @@ func (m *Manager) reconcileNetworkFinalizers(ctx context.Context, fetched *resol
 	referencedNetworks := make(map[string]bool)
 
 	for i := range fetched.Layer2Attachments {
-		referencedNetworks[fetched.Layer2Attachments[i].Spec.NetworkRef] = true
+		referencedNetworks[resolver.NamespacedKey(fetched.Layer2Attachments[i].Namespace, fetched.Layer2Attachments[i].Spec.NetworkRef)] = true
 	}
 	for i := range fetched.Inbounds {
-		referencedNetworks[fetched.Inbounds[i].Spec.NetworkRef] = true
+		referencedNetworks[resolver.NamespacedKey(fetched.Inbounds[i].Namespace, fetched.Inbounds[i].Spec.NetworkRef)] = true
 	}
 	for i := range fetched.Outbounds {
-		referencedNetworks[fetched.Outbounds[i].Spec.NetworkRef] = true
+		referencedNetworks[resolver.NamespacedKey(fetched.Outbounds[i].Namespace, fetched.Outbounds[i].Spec.NetworkRef)] = true
 	}
 	for i := range fetched.PodNetworks {
-		referencedNetworks[fetched.PodNetworks[i].Spec.NetworkRef] = true
+		referencedNetworks[resolver.NamespacedKey(fetched.PodNetworks[i].Namespace, fetched.PodNetworks[i].Spec.NetworkRef)] = true
 	}
 
 	for i := range fetched.AllNetworks {
 		net := &fetched.AllNetworks[i]
-		if referencedNetworks[net.Name] {
+		if referencedNetworks[resolver.NamespacedKey(net.Namespace, net.Name)] {
 			if !controllerutil.ContainsFinalizer(net, nc.FinalizerNetworkInUse) {
 				controllerutil.AddFinalizer(net, nc.FinalizerNetworkInUse)
 				if err := m.client.Update(ctx, net); err != nil {
@@ -142,7 +142,7 @@ func (m *Manager) reconcileDestinationFinalizers(ctx context.Context, fetched *r
 
 	for i := range fetched.AllDestinations {
 		dest := &fetched.AllDestinations[i]
-		selected := isSelectedByAny(dest.Labels, selectors)
+		selected := isSelectedByAny(dest.Namespace, dest.Labels, selectors)
 
 		if selected {
 			if !controllerutil.ContainsFinalizer(dest, nc.FinalizerDestinationInUse) {
@@ -169,12 +169,12 @@ func (m *Manager) reconcileDestinationFinalizers(ctx context.Context, fetched *r
 func (m *Manager) reconcileCollectorFinalizers(ctx context.Context, fetched *resolver.FetchedResources) error {
 	referencedCollectors := make(map[string]bool)
 	for i := range fetched.TrafficMirrors {
-		referencedCollectors[fetched.TrafficMirrors[i].Spec.Collector] = true
+		referencedCollectors[resolver.NamespacedKey(fetched.TrafficMirrors[i].Namespace, fetched.TrafficMirrors[i].Spec.Collector)] = true
 	}
 
 	for i := range fetched.Collectors {
 		col := &fetched.Collectors[i]
-		if referencedCollectors[col.Name] {
+		if referencedCollectors[resolver.NamespacedKey(col.Namespace, col.Name)] {
 			if !controllerutil.ContainsFinalizer(col, nc.FinalizerCollectorInUse) {
 				controllerutil.AddFinalizer(col, nc.FinalizerCollectorInUse)
 				if err := m.client.Update(ctx, col); err != nil {
@@ -196,35 +196,43 @@ func (m *Manager) reconcileCollectorFinalizers(ctx context.Context, fetched *res
 }
 
 // collectDestinationSelectors gathers all label selectors that target Destinations.
-func collectDestinationSelectors(fetched *resolver.FetchedResources) []*metav1.LabelSelector {
-	var selectors []*metav1.LabelSelector
+type namespacedSelector struct {
+	namespace string
+	selector  *metav1.LabelSelector
+}
+
+func collectDestinationSelectors(fetched *resolver.FetchedResources) []namespacedSelector {
+	var selectors []namespacedSelector
 	for i := range fetched.Layer2Attachments {
 		if fetched.Layer2Attachments[i].Spec.Destinations != nil {
-			selectors = append(selectors, fetched.Layer2Attachments[i].Spec.Destinations)
+			selectors = append(selectors, namespacedSelector{fetched.Layer2Attachments[i].Namespace, fetched.Layer2Attachments[i].Spec.Destinations})
 		}
 	}
 	for i := range fetched.Inbounds {
 		if fetched.Inbounds[i].Spec.Destinations != nil {
-			selectors = append(selectors, fetched.Inbounds[i].Spec.Destinations)
+			selectors = append(selectors, namespacedSelector{fetched.Inbounds[i].Namespace, fetched.Inbounds[i].Spec.Destinations})
 		}
 	}
 	for i := range fetched.Outbounds {
 		if fetched.Outbounds[i].Spec.Destinations != nil {
-			selectors = append(selectors, fetched.Outbounds[i].Spec.Destinations)
+			selectors = append(selectors, namespacedSelector{fetched.Outbounds[i].Namespace, fetched.Outbounds[i].Spec.Destinations})
 		}
 	}
 	for i := range fetched.PodNetworks {
 		if fetched.PodNetworks[i].Spec.Destinations != nil {
-			selectors = append(selectors, fetched.PodNetworks[i].Spec.Destinations)
+			selectors = append(selectors, namespacedSelector{fetched.PodNetworks[i].Namespace, fetched.PodNetworks[i].Spec.Destinations})
 		}
 	}
 	return selectors
 }
 
 // isSelectedByAny returns true if the given resource labels match any of the selectors.
-func isSelectedByAny(resourceLabels map[string]string, selectors []*metav1.LabelSelector) bool {
-	for _, sel := range selectors {
-		selector, err := metav1.LabelSelectorAsSelector(sel)
+func isSelectedByAny(namespace string, resourceLabels map[string]string, selectors []namespacedSelector) bool {
+	for _, candidate := range selectors {
+		if candidate.namespace != namespace {
+			continue
+		}
+		selector, err := metav1.LabelSelectorAsSelector(candidate.selector)
 		if err != nil {
 			continue
 		}

--- a/pkg/reconciler/intent/finalizer/finalizer_test.go
+++ b/pkg/reconciler/intent/finalizer/finalizer_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package finalizer
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
+	"github.com/telekom/das-schiff-network-operator/pkg/reconciler/intent/resolver"
+)
+
+func TestDestinationSelectorsStayWithinNamespace(t *testing.T) {
+	const (
+		tenantA      = "tenant-a"
+		roleLabelKey = "role"
+		roleClient   = "client"
+	)
+	fetched := &resolver.FetchedResources{
+		Layer2Attachments: []nc.Layer2Attachment{{
+			ObjectMeta: metav1.ObjectMeta{Namespace: tenantA},
+			Spec: nc.Layer2AttachmentSpec{
+				Destinations: &metav1.LabelSelector{MatchLabels: map[string]string{roleLabelKey: roleClient}},
+			},
+		}},
+	}
+
+	selectors := collectDestinationSelectors(fetched)
+	if !isSelectedByAny(tenantA, map[string]string{roleLabelKey: roleClient}, selectors) {
+		t.Fatal("expected selector to match a Destination in the consumer namespace")
+	}
+	if isSelectedByAny("tenant-b", map[string]string{roleLabelKey: roleClient}, selectors) {
+		t.Fatal("selector must not match a Destination in another namespace")
+	}
+}

--- a/pkg/reconciler/intent/ipam/ipam.go
+++ b/pkg/reconciler/intent/ipam/ipam.go
@@ -85,16 +85,16 @@ func newPool(ip net.IP, ipNet *net.IPNet, l3 bool) *networkPool {
 // and allocates IPs from their referenced Network's CIDR.
 // It also allocates per-node IPs for Layer2Attachments with nodeIPs.enabled.
 // Allocated IPs are written to the resource's status.addresses field.
-func (a *Allocator) ReconcileAllocations(ctx context.Context, fetched *resolver.FetchedResources, networks map[string]*resolver.ResolvedNetwork) error {
+func (a *Allocator) ReconcileAllocations(ctx context.Context, fetched *resolver.FetchedResources, data *resolver.ResolvedData) error {
 	pools := make(map[string]*networkPool)
 
 	// Seed pools with already-allocated addresses to avoid duplicate allocations.
-	a.seedExistingAllocations(fetched, pools, networks)
+	a.seedExistingAllocations(fetched, pools, data)
 
-	if err := a.reconcileInboundAllocations(ctx, fetched, networks, pools); err != nil {
+	if err := a.reconcileInboundAllocations(ctx, fetched, data, pools); err != nil {
 		return err
 	}
-	if err := a.reconcileOutboundAllocations(ctx, fetched, networks, pools); err != nil {
+	if err := a.reconcileOutboundAllocations(ctx, fetched, data, pools); err != nil {
 		return err
 	}
 
@@ -104,7 +104,7 @@ func (a *Allocator) ReconcileAllocations(ctx context.Context, fetched *resolver.
 		if l2a.Spec.NodeIPs == nil || !l2a.Spec.NodeIPs.Enabled {
 			continue
 		}
-		if err := a.reconcileNodeIPs(ctx, l2a, fetched.Nodes, networks, pools); err != nil {
+		if err := a.reconcileNodeIPs(ctx, l2a, fetched.Nodes, data, pools); err != nil {
 			a.logger.Error(err, "node IP allocation failed for Layer2Attachment", "l2a", l2a.Name)
 		}
 	}
@@ -112,7 +112,7 @@ func (a *Allocator) ReconcileAllocations(ctx context.Context, fetched *resolver.
 	return nil
 }
 
-func (a *Allocator) reconcileInboundAllocations(ctx context.Context, fetched *resolver.FetchedResources, networks map[string]*resolver.ResolvedNetwork, pools map[string]*networkPool) error {
+func (a *Allocator) reconcileInboundAllocations(ctx context.Context, fetched *resolver.FetchedResources, data *resolver.ResolvedData, pools map[string]*networkPool) error {
 	for i := range fetched.Inbounds {
 		inb := &fetched.Inbounds[i]
 		if inb.Spec.Count == nil || inb.Spec.Addresses != nil {
@@ -124,7 +124,7 @@ func (a *Allocator) reconcileInboundAllocations(ctx context.Context, fetched *re
 		if inb.Status.Addresses != nil && ipamAllocatedCorrectly(inb.Status.Addresses, int(*inb.Spec.Count)) {
 			continue
 		}
-		addrs, err := a.allocate(inb.Spec.NetworkRef, int(*inb.Spec.Count), networks, pools, true, nil)
+		addrs, err := a.allocate(inb.Namespace, inb.Spec.NetworkRef, int(*inb.Spec.Count), data, pools, true, nil)
 		if addrs == nil {
 			a.logger.Error(err, "IPAM allocation failed for Inbound", "inbound", inb.Name)
 			continue
@@ -144,7 +144,7 @@ func (a *Allocator) reconcileInboundAllocations(ctx context.Context, fetched *re
 	return nil
 }
 
-func (a *Allocator) reconcileOutboundAllocations(ctx context.Context, fetched *resolver.FetchedResources, networks map[string]*resolver.ResolvedNetwork, pools map[string]*networkPool) error {
+func (a *Allocator) reconcileOutboundAllocations(ctx context.Context, fetched *resolver.FetchedResources, data *resolver.ResolvedData, pools map[string]*networkPool) error {
 	for i := range fetched.Outbounds {
 		outb := &fetched.Outbounds[i]
 		if outb.Spec.Count == nil || outb.Spec.Addresses != nil {
@@ -154,7 +154,7 @@ func (a *Allocator) reconcileOutboundAllocations(ctx context.Context, fetched *r
 		if outb.Status.Addresses != nil && ipamAllocatedCorrectly(outb.Status.Addresses, int(*outb.Spec.Count)) {
 			continue
 		}
-		addrs, err := a.allocate(outb.Spec.NetworkRef, int(*outb.Spec.Count), networks, pools, true, nil)
+		addrs, err := a.allocate(outb.Namespace, outb.Spec.NetworkRef, int(*outb.Spec.Count), data, pools, true, nil)
 		if addrs == nil {
 			a.logger.Error(err, "IPAM allocation failed for Outbound", "outbound", outb.Name)
 			continue
@@ -211,17 +211,17 @@ func ipamAllocatedCorrectly(addrs *nc.AddressAllocation, wantPerFamily int) bool
 // Pools are created with the same L2/L3 semantics that the live allocation path
 // uses for that consumer, so a routed (L3) pool keeps the network and broadcast
 // addresses usable across reconciles.
-func (*Allocator) seedExistingAllocations(fetched *resolver.FetchedResources, pools map[string]*networkPool, networks map[string]*resolver.ResolvedNetwork) {
-	collectAddresses := func(networkRef string, addrs *nc.AddressAllocation, l3 bool) {
+func (*Allocator) seedExistingAllocations(fetched *resolver.FetchedResources, pools map[string]*networkPool, data *resolver.ResolvedData) {
+	collectAddresses := func(namespace, networkRef string, addrs *nc.AddressAllocation, l3 bool) {
 		if addrs == nil {
 			return
 		}
-		netObj, ok := networks[networkRef]
+		netObj, ok := data.Network(namespace, networkRef)
 		if !ok {
 			return
 		}
-		seedPoolFromAddresses(networkRef+"/v4", netObj.Spec.IPv4, addrs.IPv4, pools, l3)
-		seedPoolFromAddresses(networkRef+"/v6", netObj.Spec.IPv6, addrs.IPv6, pools, l3)
+		seedPoolFromAddresses(networkPoolKey(namespace, networkRef, "v4"), netObj.Spec.IPv4, addrs.IPv4, pools, l3)
+		seedPoolFromAddresses(networkPoolKey(namespace, networkRef, "v6"), netObj.Spec.IPv6, addrs.IPv6, pools, l3)
 	}
 
 	// Seed L3 routing pools (Inbound/Outbound) first so a Network shared with an
@@ -235,20 +235,20 @@ func (*Allocator) seedExistingAllocations(fetched *resolver.FetchedResources, po
 		if inb.Spec.Count != nil && inb.Spec.Addresses == nil && !ipamAllocatedCorrectly(inb.Status.Addresses, int(*inb.Spec.Count)) {
 			continue
 		}
-		collectAddresses(inb.Spec.NetworkRef, inb.Status.Addresses, true)
+		collectAddresses(inb.Namespace, inb.Spec.NetworkRef, inb.Status.Addresses, true)
 	}
 	for i := range fetched.Outbounds {
 		outb := &fetched.Outbounds[i]
 		if outb.Spec.Count != nil && outb.Spec.Addresses == nil && !ipamAllocatedCorrectly(outb.Status.Addresses, int(*outb.Spec.Count)) {
 			continue
 		}
-		collectAddresses(outb.Spec.NetworkRef, outb.Status.Addresses, true)
+		collectAddresses(outb.Namespace, outb.Spec.NetworkRef, outb.Status.Addresses, true)
 	}
 	// Seed from L2A per-node allocations (L2 subnet semantics).
 	for i := range fetched.Layer2Attachments {
 		l2a := &fetched.Layer2Attachments[i]
 		for _, addrs := range l2a.Status.NodeAddresses {
-			collectAddresses(l2a.Spec.NetworkRef, &addrs, false)
+			collectAddresses(l2a.Namespace, l2a.Spec.NetworkRef, &addrs, false)
 		}
 	}
 }
@@ -303,7 +303,7 @@ func compareIPs(a, b net.IP) int {
 // reconcileNodeIPs allocates one IP per node for an L2A with nodeIPs.enabled.
 // Existing allocations are preserved; new nodes get the next available IP.
 // IPs that fall within nodeIPs.reservedRanges (reserved for pod use) are skipped.
-func (a *Allocator) reconcileNodeIPs(ctx context.Context, l2a *nc.Layer2Attachment, nodes []corev1.Node, networks map[string]*resolver.ResolvedNetwork, pools map[string]*networkPool) error {
+func (a *Allocator) reconcileNodeIPs(ctx context.Context, l2a *nc.Layer2Attachment, nodes []corev1.Node, data *resolver.ResolvedData, pools map[string]*networkPool) error {
 	if l2a.Status.NodeAddresses == nil {
 		l2a.Status.NodeAddresses = make(map[string]nc.AddressAllocation)
 	}
@@ -324,7 +324,7 @@ func (a *Allocator) reconcileNodeIPs(ctx context.Context, l2a *nc.Layer2Attachme
 			continue // already allocated
 		}
 
-		addrs, err := a.allocate(l2a.Spec.NetworkRef, 1, networks, pools, false, reserved)
+		addrs, err := a.allocate(l2a.Namespace, l2a.Spec.NetworkRef, 1, data, pools, false, reserved)
 		if addrs == nil {
 			// Hard failure (e.g. network not resolved): abort this L2A.
 			return fmt.Errorf("allocating node IP for %q on network %q: %w", nodeName, l2a.Spec.NetworkRef, err)
@@ -380,8 +380,8 @@ func parseReservedRanges(ranges []string) ([]*net.IPNet, error) {
 // reported via the returned error. This prevents one family's exhaustion from
 // blocking exposure of the other. A nil allocation is returned only when the
 // network itself cannot be resolved.
-func (*Allocator) allocate(networkRef string, count int, networks map[string]*resolver.ResolvedNetwork, pools map[string]*networkPool, l3 bool, reserved []*net.IPNet) (*nc.AddressAllocation, error) {
-	netObj, ok := networks[networkRef]
+func (*Allocator) allocate(namespace, networkRef string, count int, data *resolver.ResolvedData, pools map[string]*networkPool, l3 bool, reserved []*net.IPNet) (*nc.AddressAllocation, error) {
+	netObj, ok := data.Network(namespace, networkRef)
 	if !ok {
 		return nil, fmt.Errorf("network %q not found", networkRef)
 	}
@@ -390,7 +390,7 @@ func (*Allocator) allocate(networkRef string, count int, networks map[string]*re
 	var errs []error
 
 	if netObj.Spec.IPv4 != nil {
-		ips, err := allocateFromCIDR(networkRef+"/v4", netObj.Spec.IPv4.CIDR, count, pools, l3, reserved)
+		ips, err := allocateFromCIDR(networkPoolKey(namespace, networkRef, "v4"), netObj.Spec.IPv4.CIDR, count, pools, l3, reserved)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("IPv4 allocation from network %q: %w", networkRef, err))
 		} else {
@@ -399,7 +399,7 @@ func (*Allocator) allocate(networkRef string, count int, networks map[string]*re
 	}
 
 	if netObj.Spec.IPv6 != nil {
-		ips, err := allocateFromCIDR(networkRef+"/v6", netObj.Spec.IPv6.CIDR, count, pools, l3, reserved)
+		ips, err := allocateFromCIDR(networkPoolKey(namespace, networkRef, "v6"), netObj.Spec.IPv6.CIDR, count, pools, l3, reserved)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("IPv6 allocation from network %q: %w", networkRef, err))
 		} else {
@@ -408,6 +408,10 @@ func (*Allocator) allocate(networkRef string, count int, networks map[string]*re
 	}
 
 	return alloc, errors.Join(errs...)
+}
+
+func networkPoolKey(namespace, networkRef, family string) string {
+	return resolver.NamespacedKey(namespace, networkRef) + "/" + family
 }
 
 // allocateFromCIDR sequentially allocates count IPs from a CIDR. For L2 subnets

--- a/pkg/reconciler/intent/ipam/ipam_test.go
+++ b/pkg/reconciler/intent/ipam/ipam_test.go
@@ -294,7 +294,7 @@ func TestAllocateDualStack(t *testing.T) {
 	t.Run("IPv6 exhaustion does not discard IPv4 allocation", func(t *testing.T) {
 		pools := make(map[string]*networkPool)
 		// Request 2 addresses: IPv4 /24 has room, IPv6 /128 is exhausted past 1.
-		alloc, err := a.allocate("net", 2, newNetworks(), pools, true, nil)
+		alloc, err := a.allocate("", "net", 2, &resolver.ResolvedData{Networks: newNetworks()}, pools, true, nil)
 		require.Error(t, err)
 		require.NotNil(t, alloc)
 		assert.Len(t, alloc.IPv4, 2)
@@ -306,7 +306,7 @@ func TestAllocateDualStack(t *testing.T) {
 		nets := newNetworks()
 		nets["net"].Spec.IPv6 = &nc.IPNetwork{CIDR: "fd00::/120"}
 		pools := make(map[string]*networkPool)
-		alloc, err := a.allocate("net", 2, nets, pools, true, nil)
+		alloc, err := a.allocate("", "net", 2, &resolver.ResolvedData{Networks: nets}, pools, true, nil)
 		require.NoError(t, err)
 		assert.Len(t, alloc.IPv4, 2)
 		assert.Len(t, alloc.IPv6, 2)
@@ -314,10 +314,37 @@ func TestAllocateDualStack(t *testing.T) {
 
 	t.Run("network not found returns nil allocation", func(t *testing.T) {
 		pools := make(map[string]*networkPool)
-		alloc, err := a.allocate("missing", 1, newNetworks(), pools, true, nil)
+		alloc, err := a.allocate("", "missing", 1, &resolver.ResolvedData{Networks: newNetworks()}, pools, true, nil)
 		require.Error(t, err)
 		assert.Nil(t, alloc)
 	})
+}
+
+func TestAllocateSeparatesSameNamedNetworksByNamespace(t *testing.T) {
+	data := &resolver.ResolvedData{
+		NetworksByKey: map[string]*resolver.ResolvedNetwork{
+			resolver.NamespacedKey("tenant-a", "shared"): {
+				Namespace: "tenant-a",
+				Name:      "shared",
+				Spec:      nc.NetworkSpec{IPv4: &nc.IPNetwork{CIDR: "10.1.0.0/30"}},
+			},
+			resolver.NamespacedKey("tenant-b", "shared"): {
+				Namespace: "tenant-b",
+				Name:      "shared",
+				Spec:      nc.NetworkSpec{IPv4: &nc.IPNetwork{CIDR: "10.2.0.0/30"}},
+			},
+		},
+	}
+	pools := make(map[string]*networkPool)
+	allocator := &Allocator{}
+
+	first, err := allocator.allocate("tenant-a", "shared", 1, data, pools, true, nil)
+	require.NoError(t, err)
+	second, err := allocator.allocate("tenant-b", "shared", 1, data, pools, true, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"10.1.0.0"}, first.IPv4)
+	assert.Equal(t, []string{"10.2.0.0"}, second.IPv4)
+	assert.Len(t, pools, 2)
 }
 
 func TestSeedExistingAllocationsSkipsStaleExplicitCIDRs(t *testing.T) {
@@ -359,10 +386,10 @@ func TestSeedExistingAllocationsSkipsStaleExplicitCIDRs(t *testing.T) {
 			pools := make(map[string]*networkPool)
 			allocator := &Allocator{}
 
-			allocator.seedExistingAllocations(tt.fetched, pools, networks)
+			allocator.seedExistingAllocations(tt.fetched, pools, &resolver.ResolvedData{Networks: networks})
 			assert.Empty(t, pools, "stale explicit CIDRs must not seed an IPAM pool")
 
-			allocated, err := allocator.allocate("net", int(count), networks, pools, true, nil)
+			allocated, err := allocator.allocate("", "net", int(count), &resolver.ResolvedData{Networks: networks}, pools, true, nil)
 			require.NoError(t, err)
 			assert.Equal(t, []string{"10.0.0.0"}, allocated.IPv4)
 		})

--- a/pkg/reconciler/intent/reconciler.go
+++ b/pkg/reconciler/intent/reconciler.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -69,7 +70,13 @@ type Reconciler struct {
 // NewReconciler creates a new intent reconciler.
 // The namespace parameter restricts which namespace intent CRDs are read from.
 // An empty string means all namespaces (cluster-wide).
-func NewReconciler(clusterClient client.Client, logger logr.Logger, timeout time.Duration, namespace string) (*Reconciler, error) {
+func NewReconciler(
+	clusterClient client.Client,
+	logger logr.Logger,
+	timeout time.Duration,
+	namespace string,
+	eventRecorders ...events.EventRecorder,
+) (*Reconciler, error) {
 	r := &Reconciler{
 		logger:    logger,
 		timeout:   timeout,
@@ -88,7 +95,7 @@ func NewReconciler(clusterClient client.Client, logger logr.Logger, timeout time
 			builder.NewSBRBuilder(),
 		},
 		finalizerManager: finalizer.NewManager(clusterClient, logger),
-		statusUpdater:    status.NewUpdater(clusterClient, logger),
+		statusUpdater:    status.NewUpdater(clusterClient, logger, eventRecorders...),
 		ipamAllocator:    ipam.NewAllocator(clusterClient, logger),
 		legacyDetector:   legacy.NewDetector(clusterClient, logger),
 	}
@@ -144,7 +151,7 @@ func (r *Reconciler) ReconcileDebounced(ctx context.Context) error {
 	}
 
 	// 4. IPAM allocation for count-mode Inbound/Outbound (before builders).
-	if err := r.ipamAllocator.ReconcileAllocations(timeoutCtx, fetched, resolved.Networks); err != nil {
+	if err := r.ipamAllocator.ReconcileAllocations(timeoutCtx, fetched, resolved); err != nil {
 		r.logger.Error(err, "IPAM allocation failed")
 		// Continue — partial allocation is acceptable.
 	}

--- a/pkg/reconciler/intent/resolver/resolve.go
+++ b/pkg/reconciler/intent/resolver/resolve.go
@@ -58,6 +58,8 @@ type FetchedResources struct {
 func ResolveAll(fetched *FetchedResources) (*ResolvedData, error) {
 	vrfs := ResolveVRFs(fetched.VRFs)
 	networks := ResolveNetworks(fetched.Networks)
+	vrfsByKey := ResolveVRFsByKey(fetched.VRFs)
+	networksByKey := ResolveNetworksByKey(fetched.Networks)
 
 	destinations, err := ResolveDestinations(fetched.Destinations, vrfs)
 	if err != nil {
@@ -69,6 +71,9 @@ func ResolveAll(fetched *FetchedResources) (*ResolvedData, error) {
 		VRFs:                 vrfs,
 		Networks:             networks,
 		Destinations:         destinations,
+		VRFsByKey:            vrfsByKey,
+		NetworksByKey:        networksByKey,
+		DestinationsByKey:    ResolveDestinationsByKey(fetched.Destinations, vrfsByKey),
 		RawDestinations:      fetched.Destinations,
 		Layer2Attachments:    fetched.Layer2Attachments,
 		Inbounds:             fetched.Inbounds,

--- a/pkg/reconciler/intent/resolver/resolver.go
+++ b/pkg/reconciler/intent/resolver/resolver.go
@@ -24,29 +24,35 @@ import (
 
 // ResolvedVRF is a VRF with its spec data accessible by name.
 type ResolvedVRF struct {
-	Name string
-	Spec nc.VRFSpec
+	Namespace string
+	Name      string
+	Spec      nc.VRFSpec
 }
 
 // ResolvedNetwork is a Network with its spec data accessible by name.
 type ResolvedNetwork struct {
-	Name string
-	Spec nc.NetworkSpec
+	Namespace string
+	Name      string
+	Spec      nc.NetworkSpec
 }
 
 // ResolvedDestination is a Destination with its VRF resolved.
 type ResolvedDestination struct {
-	Name    string
-	Spec    nc.DestinationSpec
-	VRFSpec *nc.VRFSpec
+	Namespace string
+	Name      string
+	Spec      nc.DestinationSpec
+	VRFSpec   *nc.VRFSpec
 }
 
 // ResolvedData is the pre-resolved reference graph passed to all builders.
 type ResolvedData struct {
-	Nodes        []corev1.Node
-	VRFs         map[string]*ResolvedVRF
-	Networks     map[string]*ResolvedNetwork
-	Destinations map[string]*ResolvedDestination
+	Nodes             []corev1.Node
+	VRFs              map[string]*ResolvedVRF
+	Networks          map[string]*ResolvedNetwork
+	Destinations      map[string]*ResolvedDestination
+	VRFsByKey         map[string]*ResolvedVRF
+	NetworksByKey     map[string]*ResolvedNetwork
+	DestinationsByKey map[string]*ResolvedDestination
 
 	// RawDestinations preserves the original Destination objects for label matching.
 	RawDestinations []nc.Destination
@@ -65,4 +71,40 @@ type ResolvedData struct {
 	// BGPPasswords holds resolved BGP session passwords keyed by
 	// "<namespace>/<name>" of the BGPPeering.
 	BGPPasswords map[string]string
+}
+
+// NamespacedKey returns the stable key used for namespaced intent references.
+func NamespacedKey(namespace, name string) string {
+	return namespace + "\x00" + name
+}
+
+// VRF returns a same-namespace VRF. The name-only map fallback keeps direct
+// unit-test fixtures compatible when no namespaced index is populated.
+func (d *ResolvedData) VRF(namespace, name string) (*ResolvedVRF, bool) {
+	if d.VRFsByKey != nil {
+		vrf, ok := d.VRFsByKey[NamespacedKey(namespace, name)]
+		return vrf, ok
+	}
+	vrf, ok := d.VRFs[name]
+	return vrf, ok
+}
+
+// Network returns a same-namespace Network.
+func (d *ResolvedData) Network(namespace, name string) (*ResolvedNetwork, bool) {
+	if d.NetworksByKey != nil {
+		network, ok := d.NetworksByKey[NamespacedKey(namespace, name)]
+		return network, ok
+	}
+	network, ok := d.Networks[name]
+	return network, ok
+}
+
+// Destination returns a same-namespace Destination.
+func (d *ResolvedData) Destination(namespace, name string) (*ResolvedDestination, bool) {
+	if d.DestinationsByKey != nil {
+		destination, ok := d.DestinationsByKey[NamespacedKey(namespace, name)]
+		return destination, ok
+	}
+	destination, ok := d.Destinations[name]
+	return destination, ok
 }

--- a/pkg/reconciler/intent/resolver/status_derive.go
+++ b/pkg/reconciler/intent/resolver/status_derive.go
@@ -30,8 +30,8 @@ import (
 // name. Each is empty when the Network is unresolved or lacks that family.
 // Used to surface the pool CIDRs on consumer resource status (e.g.
 // Layer2Attachment.status.networkIPv4/networkIPv6).
-func (d *ResolvedData) NetworkCIDRs(networkRef string) (ipv4, ipv6 string) {
-	net, ok := d.Networks[networkRef]
+func (d *ResolvedData) NetworkCIDRs(namespace, networkRef string) (ipv4, ipv6 string) {
+	net, ok := d.Network(namespace, networkRef)
 	if !ok {
 		return "", ""
 	}
@@ -48,7 +48,7 @@ func (d *ResolvedData) NetworkCIDRs(networkRef string) (ipv4, ipv6 string) {
 // Destination matched by sel that carries a vrfRef. This is the VRF list a
 // consumer with a destinations selector (Layer2Attachment, Inbound, Outbound)
 // is plumbed into. Destinations that use nextHop (no vrfRef) are skipped.
-func (d *ResolvedData) SelectorVRFRefs(sel *metav1.LabelSelector) []string {
+func (d *ResolvedData) SelectorVRFRefs(namespace string, sel *metav1.LabelSelector) []string {
 	if sel == nil {
 		return nil
 	}
@@ -59,7 +59,7 @@ func (d *ResolvedData) SelectorVRFRefs(sel *metav1.LabelSelector) []string {
 	set := map[string]struct{}{}
 	for i := range d.RawDestinations {
 		rd := &d.RawDestinations[i]
-		if !selector.Matches(labels.Set(rd.Labels)) {
+		if rd.Namespace != namespace || !selector.Matches(labels.Set(rd.Labels)) {
 			continue
 		}
 		if rd.Spec.VRFRef == nil || *rd.Spec.VRFRef == "" {
@@ -73,23 +73,50 @@ func (d *ResolvedData) SelectorVRFRefs(sel *metav1.LabelSelector) []string {
 // attachmentVRFRefs returns the VRF names reachable via the referenced
 // Layer2Attachment's destinations. Used for BGPPeering listenRange mode, where
 // the VRFs come from the referenced L2A (the transfer network segment).
-func (d *ResolvedData) attachmentVRFRefs(attachmentRef string) []string {
+func (d *ResolvedData) attachmentVRFRefs(namespace, attachmentRef string) []string {
 	for i := range d.Layer2Attachments {
 		l2a := &d.Layer2Attachments[i]
-		if l2a.Name == attachmentRef {
-			return d.SelectorVRFRefs(l2a.Spec.Destinations)
+		if l2a.Namespace == namespace && l2a.Name == attachmentRef {
+			return d.SelectorVRFRefs(namespace, l2a.Spec.Destinations)
 		}
 	}
 	return nil
 }
 
+func (d *ResolvedData) attachmentFabricVRFCount(l2a *nc.Layer2Attachment) int {
+	if l2a.Spec.Destinations == nil {
+		return 0
+	}
+	selector, err := metav1.LabelSelectorAsSelector(l2a.Spec.Destinations)
+	if err != nil {
+		return 0
+	}
+	vrfs := make(map[string]struct{})
+	legacy := d.DestinationsByKey == nil && d.Destinations == nil
+	for i := range d.RawDestinations {
+		destination := &d.RawDestinations[i]
+		if destination.Namespace != l2a.Namespace || !selector.Matches(labels.Set(destination.Labels)) {
+			continue
+		}
+		resolved, ok := d.Destination(l2a.Namespace, destination.Name)
+		if !ok || resolved.VRFSpec == nil {
+			if legacy && destination.Spec.VRFRef != nil {
+				vrfs[*destination.Spec.VRFRef] = struct{}{}
+			}
+			continue
+		}
+		vrfs[resolved.VRFSpec.VRF] = struct{}{}
+	}
+	return len(vrfs)
+}
+
 // inboundVRFRefs returns the VRF names reachable via the referenced Inbound's
 // destinations. Used for BGPPeering loopbackPeer mode.
-func (d *ResolvedData) inboundVRFRefs(inboundRef string) []string {
+func (d *ResolvedData) inboundVRFRefs(namespace, inboundRef string) []string {
 	for i := range d.Inbounds {
 		ib := &d.Inbounds[i]
-		if ib.Name == inboundRef {
-			return d.SelectorVRFRefs(ib.Spec.Destinations)
+		if ib.Namespace == namespace && ib.Name == inboundRef {
+			return d.SelectorVRFRefs(namespace, ib.Spec.Destinations)
 		}
 	}
 	return nil
@@ -102,12 +129,12 @@ func (d *ResolvedData) inboundVRFRefs(inboundRef string) []string {
 func (d *ResolvedData) BGPPeeringVRFRefs(bp *nc.BGPPeering) []string {
 	set := map[string]struct{}{}
 	if bp.Spec.Ref.AttachmentRef != nil {
-		for _, v := range d.attachmentVRFRefs(*bp.Spec.Ref.AttachmentRef) {
+		for _, v := range d.attachmentVRFRefs(bp.Namespace, *bp.Spec.Ref.AttachmentRef) {
 			set[v] = struct{}{}
 		}
 	}
 	for _, ref := range bp.Spec.Ref.InboundRefs {
-		for _, v := range d.inboundVRFRefs(ref) {
+		for _, v := range d.inboundVRFRefs(bp.Namespace, ref) {
 			set[v] = struct{}{}
 		}
 	}
@@ -128,7 +155,8 @@ func (d *ResolvedData) BGPPeeringLocalIPs(bp *nc.BGPPeering) []string {
 
 	var l2a *nc.Layer2Attachment
 	for i := range d.Layer2Attachments {
-		if d.Layer2Attachments[i].Name == *bp.Spec.Ref.AttachmentRef {
+		if d.Layer2Attachments[i].Namespace == bp.Namespace &&
+			d.Layer2Attachments[i].Name == *bp.Spec.Ref.AttachmentRef {
 			l2a = &d.Layer2Attachments[i]
 			break
 		}
@@ -137,7 +165,7 @@ func (d *ResolvedData) BGPPeeringLocalIPs(bp *nc.BGPPeering) []string {
 		return nil
 	}
 
-	net, ok := d.Networks[l2a.Spec.NetworkRef]
+	net, ok := d.Network(bp.Namespace, l2a.Spec.NetworkRef)
 	if !ok {
 		return nil
 	}
@@ -169,7 +197,8 @@ func (d *ResolvedData) BGPPeeringNodes(bp *nc.BGPPeering) []string {
 		}
 		var l2a *nc.Layer2Attachment
 		for i := range d.Layer2Attachments {
-			if d.Layer2Attachments[i].Name == *bp.Spec.Ref.AttachmentRef {
+			if d.Layer2Attachments[i].Namespace == bp.Namespace &&
+				d.Layer2Attachments[i].Name == *bp.Spec.Ref.AttachmentRef {
 				l2a = &d.Layer2Attachments[i]
 				break
 			}
@@ -177,7 +206,9 @@ func (d *ResolvedData) BGPPeeringNodes(bp *nc.BGPPeering) []string {
 		if l2a == nil {
 			return nil
 		}
-		selector = l2a.Spec.NodeSelector
+		if d.attachmentFabricVRFCount(l2a) > 1 {
+			selector = l2a.Spec.NodeSelector
+		}
 	}
 	// loopbackPeer (and listenRange with a nil NodeSelector) applies to all nodes.
 	return d.matchNodeNames(selector)

--- a/pkg/reconciler/intent/resolver/status_derive_test.go
+++ b/pkg/reconciler/intent/resolver/status_derive_test.go
@@ -76,13 +76,13 @@ func testData() *ResolvedData {
 
 func TestNetworkCIDRs(t *testing.T) {
 	d := testData()
-	if v4, v6 := d.NetworkCIDRs("net-a"); v4 != "10.0.0.0/24" || v6 != "2001:db8::/64" {
+	if v4, v6 := d.NetworkCIDRs("", "net-a"); v4 != "10.0.0.0/24" || v6 != "2001:db8::/64" {
 		t.Errorf("net-a = %q,%q", v4, v6)
 	}
-	if v4, v6 := d.NetworkCIDRs("net-v4only"); v4 != "10.1.0.0/24" || v6 != "" {
+	if v4, v6 := d.NetworkCIDRs("", "net-v4only"); v4 != "10.1.0.0/24" || v6 != "" {
 		t.Errorf("net-v4only = %q,%q; want v6 empty", v4, v6)
 	}
-	if v4, v6 := d.NetworkCIDRs("missing"); v4 != "" || v6 != "" {
+	if v4, v6 := d.NetworkCIDRs("", "missing"); v4 != "" || v6 != "" {
 		t.Errorf("missing = %q,%q; want empty", v4, v6)
 	}
 }
@@ -90,12 +90,12 @@ func TestNetworkCIDRs(t *testing.T) {
 func TestSelectorVRFRefs(t *testing.T) {
 	d := testData()
 	sel := &metav1.LabelSelector{MatchLabels: map[string]string{"type": "gw"}}
-	got := d.SelectorVRFRefs(sel)
+	got := d.SelectorVRFRefs("", sel)
 	want := []string{"vrf-c2m", "vrf-m2m"} // sorted, de-duplicated, nextHop skipped
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("SelectorVRFRefs = %v, want %v", got, want)
 	}
-	if got := d.SelectorVRFRefs(nil); got != nil {
+	if got := d.SelectorVRFRefs("", nil); got != nil {
 		t.Errorf("nil selector = %v, want nil", got)
 	}
 }
@@ -199,5 +199,63 @@ func TestBGPPeeringNodes(t *testing.T) {
 	}}
 	if got := d.BGPPeeringNodes(none); got != nil {
 		t.Errorf("unknown attachment nodes = %v, want nil", got)
+	}
+}
+
+func TestAttachmentFabricVRFCountUsesResolvedUniqueVRFs(t *testing.T) {
+	const (
+		namespace     = "tenant-a"
+		refA          = "vrf-a"
+		refB          = "vrf-b"
+		missing       = "missing"
+		groupKey      = "group"
+		selectedGroup = "selected"
+	)
+	sharedSpec := nc.VRFSpec{VRF: "shared-fabric"}
+	data := &ResolvedData{
+		RawDestinations: []nc.Destination{
+			{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "a", Labels: map[string]string{groupKey: selectedGroup}}, Spec: nc.DestinationSpec{VRFRef: ptrStr(refA)}},
+			{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "b", Labels: map[string]string{groupKey: selectedGroup}}, Spec: nc.DestinationSpec{VRFRef: ptrStr(refB)}},
+			{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "unresolved", Labels: map[string]string{groupKey: selectedGroup}}, Spec: nc.DestinationSpec{VRFRef: ptrStr(missing)}},
+		},
+		DestinationsByKey: map[string]*ResolvedDestination{
+			NamespacedKey(namespace, "a"): {Namespace: namespace, Name: "a", VRFSpec: &sharedSpec},
+			NamespacedKey(namespace, "b"): {Namespace: namespace, Name: "b", VRFSpec: &sharedSpec},
+		},
+	}
+	l2a := &nc.Layer2Attachment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace},
+		Spec: nc.Layer2AttachmentSpec{
+			Destinations: &metav1.LabelSelector{MatchLabels: map[string]string{groupKey: selectedGroup}},
+		},
+	}
+
+	if got := data.attachmentFabricVRFCount(l2a); got != 1 {
+		t.Fatalf("attachmentFabricVRFCount() = %d, want one resolved effective FabricVRF", got)
+	}
+}
+
+func TestBGPPeeringAttachmentRefUsesNamespace(t *testing.T) {
+	d := testData()
+	d.Layer2Attachments = append([]nc.Layer2Attachment{{
+		ObjectMeta: metav1.ObjectMeta{Name: "l2a-sel", Namespace: "other"},
+		Spec: nc.Layer2AttachmentSpec{
+			NetworkRef:   "net-a",
+			Destinations: &metav1.LabelSelector{MatchLabels: map[string]string{"type": "x"}},
+			NodeSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"rack": "b"}},
+		},
+	}}, d.Layer2Attachments...)
+
+	bp := &nc.BGPPeering{
+		Spec: nc.BGPPeeringSpec{
+			Mode: nc.BGPPeeringModeListenRange,
+			Ref:  nc.BGPPeeringRef{AttachmentRef: ptrStr("l2a-sel")},
+		},
+	}
+	if got, want := d.BGPPeeringNodes(bp), []string{"node-a1", "node-a2"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("BGPPeeringNodes() = %v, want same-namespace attachment nodes %v", got, want)
+	}
+	if got, want := d.BGPPeeringVRFRefs(bp), []string{"vrf-c2m", "vrf-m2m"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("BGPPeeringVRFRefs() = %v, want same-namespace attachment VRFs %v", got, want)
 	}
 }

--- a/pkg/reconciler/intent/resolver/vrf.go
+++ b/pkg/reconciler/intent/resolver/vrf.go
@@ -25,8 +25,22 @@ func ResolveVRFs(vrfs []nc.VRF) map[string]*ResolvedVRF {
 	resolved := make(map[string]*ResolvedVRF, len(vrfs))
 	for i := range vrfs {
 		resolved[vrfs[i].Name] = &ResolvedVRF{
-			Name: vrfs[i].Name,
-			Spec: vrfs[i].Spec,
+			Namespace: vrfs[i].Namespace,
+			Name:      vrfs[i].Name,
+			Spec:      vrfs[i].Spec,
+		}
+	}
+	return resolved
+}
+
+// ResolveVRFsByKey builds a namespace/name keyed VRF map.
+func ResolveVRFsByKey(vrfs []nc.VRF) map[string]*ResolvedVRF {
+	resolved := make(map[string]*ResolvedVRF, len(vrfs))
+	for i := range vrfs {
+		resolved[NamespacedKey(vrfs[i].Namespace, vrfs[i].Name)] = &ResolvedVRF{
+			Namespace: vrfs[i].Namespace,
+			Name:      vrfs[i].Name,
+			Spec:      vrfs[i].Spec,
 		}
 	}
 	return resolved
@@ -37,8 +51,22 @@ func ResolveNetworks(networks []nc.Network) map[string]*ResolvedNetwork {
 	resolved := make(map[string]*ResolvedNetwork, len(networks))
 	for i := range networks {
 		resolved[networks[i].Name] = &ResolvedNetwork{
-			Name: networks[i].Name,
-			Spec: networks[i].Spec,
+			Namespace: networks[i].Namespace,
+			Name:      networks[i].Name,
+			Spec:      networks[i].Spec,
+		}
+	}
+	return resolved
+}
+
+// ResolveNetworksByKey builds a namespace/name keyed Network map.
+func ResolveNetworksByKey(networks []nc.Network) map[string]*ResolvedNetwork {
+	resolved := make(map[string]*ResolvedNetwork, len(networks))
+	for i := range networks {
+		resolved[NamespacedKey(networks[i].Namespace, networks[i].Name)] = &ResolvedNetwork{
+			Namespace: networks[i].Namespace,
+			Name:      networks[i].Name,
+			Spec:      networks[i].Spec,
 		}
 	}
 	return resolved
@@ -50,8 +78,9 @@ func ResolveDestinations(destinations []nc.Destination, vrfs map[string]*Resolve
 	resolved := make(map[string]*ResolvedDestination, len(destinations))
 	for i := range destinations {
 		d := &ResolvedDestination{
-			Name: destinations[i].Name,
-			Spec: destinations[i].Spec,
+			Namespace: destinations[i].Namespace,
+			Name:      destinations[i].Name,
+			Spec:      destinations[i].Spec,
 		}
 
 		// VRFRef is optional (Destination may use nextHop instead).
@@ -67,4 +96,28 @@ func ResolveDestinations(destinations []nc.Destination, vrfs map[string]*Resolve
 		resolved[destinations[i].Name] = d
 	}
 	return resolved, nil
+}
+
+// ResolveDestinationsByKey builds a namespace/name keyed Destination map and
+// resolves each vrfRef only within the Destination's namespace.
+func ResolveDestinationsByKey(
+	destinations []nc.Destination,
+	vrfs map[string]*ResolvedVRF,
+) map[string]*ResolvedDestination {
+	resolved := make(map[string]*ResolvedDestination, len(destinations))
+	for i := range destinations {
+		destination := &destinations[i]
+		d := &ResolvedDestination{
+			Namespace: destination.Namespace,
+			Name:      destination.Name,
+			Spec:      destination.Spec,
+		}
+		if destination.Spec.VRFRef != nil {
+			if vrf, ok := vrfs[NamespacedKey(destination.Namespace, *destination.Spec.VRFRef)]; ok {
+				d.VRFSpec = &vrf.Spec
+			}
+		}
+		resolved[NamespacedKey(destination.Namespace, destination.Name)] = d
+	}
+	return resolved
 }

--- a/pkg/reconciler/intent/resolver/vrf_test.go
+++ b/pkg/reconciler/intent/resolver/vrf_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
+)
+
+func TestNamespacedIndexesKeepDuplicateNamesIsolated(t *testing.T) {
+	const (
+		tenantA = "tenant-a"
+		tenantB = "tenant-b"
+	)
+	ref := "shared-vrf"
+	vrfs := []nc.VRF{
+		{ObjectMeta: metav1.ObjectMeta{Namespace: tenantA, Name: ref}, Spec: nc.VRFSpec{VRF: "fabric-a"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: tenantB, Name: ref}, Spec: nc.VRFSpec{VRF: "fabric-b"}},
+	}
+	destinations := []nc.Destination{
+		{ObjectMeta: metav1.ObjectMeta{Namespace: tenantA, Name: "shared-destination"}, Spec: nc.DestinationSpec{VRFRef: &ref}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: tenantB, Name: "shared-destination"}, Spec: nc.DestinationSpec{VRFRef: &ref}},
+	}
+
+	data := ResolvedData{
+		VRFsByKey:         ResolveVRFsByKey(vrfs),
+		DestinationsByKey: ResolveDestinationsByKey(destinations, ResolveVRFsByKey(vrfs)),
+	}
+
+	for namespace, wantVRF := range map[string]string{tenantA: "fabric-a", tenantB: "fabric-b"} {
+		vrf, ok := data.VRF(namespace, ref)
+		if !ok || vrf.Spec.VRF != wantVRF {
+			t.Fatalf("VRF(%q, %q) = %#v, %v; want %q", namespace, ref, vrf, ok, wantVRF)
+		}
+		destination, ok := data.Destination(namespace, "shared-destination")
+		if !ok || destination.VRFSpec == nil || destination.VRFSpec.VRF != wantVRF {
+			t.Fatalf("Destination(%q) resolved VRF = %#v, %v; want %q", namespace, destination, ok, wantVRF)
+		}
+	}
+}

--- a/pkg/reconciler/intent/status/status.go
+++ b/pkg/reconciler/intent/status/status.go
@@ -22,9 +22,11 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
@@ -68,16 +70,46 @@ func applyBuildIssue(issues map[string]ResourceIssue, kind, namespace, name stri
 
 // Updater handles status condition updates for intent CRDs.
 type Updater struct {
-	client client.Client
-	logger logr.Logger
+	client        client.Client
+	logger        logr.Logger
+	eventRecorder events.EventRecorder
 }
 
 // NewUpdater creates a new status Updater.
-func NewUpdater(c client.Client, logger logr.Logger) *Updater {
-	return &Updater{
+func NewUpdater(c client.Client, logger logr.Logger, eventRecorders ...events.EventRecorder) *Updater {
+	updater := &Updater{
 		client: c,
 		logger: logger.WithName("status-updater"),
 	}
+	if len(eventRecorders) > 0 {
+		updater.eventRecorder = eventRecorders[0]
+	}
+	return updater
+}
+
+func (u *Updater) emitReadyWarning(
+	object client.Object,
+	previousReady *metav1.Condition,
+	readyStatus metav1.ConditionStatus,
+	reason,
+	message string,
+) {
+	if u.eventRecorder == nil || readyStatus != metav1.ConditionFalse {
+		return
+	}
+	if previousReady != nil && previousReady.Status == metav1.ConditionFalse {
+		return
+	}
+	u.eventRecorder.Eventf(object, nil, corev1.EventTypeWarning, reason, "IntentNotReady", "%s", message)
+}
+
+func readyConditionSnapshot(conditions []metav1.Condition) *metav1.Condition {
+	current := apimeta.FindStatusCondition(conditions, nc.ConditionTypeReady)
+	if current == nil {
+		return nil
+	}
+	snapshot := *current
+	return &snapshot
 }
 
 // statusUpdateWithRetry performs a status update with conflict retry.
@@ -187,12 +219,13 @@ func (u *Updater) updateNetworkConditions(ctx context.Context, fetched *resolver
 func (u *Updater) updateDestinationConditions(ctx context.Context, fetched *resolver.FetchedResources, resolved *resolver.ResolvedData) error {
 	for i := range fetched.Destinations {
 		dest := &fetched.Destinations[i]
+		previousReady := readyConditionSnapshot(dest.Status.Conditions)
 		resolvedStatus := metav1.ConditionTrue
 		resolvedReason := reasonAllResolved
 		resolvedMsg := msgAllResolved
 
 		if dest.Spec.VRFRef != nil {
-			if _, ok := resolved.VRFs[*dest.Spec.VRFRef]; !ok {
+			if _, ok := resolved.VRF(dest.Namespace, *dest.Spec.VRFRef); !ok {
 				resolvedStatus = metav1.ConditionFalse
 				resolvedReason = "VRFNotFound"
 				resolvedMsg = fmt.Sprintf("referenced VRF %q not found", *dest.Spec.VRFRef)
@@ -213,6 +246,7 @@ func (u *Updater) updateDestinationConditions(ctx context.Context, fetched *reso
 		}); err != nil {
 			return fmt.Errorf("updating Destination %q status: %w", dest.Name, err)
 		}
+		u.emitReadyWarning(dest, previousReady, readyStatus, resolvedReason, readyMsg)
 	}
 	return nil
 }
@@ -220,7 +254,8 @@ func (u *Updater) updateDestinationConditions(ctx context.Context, fetched *reso
 func (u *Updater) updateInboundConditions(ctx context.Context, fetched *resolver.FetchedResources, resolved *resolver.ResolvedData, issues map[string]ResourceIssue) error {
 	for i := range fetched.Inbounds {
 		inb := &fetched.Inbounds[i]
-		resolvedStatus, resolvedReason, resolvedMsg := checkNetworkRef(inb.Spec.NetworkRef, resolved)
+		previousReady := readyConditionSnapshot(inb.Status.Conditions)
+		resolvedStatus, resolvedReason, resolvedMsg := checkNetworkRef(inb.Namespace, inb.Spec.NetworkRef, resolved)
 
 		readyStatus := resolvedStatus
 		readyReason := resolvedReason
@@ -230,7 +265,7 @@ func (u *Updater) updateInboundConditions(ctx context.Context, fetched *resolver
 		}
 		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "Inbound", inb.Namespace, inb.Name, readyStatus, readyReason, readyMsg)
 
-		vrfs := resolved.SelectorVRFRefs(inb.Spec.Destinations)
+		vrfs := resolved.SelectorVRFRefs(inb.Namespace, inb.Spec.Destinations)
 
 		if err := u.statusUpdateWithRetry(ctx, inb, func(obj client.Object) {
 			in := obj.(*nc.Inbound)
@@ -248,6 +283,7 @@ func (u *Updater) updateInboundConditions(ctx context.Context, fetched *resolver
 		}); err != nil {
 			return fmt.Errorf("updating Inbound %q status: %w", inb.Name, err)
 		}
+		u.emitReadyWarning(inb, previousReady, readyStatus, readyReason, readyMsg)
 	}
 	return nil
 }
@@ -255,7 +291,8 @@ func (u *Updater) updateInboundConditions(ctx context.Context, fetched *resolver
 func (u *Updater) updateOutboundConditions(ctx context.Context, fetched *resolver.FetchedResources, resolved *resolver.ResolvedData, issues map[string]ResourceIssue) error {
 	for i := range fetched.Outbounds {
 		outb := &fetched.Outbounds[i]
-		resolvedStatus, resolvedReason, resolvedMsg := checkNetworkRef(outb.Spec.NetworkRef, resolved)
+		previousReady := readyConditionSnapshot(outb.Status.Conditions)
+		resolvedStatus, resolvedReason, resolvedMsg := checkNetworkRef(outb.Namespace, outb.Spec.NetworkRef, resolved)
 
 		readyStatus := resolvedStatus
 		readyReason := resolvedReason
@@ -265,7 +302,7 @@ func (u *Updater) updateOutboundConditions(ctx context.Context, fetched *resolve
 		}
 		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "Outbound", outb.Namespace, outb.Name, readyStatus, readyReason, readyMsg)
 
-		vrfs := resolved.SelectorVRFRefs(outb.Spec.Destinations)
+		vrfs := resolved.SelectorVRFRefs(outb.Namespace, outb.Spec.Destinations)
 
 		if err := u.statusUpdateWithRetry(ctx, outb, func(obj client.Object) {
 			o := obj.(*nc.Outbound)
@@ -279,6 +316,7 @@ func (u *Updater) updateOutboundConditions(ctx context.Context, fetched *resolve
 		}); err != nil {
 			return fmt.Errorf("updating Outbound %q status: %w", outb.Name, err)
 		}
+		u.emitReadyWarning(outb, previousReady, readyStatus, readyReason, readyMsg)
 	}
 	return nil
 }
@@ -286,7 +324,8 @@ func (u *Updater) updateOutboundConditions(ctx context.Context, fetched *resolve
 func (u *Updater) updateLayer2AttachmentConditions(ctx context.Context, fetched *resolver.FetchedResources, resolved *resolver.ResolvedData, issues map[string]ResourceIssue) error {
 	for i := range fetched.Layer2Attachments {
 		l2a := &fetched.Layer2Attachments[i]
-		resolvedStatus, resolvedReason, resolvedMsg := checkNetworkRef(l2a.Spec.NetworkRef, resolved)
+		previousReady := readyConditionSnapshot(l2a.Status.Conditions)
+		resolvedStatus, resolvedReason, resolvedMsg := checkNetworkRef(l2a.Namespace, l2a.Spec.NetworkRef, resolved)
 
 		readyStatus := resolvedStatus
 		readyReason := resolvedReason
@@ -297,8 +336,8 @@ func (u *Updater) updateLayer2AttachmentConditions(ctx context.Context, fetched 
 		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "Layer2Attachment", l2a.Namespace, l2a.Name, readyStatus, readyReason, readyMsg)
 
 		effIfName := effectiveInterfaceName(l2a, resolved)
-		netIPv4, netIPv6 := resolved.NetworkCIDRs(l2a.Spec.NetworkRef)
-		vrfs := resolved.SelectorVRFRefs(l2a.Spec.Destinations)
+		netIPv4, netIPv6 := resolved.NetworkCIDRs(l2a.Namespace, l2a.Spec.NetworkRef)
+		vrfs := resolved.SelectorVRFRefs(l2a.Namespace, l2a.Spec.Destinations)
 
 		if err := u.statusUpdateWithRetry(ctx, l2a, func(obj client.Object) {
 			la := obj.(*nc.Layer2Attachment)
@@ -312,6 +351,7 @@ func (u *Updater) updateLayer2AttachmentConditions(ctx context.Context, fetched 
 		}); err != nil {
 			return fmt.Errorf("updating Layer2Attachment %q status: %w", l2a.Name, err)
 		}
+		u.emitReadyWarning(l2a, previousReady, readyStatus, readyReason, readyMsg)
 	}
 	return nil
 }
@@ -319,7 +359,8 @@ func (u *Updater) updateLayer2AttachmentConditions(ctx context.Context, fetched 
 func (u *Updater) updatePodNetworkConditions(ctx context.Context, fetched *resolver.FetchedResources, resolved *resolver.ResolvedData, issues map[string]ResourceIssue) error {
 	for i := range fetched.PodNetworks {
 		pn := &fetched.PodNetworks[i]
-		resolvedStatus, resolvedReason, resolvedMsg := checkNetworkRef(pn.Spec.NetworkRef, resolved)
+		previousReady := readyConditionSnapshot(pn.Status.Conditions)
+		resolvedStatus, resolvedReason, resolvedMsg := checkNetworkRef(pn.Namespace, pn.Spec.NetworkRef, resolved)
 
 		readyStatus := resolvedStatus
 		readyReason := resolvedReason
@@ -329,8 +370,8 @@ func (u *Updater) updatePodNetworkConditions(ctx context.Context, fetched *resol
 		}
 		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "PodNetwork", pn.Namespace, pn.Name, readyStatus, readyReason, readyMsg)
 
-		netIPv4, netIPv6 := resolved.NetworkCIDRs(pn.Spec.NetworkRef)
-		vrfs := resolved.SelectorVRFRefs(pn.Spec.Destinations)
+		netIPv4, netIPv6 := resolved.NetworkCIDRs(pn.Namespace, pn.Spec.NetworkRef)
+		vrfs := resolved.SelectorVRFRefs(pn.Namespace, pn.Spec.Destinations)
 
 		if err := u.statusUpdateWithRetry(ctx, pn, func(obj client.Object) {
 			p := obj.(*nc.PodNetwork)
@@ -343,6 +384,7 @@ func (u *Updater) updatePodNetworkConditions(ctx context.Context, fetched *resol
 		}); err != nil {
 			return fmt.Errorf("updating PodNetwork %q status: %w", pn.Name, err)
 		}
+		u.emitReadyWarning(pn, previousReady, readyStatus, readyReason, readyMsg)
 	}
 	return nil
 }
@@ -350,6 +392,7 @@ func (u *Updater) updatePodNetworkConditions(ctx context.Context, fetched *resol
 func (u *Updater) updateCollectorConditions(ctx context.Context, fetched *resolver.FetchedResources, issues map[string]ResourceIssue) error {
 	for i := range fetched.Collectors {
 		col := &fetched.Collectors[i]
+		previousReady := readyConditionSnapshot(col.Status.Conditions)
 		readyStatus, readyReason, readyMsg := applyBuildIssue(issues, "Collector", col.Namespace, col.Name,
 			metav1.ConditionTrue, "Ready", "Collector is ready")
 		if err := u.statusUpdateWithRetry(ctx, col, func(obj client.Object) {
@@ -360,6 +403,7 @@ func (u *Updater) updateCollectorConditions(ctx context.Context, fetched *resolv
 		}); err != nil {
 			return fmt.Errorf("updating Collector %q status: %w", col.Name, err)
 		}
+		u.emitReadyWarning(col, previousReady, readyStatus, readyReason, readyMsg)
 	}
 	return nil
 }
@@ -367,16 +411,20 @@ func (u *Updater) updateCollectorConditions(ctx context.Context, fetched *resolv
 func (u *Updater) updateTrafficMirrorConditions(ctx context.Context, fetched *resolver.FetchedResources, resolved *resolver.ResolvedData, issues map[string]ResourceIssue) error {
 	collectorNames := make(map[string]bool, len(resolved.Collectors))
 	for i := range resolved.Collectors {
-		collectorNames[resolved.Collectors[i].Name] = true
+		collectorNames[resolver.NamespacedKey(
+			resolved.Collectors[i].Namespace,
+			resolved.Collectors[i].Name,
+		)] = true
 	}
 
 	for i := range fetched.TrafficMirrors {
 		tm := &fetched.TrafficMirrors[i]
+		previousReady := readyConditionSnapshot(tm.Status.Conditions)
 		resolvedStatus := metav1.ConditionTrue
 		resolvedReason := reasonAllResolved
 		resolvedMsg := msgAllResolved
 
-		if !collectorNames[tm.Spec.Collector] {
+		if !collectorNames[resolver.NamespacedKey(tm.Namespace, tm.Spec.Collector)] {
 			resolvedStatus = metav1.ConditionFalse
 			resolvedReason = "CollectorNotFound"
 			resolvedMsg = fmt.Sprintf("referenced Collector %q not found", tm.Spec.Collector)
@@ -398,6 +446,7 @@ func (u *Updater) updateTrafficMirrorConditions(ctx context.Context, fetched *re
 		}); err != nil {
 			return fmt.Errorf("updating TrafficMirror %q status: %w", tm.Name, err)
 		}
+		u.emitReadyWarning(tm, previousReady, readyStatus, readyReason, readyMsg)
 	}
 	return nil
 }
@@ -405,11 +454,12 @@ func (u *Updater) updateTrafficMirrorConditions(ctx context.Context, fetched *re
 func (u *Updater) updateNodeAttachmentConditions(ctx context.Context, fetched *resolver.FetchedResources, resolved *resolver.ResolvedData, issues map[string]ResourceIssue) error {
 	for i := range fetched.NodeAttachments {
 		na := &fetched.NodeAttachments[i]
+		previousReady := readyConditionSnapshot(na.Status.Conditions)
 		resolvedStatus := metav1.ConditionTrue
 		resolvedReason := reasonAllResolved
 		resolvedMsg := msgAllResolved
 
-		if _, ok := resolved.VRFs[na.Spec.VRFRef]; !ok {
+		if _, ok := resolved.VRF(na.Namespace, na.Spec.VRFRef); !ok {
 			resolvedStatus = metav1.ConditionFalse
 			resolvedReason = "VRFNotFound"
 			resolvedMsg = fmt.Sprintf("referenced VRF %q not found", na.Spec.VRFRef)
@@ -423,7 +473,7 @@ func (u *Updater) updateNodeAttachmentConditions(ctx context.Context, fetched *r
 		}
 		readyStatus, readyReason, readyMsg = applyBuildIssue(issues, "NodeAttachment", na.Namespace, na.Name, readyStatus, readyReason, readyMsg)
 
-		vrfs := resolved.SelectorVRFRefs(na.Spec.Destinations)
+		vrfs := resolved.SelectorVRFRefs(na.Namespace, na.Spec.Destinations)
 
 		if err := u.statusUpdateWithRetry(ctx, na, func(obj client.Object) {
 			n := obj.(*nc.NodeAttachment)
@@ -434,6 +484,7 @@ func (u *Updater) updateNodeAttachmentConditions(ctx context.Context, fetched *r
 		}); err != nil {
 			return fmt.Errorf("updating NodeAttachment %q status: %w", na.Name, err)
 		}
+		u.emitReadyWarning(na, previousReady, readyStatus, readyReason, readyMsg)
 	}
 	return nil
 }
@@ -441,6 +492,7 @@ func (u *Updater) updateNodeAttachmentConditions(ctx context.Context, fetched *r
 func (u *Updater) updateBGPPeeringConditions(ctx context.Context, fetched *resolver.FetchedResources, resolved *resolver.ResolvedData, issues map[string]ResourceIssue, nodeASNs map[string]int64) error {
 	for i := range fetched.BGPPeerings {
 		bp := &fetched.BGPPeerings[i]
+		previousReady := readyConditionSnapshot(bp.Status.Conditions)
 		resolvedStatus, resolvedReason, resolvedMsg := checkBGPPeeringRefs(bp, resolved)
 
 		readyStatus := resolvedStatus
@@ -472,6 +524,7 @@ func (u *Updater) updateBGPPeeringConditions(ctx context.Context, fetched *resol
 		}); err != nil {
 			return fmt.Errorf("updating BGPPeering %q status: %w", bp.Name, err)
 		}
+		u.emitReadyWarning(bp, previousReady, readyStatus, readyReason, readyMsg)
 	}
 	return nil
 }
@@ -525,14 +578,14 @@ func checkBGPPeeringRefs(bp *nc.BGPPeering, resolved *resolver.ResolvedData) (co
 		if bp.Spec.Ref.AttachmentRef == nil {
 			return metav1.ConditionFalse, "AttachmentRefMissing", "listenRange mode requires attachmentRef"
 		}
-		if !layer2AttachmentExists(*bp.Spec.Ref.AttachmentRef, resolved) {
+		if !layer2AttachmentExists(bp.Namespace, *bp.Spec.Ref.AttachmentRef, resolved) {
 			return metav1.ConditionFalse, "AttachmentNotFound", fmt.Sprintf("referenced Layer2Attachment %q not found", *bp.Spec.Ref.AttachmentRef)
 		}
 		if len(bp.Spec.Ref.NetworkRefs) == 0 {
 			return metav1.ConditionFalse, "NetworkRefsMissing", "listenRange mode requires at least one networkRef"
 		}
 		for _, ref := range bp.Spec.Ref.NetworkRefs {
-			if _, ok := resolved.Networks[ref]; !ok {
+			if _, ok := resolved.Network(bp.Namespace, ref); !ok {
 				return metav1.ConditionFalse, "NetworkNotFound", fmt.Sprintf("referenced Network %q not found", ref)
 			}
 		}
@@ -541,7 +594,7 @@ func checkBGPPeeringRefs(bp *nc.BGPPeering, resolved *resolver.ResolvedData) (co
 			return metav1.ConditionFalse, "InboundRefsMissing", "loopbackPeer mode requires at least one inboundRef"
 		}
 		for _, ref := range bp.Spec.Ref.InboundRefs {
-			if !inboundExists(ref, resolved) {
+			if !inboundExists(bp.Namespace, ref, resolved) {
 				return metav1.ConditionFalse, "InboundNotFound", fmt.Sprintf("referenced Inbound %q not found", ref)
 			}
 		}
@@ -553,9 +606,9 @@ func checkBGPPeeringRefs(bp *nc.BGPPeering, resolved *resolver.ResolvedData) (co
 
 // layer2AttachmentExists reports whether a Layer2Attachment with the given name
 // is present in the resolved data.
-func layer2AttachmentExists(name string, resolved *resolver.ResolvedData) bool {
+func layer2AttachmentExists(namespace, name string, resolved *resolver.ResolvedData) bool {
 	for i := range resolved.Layer2Attachments {
-		if resolved.Layer2Attachments[i].Name == name {
+		if resolved.Layer2Attachments[i].Namespace == namespace && resolved.Layer2Attachments[i].Name == name {
 			return true
 		}
 	}
@@ -564,9 +617,9 @@ func layer2AttachmentExists(name string, resolved *resolver.ResolvedData) bool {
 
 // inboundExists reports whether an Inbound with the given name is present in the
 // resolved data.
-func inboundExists(name string, resolved *resolver.ResolvedData) bool {
+func inboundExists(namespace, name string, resolved *resolver.ResolvedData) bool {
 	for i := range resolved.Inbounds {
-		if resolved.Inbounds[i].Name == name {
+		if resolved.Inbounds[i].Namespace == namespace && resolved.Inbounds[i].Name == name {
 			return true
 		}
 	}
@@ -574,8 +627,8 @@ func inboundExists(name string, resolved *resolver.ResolvedData) bool {
 }
 
 // checkNetworkRef checks if a networkRef resolves to an existing Network.
-func checkNetworkRef(networkRef string, resolved *resolver.ResolvedData) (condStatus metav1.ConditionStatus, reason, message string) {
-	if _, ok := resolved.Networks[networkRef]; !ok {
+func checkNetworkRef(namespace, networkRef string, resolved *resolver.ResolvedData) (condStatus metav1.ConditionStatus, reason, message string) {
+	if _, ok := resolved.Network(namespace, networkRef); !ok {
 		return metav1.ConditionFalse, "NetworkNotFound", fmt.Sprintf("referenced Network %q not found", networkRef)
 	}
 	return metav1.ConditionTrue, reasonAllResolved, msgAllResolved
@@ -589,7 +642,7 @@ func checkNetworkRef(networkRef string, resolved *resolver.ResolvedData) (condSt
 // when the name cannot be determined. This mirrors the naming logic in
 // intent.buildNetplanState so the status reflects what lands on the node.
 func effectiveInterfaceName(l2a *nc.Layer2Attachment, resolved *resolver.ResolvedData) string {
-	net, ok := resolved.Networks[l2a.Spec.NetworkRef]
+	net, ok := resolved.Network(l2a.Namespace, l2a.Spec.NetworkRef)
 	if ok && net.Spec.VLAN == nil {
 		// Native/untagged mode: the parent interfaceRef is configured directly.
 		if l2a.Spec.InterfaceRef != nil && *l2a.Spec.InterfaceRef != "" {

--- a/pkg/reconciler/intent/status/status_test.go
+++ b/pkg/reconciler/intent/status/status_test.go
@@ -20,11 +20,57 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
 
 	nc "github.com/telekom/das-schiff-network-operator/api/v1alpha1/network-connector"
 	"github.com/telekom/das-schiff-network-operator/pkg/reconciler/intent/resolver"
 )
+
+func TestEmitReadyWarning(t *testing.T) {
+	recorder := events.NewFakeRecorder(1)
+	updater := &Updater{eventRecorder: recorder}
+	object := &nc.Layer2Attachment{
+		ObjectMeta: metav1.ObjectMeta{Name: "attachment-a", Namespace: "tenant-a"},
+	}
+
+	updater.emitReadyWarning(
+		object,
+		nil,
+		metav1.ConditionFalse,
+		"ConflictingStaticRoute",
+		"conflicting route",
+	)
+
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, corev1.EventTypeWarning+" ConflictingStaticRoute conflicting route")
+	default:
+		t.Fatal("expected Warning event for Ready=False")
+	}
+
+	updater.emitReadyWarning(object, nil, metav1.ConditionTrue, "Ready", "ready")
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected event for Ready=True: %s", event)
+	default:
+	}
+
+	existing := &metav1.Condition{
+		Type:               nc.ConditionTypeReady,
+		Status:             metav1.ConditionFalse,
+		Reason:             "ConflictingStaticRoute",
+		Message:            "conflicting route",
+		ObservedGeneration: 1,
+	}
+	updater.emitReadyWarning(object, existing, metav1.ConditionFalse, "DifferentReason", "different message")
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected duplicate event for unchanged Ready=False: %s", event)
+	default:
+	}
+}
 
 func TestEffectiveInterfaceName(t *testing.T) {
 	vlan1000 := int32(1000)

--- a/pkg/reconciler/nncnames/reduce.go
+++ b/pkg/reconciler/nncnames/reduce.go
@@ -15,6 +15,8 @@ import (
 	"github.com/telekom/das-schiff-network-operator/pkg/vrfname"
 )
 
+const reservedClusterVRFName = "cluster"
+
 // Reduce rewrites every VRF name in spec to its reduced form. It is
 // deterministic and idempotent. It returns an error if two distinct VRF names
 // reduce to the same value (a collision), which must be surfaced rather than
@@ -28,12 +30,23 @@ func Reduce(spec *v1alpha1.NodeNetworkConfigSpec) error {
 	if err != nil {
 		return fmt.Errorf("fabric VRFs: %w", err)
 	}
-	spec.FabricVRFs = fabric
+	if _, exists := fabric[reservedClusterVRFName]; exists {
+		return fmt.Errorf("fabric VRF name reduces to reserved cluster VRF %q", reservedClusterVRFName)
+	}
 
 	local, err := reduceKeys(spec.LocalVRFs)
 	if err != nil {
 		return fmt.Errorf("local VRFs: %w", err)
 	}
+	for name := range local {
+		if name == reservedClusterVRFName {
+			return fmt.Errorf("local VRF name reduces to reserved cluster VRF %q", name)
+		}
+		if _, exists := fabric[name]; exists {
+			return fmt.Errorf("fabric VRF and local VRF both reduce to %q", name)
+		}
+	}
+	spec.FabricVRFs = fabric
 	spec.LocalVRFs = local
 
 	if spec.ClusterVRF != nil {

--- a/pkg/reconciler/nncnames/reduce_test.go
+++ b/pkg/reconciler/nncnames/reduce_test.go
@@ -117,6 +117,40 @@ func TestReduce_CollisionIsError(t *testing.T) {
 	}
 }
 
+func TestReduce_CrossMapCollisionIsError(t *testing.T) {
+	localName := "s-123456789bcdf"
+	fabricName := "s-1a23456789bcdf"
+	if vrfname.Reduce(fabricName) != localName {
+		t.Fatalf("test names do not collide under current rule (%q vs %q)", vrfname.Reduce(fabricName), localName)
+	}
+	spec := &v1alpha1.NodeNetworkConfigSpec{
+		FabricVRFs: map[string]v1alpha1.FabricVRF{fabricName: {VNI: 1}},
+		LocalVRFs:  map[string]v1alpha1.VRF{localName: {}},
+	}
+
+	err := Reduce(spec)
+	if err == nil {
+		t.Fatal("expected cross-map collision error, got nil")
+	}
+	if !strings.Contains(err.Error(), `both reduce to "s-123456789bcdf"`) {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestReduce_ReservedFabricVRFNameIsError(t *testing.T) {
+	spec := &v1alpha1.NodeNetworkConfigSpec{
+		FabricVRFs: map[string]v1alpha1.FabricVRF{"cluster": {VNI: 1}},
+	}
+
+	err := Reduce(spec)
+	if err == nil {
+		t.Fatal("expected reserved FabricVRF name error")
+	}
+	if !strings.Contains(err.Error(), `reserved cluster VRF "cluster"`) {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
 func TestReduce_IrreducibleKeyIsError(t *testing.T) {
 	// A long incompressible name (no removable vowels, no underscores) cannot be
 	// reduced to fit and must be reported rather than silently passed through.

--- a/pkg/vrfname/vrfname.go
+++ b/pkg/vrfname/vrfname.go
@@ -36,26 +36,40 @@ const MaxLen = 15
 // VRF.
 const sbrPrefix = "s-"
 
-// sbrHashLen is the number of hex characters used for the hashed SBR name. It
-// is the largest value that still fits within MaxLen after the prefix, which
-// maximises collision resistance (sbrHashLen*4 bits) for free.
-const sbrHashLen = MaxLen - len(sbrPrefix)
+// l2aPrefix prefixes the name of a Layer2Attachment intermediate VRF. It is
+// distinct from sbrPrefix because SBR imports the cluster routing table while
+// an L2 attachment must not inherit that reachability.
+const l2aPrefix = "l-"
 
-// SBRName returns the name of the SBR intermediate VRF for the given key.
+// IntermediateName returns the name of an intermediate VRF for the given key.
 //
 // For a single-VRF key that still fits within MaxLen it keeps the readable
 // "s-<key>" form. Otherwise (a key that would overflow MaxLen, or a multi-VRF
 // combo key which contains "+") it falls back to a hash: "s-<hash>", sized to
 // fill MaxLen exactly. It is deterministic: the same key always yields the same
 // name.
-func SBRName(key string) string {
+func IntermediateName(key string) string {
+	return buildIntermediateName(sbrPrefix, key)
+}
+
+// L2AName returns the name of a Layer2Attachment intermediate VRF.
+func L2AName(key string) string {
+	return buildIntermediateName(l2aPrefix, key)
+}
+
+func buildIntermediateName(prefix, key string) string {
 	if !strings.Contains(key, "+") {
-		if candidate := sbrPrefix + key; len(candidate) <= MaxLen {
+		if candidate := prefix + key; len(candidate) <= MaxLen {
 			return candidate
 		}
 	}
 	sum := sha256.Sum256([]byte(key))
-	return sbrPrefix + hex.EncodeToString(sum[:])[:sbrHashLen]
+	return prefix + hex.EncodeToString(sum[:])[:MaxLen-len(prefix)]
+}
+
+// SBRName returns the name of an SBR intermediate VRF for the given key.
+func SBRName(key string) string {
+	return IntermediateName(key)
 }
 
 // Reduce shortens name to at most MaxLen bytes using the cascade described in

--- a/pkg/vrfname/vrfname_test.go
+++ b/pkg/vrfname/vrfname_test.go
@@ -25,6 +25,23 @@ func TestSBRName(t *testing.T) {
 	}
 }
 
+func TestL2ANameUsesDistinctNamespace(t *testing.T) {
+	key := "blue+green"
+	l2a := L2AName(key)
+	if len(l2a) > MaxLen {
+		t.Fatalf("L2AName(%q) = %q exceeds MaxLen", key, l2a)
+	}
+	if l2a[:2] != "l-" {
+		t.Errorf("L2AName(%q) = %q must keep the l- prefix", key, l2a)
+	}
+	if l2a == SBRName(key) {
+		t.Errorf("L2AName and SBRName must differ for the same key, got %q", l2a)
+	}
+	if L2AName(key) != l2a {
+		t.Error("L2AName is not deterministic")
+	}
+}
+
 func TestReduce_ShortNamesUnchanged(t *testing.T) {
 	// Anything already within MaxLen must pass through untouched.
 	cases := []string{


### PR DESCRIPTION
## Summary

- resolve all Fabric VRFs selected by a `Layer2Attachment` instead of using the first matching Destination
- attach a multi-VRF L2 IRB to a deterministic combo `LocalVRF`
- route selected Destination prefixes from the combo VRF to their respective Fabric VRFs
- route the attached Network from each Fabric VRF back through the combo VRF and export it via EVPN
- keep the single-VRF path unchanged and avoid `ClusterVRF` policy routing for directly attached combo VRFs
- reject equivalent Destination prefixes assigned to different target VRFs
- prefer explicit VRF next-hop routes over same-prefix blackhole aggregates during contribution assembly

## Tests

- added unit coverage for single- and multi-VRF L2A routing, deterministic combo naming, bidirectional routes, and ambiguous CIDRs
- added assembler coverage for explicit next-hop versus blackhole aggregate merging in both contribution orders
- added an NNC-level E2E scenario using isolated generic fixtures and RFC documentation address ranges
- ran affected unit tests, the Intent envtest suite, E2E package compilation, and differential `golangci-lint`

## E2E limitation

The NNC-level E2E scenario is included but was not executed against a live E2E cluster. It validates the generated NNC topology without duplicating an L2 network between Fabric VRFs.